### PR TITLE
fix: HTTP mutex + URL encoding for WebServerManager (#75, #76)

### DIFF
--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -45,12 +45,12 @@ extern "C" {
 static String urlEncode(const char* str) {
     String encoded;
     while (*str) {
-        char c = *str++;
+        unsigned char c = (unsigned char)*str++;
         if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
-            encoded += c;
+            encoded += (char)c;
         } else {
             char buf[4];
-            snprintf(buf, sizeof(buf), "%%%02X", (unsigned char)c);
+            snprintf(buf, sizeof(buf), "%%%02X", c);
             encoded += buf;
         }
     }


### PR DESCRIPTION
## Summary
Two code review fixes for WebServerManager:

**#75 — HTTP mutex:** All three Spoolman-facing handlers now acquire `g_httpMutex` before making HTTP requests. Prevents races with SpoolmanManager background sync. Returns 503 if mutex is busy.
- `handleApiSpoolmanSpools()` 
- `handleApiSpoolmanLink()`
- `handleApiRegisterUid()`

**#76 — URL encoding:** Manufacturer name is now URL-encoded in the vendor lookup query string. Fixes broken UID registration for vendors with spaces (e.g., "Bambu Lab").

Closes #75, closes #76

## Test Plan
- [ ] Clean compile on esp32s3zero and esp32dev (verified)
- [ ] Scan tag while web UI loads spool list — no HTTP 400 errors
- [ ] Register a UID with a vendor name containing spaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent outbound HTTP requests to avoid conflicts and race conditions by serializing access with a timeout.
  * Return "503 Busy — try again" when the system is already processing other requests.
  * Improved vendor lookup to safely handle manufacturer names with special characters via URL-encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->