### PR TITLE
feat: rearrange WROOM keypad pins for easier wiring (#69)

### DIFF
--- a/include/BoardPins.h
+++ b/include/BoardPins.h
@@ -73,13 +73,13 @@
   // Status LED — external SK6812 RGBW (optional, requires wiring)
   #define PIN_STATUS_LED   4
   // 3x4 Matrix Keypad (ENABLE_KEYPAD)
-  #define PIN_KEYPAD_ROW1  15
-  #define PIN_KEYPAD_ROW2  16
-  #define PIN_KEYPAD_ROW3  17
-  #define PIN_KEYPAD_ROW4  18
-  #define PIN_KEYPAD_COL1  19
+  #define PIN_KEYPAD_ROW1  19
+  #define PIN_KEYPAD_ROW2  15
+  #define PIN_KEYPAD_ROW3  16
+  #define PIN_KEYPAD_ROW4  5
+  #define PIN_KEYPAD_COL1  18
   #define PIN_KEYPAD_COL2  21
-  #define PIN_KEYPAD_COL3  5
+  #define PIN_KEYPAD_COL3  17
   // TFT SPI display (ENABLE_TFT — mutually exclusive with LCD I2C)
   // Uses VSPI. Pins 23/22 freed from LCD when TFT replaces it.
   #define PIN_TFT_MOSI     23  // VSPI MOSI (shared with LCD SDA when LCD enabled)


### PR DESCRIPTION
## Summary
Rearranges the WROOM keypad GPIO pin assignments so they match the physical order of the keypad connector, eliminating crossed wires during assembly.

Based on PR #69 by @mrsimicsak, rebased cleanly onto dev.

## Breaking Change
**Users with existing keypad wiring will need to re-wire.** The same 7 GPIOs are used but assigned to different row/column lines.

| Pin | Before | After |
|---|---|---|
| GPIO 19 | COL1 | ROW1 |
| GPIO 15 | ROW1 | ROW2 |
| GPIO 16 | ROW2 | ROW3 |
| GPIO 5 | COL3 | ROW4 |
| GPIO 18 | ROW4 | COL1 |
| GPIO 21 | COL2 | COL2 |
| GPIO 17 | ROW3 | COL3 |

## TODO before merge
- [ ] Update keypad wiring docs on spoolsense.org
- [ ] Check README for pin references

## Test Plan
- [ ] Compiles on esp32dev (verified)
- [ ] Hardware test with keypad on new pin assignments