### PR TITLE
Add set_color MQTT command handler for LED

### DIFF
--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -2,6 +2,7 @@
 #include "ApplicationManager.h"
 #include "ConfigurationManager.h"
 #include "ConversionUtils.h"
+#include "LEDManager.h"
 
 #ifndef NATIVE_TEST
   #include <Arduino.h>
@@ -829,6 +830,20 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
         strncpy(command, commandPath, sizeof(command) - 1);
     }
     if (strcmp(command, "response") == 0) {
+        return;
+    }
+
+    // set_color: set the LED to a specific color from Spoolman lookup
+    // No tag required — this is sent by the middleware for UID-only tags
+    if (strcmp(command, "set_color") == 0) {
+        if (strlen(payload) == 6) {
+            uint8_t r, g, b;
+            if (sscanf(payload, "%2hhx%2hhx%2hhx", &r, &g, &b) == 3) {
+                Serial.printf("HomeAssistantManager: set_color #%s → RGB(%d,%d,%d)\n", payload, r, g, b);
+                extern LEDManager ledManager;
+                ledManager.showFilamentColor(r, g, b);
+            }
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary

New `set_color` MQTT command handler in HomeAssistantManager. Receives a 6-character hex color string via `spoolsense/<device_id>/cmd/set_color` and sets the LED to that color.

Used by the middleware for UID-only tags where the filament color comes from Spoolman, not from the tag itself. No tag needs to be present — the command is processed before the tag-present check.

## Test plan

- [x] Scan UID-only tag → middleware sends set_color → LED turns yellow (F5EC00)
- [x] Smart tags still work (LED set from tag data directly)
- [x] Compiles clean on ESP32-WROOM

Paired with spoolsense_middleware PR #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for controlling LED colors through Home Assistant, enabling dynamic RGB color adjustments for compatible devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->