### PR TITLE
fix: escape error JSON responses, check write/OTA return values (#77, #78)

### DIFF
--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -1523,15 +1523,23 @@ void WebServerManager::handleApiWriteOpenTag3D() {
 
 void WebServerManager::sendError(int code, const char* msg) {
     _server.sendHeader("Access-Control-Allow-Origin", "*");
-    // Escape quotes and backslashes in msg to produce valid JSON
-    char escaped[128];
+    // Escape quotes, backslashes, and control chars for valid JSON
+    char escaped[192];
     size_t j = 0;
-    for (size_t i = 0; msg[i] && j < sizeof(escaped) - 2; i++) {
-        if (msg[i] == '"' || msg[i] == '\\') {
-            escaped[j++] = '\\';
-        }
-        if (j < sizeof(escaped) - 1) {
-            escaped[j++] = msg[i];
+    for (size_t i = 0; msg[i] && j < sizeof(escaped) - 6; i++) {
+        char c = msg[i];
+        if (c == '"' || c == '\\') {
+            escaped[j++] = '\\'; escaped[j++] = c;
+        } else if (c == '\n') {
+            escaped[j++] = '\\'; escaped[j++] = 'n';
+        } else if (c == '\r') {
+            escaped[j++] = '\\'; escaped[j++] = 'r';
+        } else if (c == '\t') {
+            escaped[j++] = '\\'; escaped[j++] = 't';
+        } else if ((unsigned char)c < 0x20) {
+            j += snprintf(escaped + j, sizeof(escaped) - j, "\\u%04X", (unsigned char)c);
+        } else {
+            escaped[j++] = c;
         }
     }
     escaped[j] = '\0';


### PR DESCRIPTION
## Summary
- **#77**: `sendError()` now escapes quotes and backslashes in error messages before embedding in JSON, preventing malformed responses when upstream text contains special characters
- **#78**: Three unchecked return values fixed:
  - `handleApiFormatTag()` — `enqueueWrite()` return checked, returns 503 if queue full
  - `handleApiWriteTigerTag()` — same
  - `handleApiUpdateFromUrl()` — `xTaskCreatePinnedToCore()` return checked, returns 500 and resets OTA state if task creation fails

## Test Plan
- [ ] `pio run -e esp32dev` compiles clean
- [ ] `pio run -e esp32s3zero` compiles clean
- [ ] Error responses with special characters produce valid JSON
- [ ] Format tag with full write queue returns 503
- [ ] TigerTag write with full queue returns 503
- [ ] OTA update from URL with insufficient heap returns 500

Closes #77, closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OTA updates now detect and report failures when the update task fails to start, returning an error instead of a false success.
  * NFC tag formatting/writing now returns a "write queue full" error when the write queue is saturated.
  * API error responses are escaped and restructured to prevent malformed JSON and ensure valid error payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->