### PR TITLE
Fix web UI nav and landing page issues

### DIFF
--- a/src/LandingHTML.h
+++ b/src/LandingHTML.h
@@ -64,10 +64,22 @@ const char LANDING_HTML[] PROGMEM = R"rawliteral(
         <div class="tool-desc">Write filament data to NTAG213/215 tags using the TigerTag binary format.</div>
       </a>
 
+      <a href="/writer/opentag3d" class="tool-card">
+        <div class="tool-icon">&#128196;</div>
+        <div class="tool-name">OpenTag3D Writer</div>
+        <div class="tool-desc">Write filament data to NTAG215/216 tags using the OpenTag3D format.</div>
+      </a>
+
       <a href="/update" class="tool-card">
         <div class="tool-icon">&#9889;</div>
         <div class="tool-name">Firmware Update</div>
         <div class="tool-desc">Check for new firmware versions and update over WiFi.</div>
+      </a>
+
+      <a href="/troubleshooting" class="tool-card">
+        <div class="tool-icon">&#128736;</div>
+        <div class="tool-name">Troubleshooting</div>
+        <div class="tool-desc">Verify scanner connectivity, MQTT, Spoolman, and NFC reader status.</div>
       </a>
 
       <a href="/config" class="tool-card">

--- a/src/SharedCSS.h
+++ b/src/SharedCSS.h
@@ -45,7 +45,7 @@ nav{
   border:1px solid var(--border);
   border-radius:var(--radius);
   background:var(--panel);
-  overflow-x:auto;
+  flex-wrap:wrap;
 }
 
 nav a{

--- a/src/TroubleshootingHTML.h
+++ b/src/TroubleshootingHTML.h
@@ -67,9 +67,9 @@ const char TROUBLESHOOTING_HTML[] PROGMEM = R"rawliteral(
       <a href="/writer/openprinttag">OpenPrintTag</a>
       <a href="/writer/tigertag">TigerTag</a>
       <a href="/writer/opentag3d">OpenTag3D</a>
-      <a href="/config">Config</a>
       <a href="/update">Update</a>
       <a href="/troubleshooting" class="active">Troubleshooting</a>
+      <a href="/config">Config</a>
     </nav>
 
     <h2 style="margin-bottom:6px">Troubleshooting</h2>


### PR DESCRIPTION
## Summary

- Fix nav link order on troubleshooting page to match all other pages
- Add missing OpenTag3D Writer and Troubleshooting cards to landing page
- Change nav from `overflow-x: auto` to `flex-wrap: wrap` so all links are visible (Config was hidden off-screen on wide monitors)

## Test plan

- [x] Generated preview HTML files, verified in browser
- [x] Landing page shows all cards including OpenTag3D and Troubleshooting
- [x] Nav wraps to two rows — Config visible
- [x] Content clipping on troubleshooting page confirmed fixed
- [ ] Test on actual scanner hardware when available

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "OpenTag3D Writer" navigation link to write filament data in OpenTag3D format.
  * Added "Troubleshooting" navigation link for system verification and diagnostics.

* **Improvements**
  * Updated navigation display behavior to wrap content instead of scrolling horizontally.
  * Reordered navigation links for improved page organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->