### PR TITLE
fix: HA publish queue — increase to 12 + log drops (#28)

### DIFF
--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -188,8 +188,11 @@ bool HomeAssistantManager::begin() {
 
 bool HomeAssistantManager::enqueuePublish(const HAPublishRequest& req) {
     if (publishQueue == nullptr) return false;
-    // Overwrite oldest if full (drop semantics for state-based retained messages)
-    return xQueueSend(publishQueue, &req, 0) == pdTRUE;
+    if (xQueueSend(publishQueue, &req, 0) != pdTRUE) {
+        Serial.printf("HomeAssistantManager: Queue full, dropped publish to %s\n", req.topic);
+        return false;
+    }
+    return true;
 }
 
 #ifndef NATIVE_TEST

--- a/src/HomeAssistantManager.h
+++ b/src/HomeAssistantManager.h
@@ -68,7 +68,7 @@ private:
     uint32_t lastReconnectAttempt_ = 0;
     static constexpr uint32_t MAX_RECONNECT_DELAY = 30000;
 
-    static constexpr size_t QUEUE_SIZE = 6;
+    static constexpr size_t QUEUE_SIZE = 12;
     static constexpr size_t TASK_STACK_SIZE = 8192;
     static constexpr UBaseType_t TASK_PRIORITY = 2;
 


### PR DESCRIPTION
## Summary
- Increase MQTT publish queue from 6 to 12 items (~2.9KB additional heap)
- Log when messages are dropped due to full queue (was silent)
- Fix misleading "overwrite oldest" comment

Closes #28

## Test Plan
- [ ] Clean compile on esp32s3zero and esp32dev (verified)
- [ ] Serial log shows drop warning when MQTT is disconnected and queue fills
- [ ] Normal operation unaffected — queue rarely reaches 6, let alone 12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for MQTT publish operations with diagnostic logging when the publish queue reaches capacity.

* **Chores**
  * Increased the maximum capacity of the MQTT publish request queue to better support higher volumes of concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->