### PR TITLE
fix: ApplicationManager code hygiene (#79, #80, #81)

### DIFF
--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -395,7 +395,10 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
         if (s.max_bed_temp != 0   && static_cast<size_t>(len) < sizeof(json) - 1) len += snprintf(json + len, sizeof(json) - len, ",\"max_bed_temp\":%d", s.max_bed_temp);
         if (s.density > 0.0f      && static_cast<size_t>(len) < sizeof(json) - 1) len += snprintf(json + len, sizeof(json) - len, ",\"density\":%.2f", s.density);
         if (s.diameter > 0.0f     && static_cast<size_t>(len) < sizeof(json) - 1) len += snprintf(json + len, sizeof(json) - len, ",\"diameter_mm\":%.2f", s.diameter);
-        snprintf(json + len, sizeof(json) - len, "}");
+        // Re-clamp before closing brace — snprintf return can exceed buffer
+        if (static_cast<size_t>(len) >= sizeof(json) - 1) len = sizeof(json) - 2;
+        json[len++] = '}';
+        json[len] = '\0';
         publishToHA("tag/state", json, true);
         strncpy(lastHAStateJson_, json, sizeof(lastHAStateJson_) - 1);
         lastHAStateJson_[sizeof(lastHAStateJson_) - 1] = '\0';
@@ -801,12 +804,11 @@ void ApplicationManager::handleHAWriteTag(const AppMessage& msg) {
 
     // Enqueue individual write requests for each field
     const auto& p = msg.payload.haWriteTag;
-    static uint32_t nextRequestId = 1;
 
     // Material type
     NFCWriteRequest req;
     memset(&req, 0, sizeof(req));
-    req.request_id = nextRequestId++;
+    req.request_id = NFCManager::getInstance().generateRequestId();
     req.type = NFCWriteType::CHANGE_FILAMENT_TYPE;
     strncpy(req.expected_spool_id, p.expected_uid, sizeof(req.expected_spool_id) - 1);
     req.data.new_material_type = p.material_type;
@@ -814,7 +816,7 @@ void ApplicationManager::handleHAWriteTag(const AppMessage& msg) {
 
     // Color
     memset(&req, 0, sizeof(req));
-    req.request_id = nextRequestId++;
+    req.request_id = NFCManager::getInstance().generateRequestId();
     req.type = NFCWriteType::CHANGE_COLOR;
     strncpy(req.expected_spool_id, p.expected_uid, sizeof(req.expected_spool_id) - 1);
     memcpy(req.data.new_color, p.color, 4);
@@ -822,7 +824,7 @@ void ApplicationManager::handleHAWriteTag(const AppMessage& msg) {
 
     // Brand name
     memset(&req, 0, sizeof(req));
-    req.request_id = nextRequestId++;
+    req.request_id = NFCManager::getInstance().generateRequestId();
     req.type = NFCWriteType::SET_BRAND_NAME;
     strncpy(req.expected_spool_id, p.expected_uid, sizeof(req.expected_spool_id) - 1);
     strncpy(req.data.brand_name, p.manufacturer, sizeof(req.data.brand_name) - 1);
@@ -833,7 +835,7 @@ void ApplicationManager::handleHAWriteTag(const AppMessage& msg) {
         float consumed = p.initial_weight_g - p.remaining_g;
         if (consumed < 0) consumed = 0;
         memset(&req, 0, sizeof(req));
-        req.request_id = nextRequestId++;
+        req.request_id = NFCManager::getInstance().generateRequestId();
         req.type = NFCWriteType::SET_CONSUMED_WEIGHT;
         strncpy(req.expected_spool_id, p.expected_uid, sizeof(req.expected_spool_id) - 1);
         req.data.consumed_weight = consumed;
@@ -843,7 +845,7 @@ void ApplicationManager::handleHAWriteTag(const AppMessage& msg) {
     // Spoolman ID
     if (p.spoolman_id > 0) {
         memset(&req, 0, sizeof(req));
-        req.request_id = nextRequestId++;
+        req.request_id = NFCManager::getInstance().generateRequestId();
         req.type = NFCWriteType::WRITE_SPOOLMAN_ID;
         strncpy(req.expected_spool_id, p.expected_uid, sizeof(req.expected_spool_id) - 1);
         req.data.spoolman_id = p.spoolman_id;

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -69,6 +69,7 @@ public:
     void setAtomicWriteFields(const AtomicWriteFields& fields) { atomicWriteFields_ = fields; }
     bool writeSpoolmanDataToTag(int32_t spoolman_id, const char* expected_spool_id = nullptr);
     bool isRequestCompleted(uint32_t request_id);    // Check if request done
+    uint32_t generateRequestId();                    // Monotonic request ID
     void requestCurrentSpool();                      // Clear dedup to resend current spool
     bool scanOnce();                                 // Single scan cycle (for testing)
     bool getCurrentSpoolState(CurrentSpoolState& out);
@@ -130,7 +131,7 @@ private:
     // Deduplication
     void markRequestCompleted(uint32_t request_id);
     bool isDuplicateSpool(const uint8_t* uid, uint8_t uid_length);
-    uint32_t generateRequestId();
+
 
     // State
     CurrentSpoolState currentSpool;


### PR DESCRIPTION
## Summary
- **#79**: Guard snprintf buffer overflow in `handleSpoolDetected` HA JSON — clamp `len` after initial snprintf and check remaining capacity before each conditional append
- **#80**: Replace `millis()`-based request IDs with monotonic counter in `handleHAWriteTag` to prevent ID collisions across batched writes
- **#81**: Cap `processMessages()` loop at `QUEUE_SIZE` iterations to guarantee timer/display logic runs periodically even under rapid message bursts

## Test Plan
- [ ] `pio run -e esp32dev` compiles clean
- [ ] `pio run -e esp32s3zero` compiles clean
- [ ] HA tag write batches use unique sequential IDs (verify via Serial log)
- [ ] Rapid NFC scan + Spoolman response bursts don't starve timer checks

Closes #79, closes #80, closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message queue processing stability with enhanced resource management and processing limits to prevent system slowdowns during periods of sustained high message volume.
  * Enhanced safety for sensor data operations with comprehensive boundary validation and protective buffer checks to prevent overflow conditions.
  * Refined NFC write request tracking mechanism with improved reliability and consistency across sequential and concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->