### PR TITLE
feat: streaming Spoolman UID lookup — fixes NoMemory on 30+ spools (#68)

### DIFF
--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -243,7 +243,7 @@ static int streamFindSpoolByNfcId(const char* path, const char* uuid) {
     if (code != 200) {
         Serial.printf("SpoolmanManager: streamFind HTTP %d for %s\n", code, path);
         streamHttp.end();
-        return -1;
+        return -2;  // error (distinct from -1 = not found)
     }
 
     WiFiClient* stream = streamHttp.getStreamPtr();
@@ -267,10 +267,12 @@ static int streamFindSpoolByNfcId(const char* path, const char* uuid) {
     bool inNumValue = false;
 
     unsigned long lastData = millis();
+    bool timedOut = false;
 
     while (stream->available() || stream->connected()) {
         if (millis() - lastData > 10000) {
             Serial.println("SpoolmanManager: streamFind timeout");
+            timedOut = true;
             break;
         }
 
@@ -369,14 +371,12 @@ static int streamFindSpoolByNfcId(const char* path, const char* uuid) {
                 if (inExtra && depth == extraDepth) {
                     inExtra = false;
                 }
+                // Clear numeric state on every closing brace to prevent
+                // nested id values (filament.id, vendor.id) from leaking
+                inValue = false;
+                inNumValue = false;
                 depth--;
                 if (depth == 0) {
-                    // End of spool object — check for trailing numeric id
-                    if (inNumValue && strcmp(keyBuf, "id") == 0) {
-                        valBuf[valPos] = '\0';
-                        currentId = atoi(valBuf);
-                        inNumValue = false;
-                    }
                     // Deferred match — both id and nfc_id are now known
                     if (nfcIdMatched && currentId > bestMatchId) {
                         bestMatchId = currentId;
@@ -412,9 +412,12 @@ static int streamFindSpoolByNfcId(const char* path, const char* uuid) {
 
     if (bestMatchId >= 0) {
         Serial.printf("SpoolmanManager: streamFind matched uuid=%s to spool id=%d\n", uuid, bestMatchId);
+        return bestMatchId;
     }
 
-    return bestMatchId;
+    // Distinguish "not found" from "error" so callers don't create duplicates on transient failures
+    if (timedOut) return -2;
+    return -1;  // complete scan, no match
 }
 
 // --- File-local Spoolman API helpers ---


### PR DESCRIPTION
## Summary
Replace the ArduinoJson-based Spoolman UID lookup with a streaming HTTP parser that reads the response in 512-byte chunks. Fixes NoMemory crash on ESP32 WROOM when Spoolman has 30+ spools.

**Before:** Downloads entire spool list (~30KB) into a String, parses with DynamicJsonDocument (~60KB heap). Fails with NoMemory.

**After:** Streams the HTTP response, scans for `id` and `extra.nfc_id` as bytes flow in. Uses ~600 bytes regardless of spool count.

### Changes
- Add `streamFindSpoolByNfcId()` — streaming parser with depth tracking, escaped quote handling, and deferred match (field-order independent)
- Replace all 3 callers: `findSpoolByUuid()`, `findSpoolByUuidGlobal()`, `lookupSpoolByUid()`
- Remove old `parseSpoolIdByUuid()` function
- Uses separate WiFiClient/HTTPClient (no connection poisoning of shared client)
- `useHTTP10(true)` to avoid chunked encoding behind reverse proxies

Closes #68

## Codex Review Fixes
- HTTP/1.0 to avoid chunked transfer encoding corruption
- Deferred match to end of spool object (no JSON field order dependency)

## Test Plan
- [x] Clean compile on esp32s3zero and esp32dev
- [x] Hardware tested: PET-GF generic UID tag — found spool #1 (was NoMemory before)
- [x] Hardware tested: TigerTag, OpenTag3D — streaming lookup works for all formats
- [x] No NoMemory errors across multiple scans
- [x] Bad UIDs (PN5180 glitch) correctly return no match
- [ ] Test with Spoolman behind reverse proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overhauled spool lookup to a streaming-based scan for large responses, improving memory use and reliability.
  * Changed lookup outcomes so transient scan or network failures are treated as “no match,” reducing unintended spool creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->