### PR TITLE
fix: substitute dim white for black spool color on LED

### DIFF
--- a/src/LEDManager.cpp
+++ b/src/LEDManager.cpp
@@ -84,13 +84,22 @@ void LEDManager::showOff() {
     setTarget(LEDMode::OFF, 0, 0, 0);
 }
 
+// Black (0,0,0) is indistinguishable from LED off — substitute dim white
+// so the user can tell a spool is scanned. The scan flash pattern provides
+// scan feedback; the steady color should always be visible.
+static void substituteBlack(uint8_t& r, uint8_t& g, uint8_t& b) {
+    if (r == 0 && g == 0 && b == 0) { r = 0x33; g = 0x33; b = 0x33; }
+}
+
 void LEDManager::showFilamentColor(uint8_t r, uint8_t g, uint8_t b) {
     if (!_initialized) return;
+    substituteBlack(r, g, b);
     setTarget(LEDMode::SOLID, r, g, b);
 }
 
 void LEDManager::breatheFilamentColor(uint8_t r, uint8_t g, uint8_t b) {
     if (!_initialized) return;
+    substituteBlack(r, g, b);
     setTarget(LEDMode::BREATHING, r, g, b);
 }
 


### PR DESCRIPTION
## Summary

Black filament (0,0,0) is indistinguishable from LED off. Both `showFilamentColor` and `breatheFilamentColor` now substitute dim white (#333333) so the user can tell a spool is scanned. The scan flash pattern provides scan feedback; the steady color should always be visible.

Matches the middleware's `display_spoolcolor()` behavior.

## Test plan

- [ ] Scan a black spool — LED shows dim white instead of off
- [ ] Scan any other color — unchanged behavior
- [ ] Low spool breathing with black spool — breathes dim white

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted LED color behavior in filament display modes to ensure the LED is no longer completely dark; a subtle dim color is now displayed instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->