### PR TITLE
feat: add 3s scan cooldown for PN5180 partial UID suppression (#70)

### DIFF
--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -304,6 +304,7 @@ void NFCManager::scanLoop() {
                         memcpy(lastSeenUid, uid, uidLength);
                         lastSeenUidLength = uidLength;
                         lastSeenValid = true;
+                        lastSeenMs = millis();
                         xSemaphoreGive(tagMutex);
                     }
                     Serial.printf("NFCManager: Bambu Lab tag — UID=%s (encrypted, no data access)\n", scan.uid_hex);
@@ -431,6 +432,7 @@ void NFCManager::scanLoop() {
                         memcpy(lastSeenUid, uid, uidLength);
                         lastSeenUidLength = uidLength;
                         lastSeenValid = true;
+                        lastSeenMs = millis();
 
                         if (isTigerTag) {
                             currentSpool.kind = TagKind::TigerTag;
@@ -504,6 +506,7 @@ if (!readOk) {
         memcpy(lastSeenUid, uid, uidLength);
         lastSeenUidLength = uidLength;
         lastSeenValid = true;
+        lastSeenMs = millis();
         blankStateCaptured = true;
         xSemaphoreGive(tagMutex);
     } else {
@@ -611,6 +614,7 @@ bool NFCManager::readAndParseTag(uint8_t* uid, uint8_t uid_length) {
     memcpy(lastSeenUid, uid, uid_length);
     lastSeenUidLength = uid_length;
     lastSeenValid = true;
+    lastSeenMs = millis();
 
     xSemaphoreGive(tagMutex);
 
@@ -2014,6 +2018,16 @@ bool NFCManager::isDuplicateSpool(const uint8_t* uid, uint8_t uid_length) {
         return true;
     }
 
+    // Cooldown: suppress re-reads within 3s where first 3 bytes match.
+    // Catches PN5180 partial UID reads (e.g., 04A651FFFFFFFF) that happen
+    // when the tag is re-detected after a brief communication glitch.
+    if (lastSeenUidLength > 0 && uid_length >= 3 && lastSeenUidLength >= 3 &&
+        (millis() - lastSeenMs) < SCAN_COOLDOWN_MS &&
+        memcmp(uid, lastSeenUid, 3) == 0) {
+        Serial.println("NFCManager: Suppressed re-read (cooldown, partial UID match)");
+        return true;
+    }
+
     if (!lastSeenValid) {
         return false;
     }
@@ -2140,6 +2154,7 @@ if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
     memcpy(lastSeenUid, uid, uidLength);
     lastSeenUidLength = uidLength;
     lastSeenValid = true;
+    lastSeenMs = millis();
     blankStateCaptured = true;
     xSemaphoreGive(tagMutex);
 }

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -137,6 +137,8 @@ private:
     uint8_t lastSeenUid[8];      // ISO15693 uses 8-byte UID
     uint8_t lastSeenUidLength = 0;
     bool lastSeenValid = false;
+    unsigned long lastSeenMs = 0;            // millis() when last tag was detected
+    static constexpr unsigned long SCAN_COOLDOWN_MS = 3000;  // suppress re-reads within 3s
 
     // Recent spools history (RAM only, most recent first)
     RecentSpoolEntry recentSpools[MAX_RECENT_SPOOLS];


### PR DESCRIPTION
## Summary
Adds a 3-second cooldown after each successful tag detection. If a new tag is detected within the cooldown window and its first 3 UID bytes match the previous tag, it's suppressed as a partial re-read.

This prevents the PN5180 double-scan glitch where the reader partially reads the UID (e.g., `04A651FFFFFFFF`) immediately after a successful scan, triggering a false "new tag" detection and a failed Spoolman lookup.

Closes #70

## How it works
- `lastSeenMs` tracks when the last tag was detected
- `isDuplicateSpool()` checks: if within 3 seconds AND first 3 bytes match → suppress
- Logs "Suppressed re-read (cooldown, partial UID match)" when triggered
- Does NOT affect write operations (writes use a separate queue path)
- Does NOT suppress genuinely different tags (full UID mismatch)

## Test Plan
- [ ] Clean compile on esp32s3zero and esp32dev (verified)
- [ ] Scan tag — verify normal detection works
- [ ] Quick tap-and-hold — verify no duplicate "New spool detected" with FFFFFFFF UID
- [ ] Scan tag A, quickly swap to tag B — verify B is detected (different UID prefix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NFC tag detection now includes a 3-second cooldown mechanism to prevent duplicate reads of the same tag during consecutive scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->