### PR TITLE
feat: WiFi reconnection with exponential backoff (#29)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@ static unsigned long g_lastReconnectAttemptMs = 0;
 static constexpr unsigned long WIFI_CHECK_INTERVAL_MS = 5000;
 static constexpr unsigned long WIFI_RECONNECT_INITIAL_MS = 5000;
 static constexpr unsigned long WIFI_RECONNECT_MAX_MS = 60000;
+static constexpr uint16_t HTTP_PORT = 80;
 
 // Always declared; only initialized if isLcdEnabled() at runtime
 LCDManager lcdManager(0x27, 16, 2);
@@ -194,7 +195,7 @@ void checkWiFi() {
     // Re-initialize mDNS (IP may have changed)
     MDNS.end();
     if (MDNS.begin("spoolsense")) {
-      MDNS.addService("http", "tcp", 80);
+      MDNS.addService("http", "tcp", HTTP_PORT);
       Serial.println("WiFi: mDNS restarted (spoolsense.local)");
     } else {
       Serial.println("WiFi: mDNS restart failed — reachable by IP only");


### PR DESCRIPTION
## Summary
- Add WiFi watchdog in main loop that detects disconnection and auto-reconnects
- Exponential backoff: 5s → 10s → 20s → 40s → 60s (capped)
- Event-based display messages: "WiFi Lost" on drop, "WiFi OK <IP>" on reconnect
- Re-initializes mDNS on reconnect (IP may have changed)
- NFC scanning continues uninterrupted during WiFi outage
- Skips entirely in AP mode

Closes #29

## Test Plan
- [ ] Clean compile on esp32s3zero and esp32dev (verified)
- [ ] Flash and verify normal WiFi connect on boot
- [ ] Disconnect WiFi (router reboot / disable AP) — verify "WiFi Lost" on display
- [ ] Re-enable WiFi — verify "WiFi OK" on display and spoolsense.local resolves
- [ ] Verify MQTT reconnects after WiFi recovery
- [ ] Verify NFC scanning works throughout outage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device discovery via mDNS so the device is more easily found on local networks.
* **Bug Fixes**
  * Improved Wi‑Fi reconnection behavior with faster recovery after drops and controlled retry backoff.
  * UI/display now reflects Wi‑Fi status changes immediately after reconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->