### PR TITLE
fix: reuse existing spool instead of creating duplicate (#91)

### DIFF
--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -1567,16 +1567,26 @@ bool SpoolmanManager::syncSpool(const SpoolmanSyncRequest& req, int& resolvedSpo
 
     if (spoolId < 0) {
         // No spool with this nfc_id under the new filament.
-        // Check if another spool (different filament) has this nfc_id — archive it.
+        // Check if another spool (different filament) has this nfc_id.
         int oldSpoolId = findSpoolByUuidGlobal(req.spool_id);
         if (oldSpoolId > 0) {
             if (shouldArchiveAndReplace(oldSpoolId, filamentId, req)) {
+                // Filament changed or weight jump — archive old, create new
                 archiveSpool(oldSpoolId);
                 invalidateCachedSpoolmanId(req.spool_id);
+                spoolId = createSpool(filamentId, req);
+                success = (spoolId >= 0);
+            } else {
+                // Same effective filament — reuse existing spool, update it
+                Serial.printf("SpoolmanManager: Reusing existing spool %d (same nfc_id, no archive needed)\n", oldSpoolId);
+                spoolId = oldSpoolId;
+                success = updateSpool(spoolId, filamentId, req.remaining_weight_g);
             }
+        } else {
+            // No existing spool anywhere — create new
+            spoolId = createSpool(filamentId, req);
+            success = (spoolId >= 0);
         }
-        spoolId = createSpool(filamentId, req);
-        success = (spoolId >= 0);
     } else {
         // Same filament + same nfc_id — check for weight jump (same type, fresh spool)
         if (shouldArchiveAndReplace(spoolId, filamentId, req)) {


### PR DESCRIPTION
## Summary
- When a spool with the same nfc_id exists under a different filament and `shouldArchiveAndReplace` returns false, **reuse the existing spool** instead of unconditionally creating a new one
- The old code always ran `createSpool()` on line 1578 regardless of archive decision, creating duplicates
- Now: archive=true → archive + create new. archive=false → reuse existing + update weight. no existing → create new.

## Root Cause
`syncSpool()` found an existing spool globally but when `shouldArchiveAndReplace` returned false (same effective filament, no weight jump), it fell through to `createSpool()` unconditionally — creating a duplicate with the same nfc_id every scan.

## Test Plan
- [ ] `pio run -e esp32dev` compiles clean
- [ ] `pio run -e esp32s3zero` compiles clean
- [ ] Scan same tag repeatedly — no new spools created
- [ ] Run spoolman-cleanup.py after several scans — no new duplicates
- [ ] Change filament on a tag, re-scan — old spool archived, new one created

Closes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spool synchronization to intelligently reuse and update existing spools rather than creating unnecessary duplicates, resulting in cleaner spool inventory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->