### PR TITLE
fix(ci): resolve latest release tag on workflow_dispatch for docs sync

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -24,12 +24,24 @@ jobs:
           cp CHANGELOG.md docs-site/docs/releases/scanner.md
           sed -i '1s/.*/# Scanner Changelog/' docs-site/docs/releases/scanner.md
 
+      - name: Resolve release tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_PUSH_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          if [ -z "$TAG" ]; then
+            TAG=$(gh release view --repo SpoolSense/spoolsense_scanner --json tagName -q .tagName)
+            echo "Resolved latest release tag: $TAG"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Download firmware binaries from release
         env:
           GH_TOKEN: ${{ secrets.DOCS_PUSH_TOKEN }}
         run: |
           mkdir -p docs-site/docs/firmware
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ steps.tag.outputs.tag }}"
           for file in bootloader_esp32dev.bin bootloader_esp32s3zero.bin \
                       partitions_esp32dev.bin partitions_esp32s3zero.bin \
                       spoolsense_scanner_esp32dev.bin spoolsense_scanner_esp32s3zero.bin; do
@@ -39,7 +51,7 @@ jobs:
 
       - name: Update manifest version
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ steps.tag.outputs.tag }}"
           VERSION="${TAG#v}"
           sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" docs-site/docs/installation/manifest.json
 
@@ -50,5 +62,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/releases/scanner.md docs/firmware/ docs/installation/manifest.json
           git diff --cached --quiet && exit 0
-          git commit -m "docs: sync scanner changelog + firmware from ${{ github.event.release.tag_name }}"
+          TAG="${{ steps.tag.outputs.tag }}"
+          git commit -m "docs: sync scanner changelog + firmware from $TAG"
           git push


### PR DESCRIPTION
## Summary
- The `sync-changelog.yml` workflow failed on `workflow_dispatch` because `github.event.release.tag_name` is empty outside of `release` events
- Added a "Resolve release tag" step that falls back to `gh release view --json tagName` when the event tag is empty
- All downstream steps now reference `steps.tag.outputs.tag` instead of `github.event.release.tag_name`

This caused the web flasher manifest to have an empty version string and v1.6.3/v1.6.4 firmware to not sync.

## Test Plan
- [ ] Merge, then trigger `workflow_dispatch` manually — should sync latest release correctly
- [ ] Next `release: published` event should still work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release automation workflow to more reliably determine release tags, with better fallback handling for tag resolution during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->