### PR TITLE
feat: GC9A01 round TFT display support

### DIFF
--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -201,11 +201,18 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
                 </label>
               </div>
               <div class="toggle-row">
-                <span class="toggle-label">TFT Display (ST7789 240x240)</span>
+                <span class="toggle-label">TFT Display (240x240)</span>
                 <label class="toggle-switch">
                   <input type="checkbox" id="tft_enabled" />
                   <span class="toggle-track"></span>
                 </label>
+              </div>
+              <div class="toggle-row" id="tft_driver_row" style="display:none">
+                <span class="toggle-label">TFT Driver</span>
+                <select id="tft_driver" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text);font-size:0.95em">
+                  <option value="st7789">ST7789 (square)</option>
+                  <option value="gc9a01">GC9A01 (round)</option>
+                </select>
               </div>
               <div class="toggle-row">
                 <span class="toggle-label">NFC Reader</span>
@@ -255,6 +262,11 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
       document.getElementById('led_enabled').checked = !!cfg.led_enabled;
       document.getElementById('keypad_enabled').checked = !!cfg.keypad_enabled;
       document.getElementById('tft_enabled').checked = !!cfg.tft_enabled;
+      if (cfg.tft_driver) document.getElementById('tft_driver').value = cfg.tft_driver;
+      document.getElementById('tft_driver_row').style.display = cfg.tft_enabled ? '' : 'none';
+      document.getElementById('tft_enabled').addEventListener('change', function() {
+        document.getElementById('tft_driver_row').style.display = this.checked ? '' : 'none';
+      });
       if (cfg.nfc_reader) document.getElementById('nfc_reader').value = cfg.nfc_reader;
       maybeSetValue('moonraker_url', cfg.moonraker_url);
       // Password placeholders
@@ -307,6 +319,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
         led_enabled: document.getElementById('led_enabled').checked ? 1 : 0,
         keypad_enabled: document.getElementById('keypad_enabled').checked ? 1 : 0,
         tft_enabled: document.getElementById('tft_enabled').checked ? 1 : 0,
+        tft_driver: document.getElementById('tft_driver').value,
         nfc_reader: document.getElementById('nfc_reader').value,
         moonraker_url: document.getElementById('moonraker_url').value.trim(),
         prusalink_on: document.getElementById('prusalink_on').checked ? 1 : 0,

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -24,6 +24,7 @@ static const char* NVS_KEY_LCD_ON         = "lcd_on";
 static const char* NVS_KEY_LED_ON         = "led_on";
 static const char* NVS_KEY_KEYPAD_ON      = "keypad_on";
 static const char* NVS_KEY_TFT_ON         = "tft_on";
+static const char* NVS_KEY_TFT_DRIVER     = "tft_driver";
 static const char* NVS_KEY_MOONRAKER_URL  = "moonraker_url";
 static const char* NVS_KEY_PRUSALINK_ON   = "prusalink_on";
 static const char* NVS_KEY_PRUSALINK_URL  = "prusalink_url";
@@ -223,6 +224,10 @@ bool ConfigurationManager::loadFromNVS() {
         _tftEnabled = prefs.getUChar(NVS_KEY_TFT_ON, _tftEnabled ? 1 : 0) != 0;
         anyOverride = true;
     }
+    if (prefs.isKey(NVS_KEY_TFT_DRIVER)) {
+        prefs.getString(NVS_KEY_TFT_DRIVER, _tftDriver, sizeof(_tftDriver));
+        anyOverride = true;
+    }
     if (prefs.isKey(NVS_KEY_NFC_READER)) {
         prefs.getString(NVS_KEY_NFC_READER, _nfcReader, sizeof(_nfcReader));
         anyOverride = true;
@@ -314,6 +319,10 @@ bool ConfigurationManager::isTftEnabled() const {
     return _tftEnabled;
 }
 
+const char* ConfigurationManager::getTftDriver() const {
+    return _tftDriver;
+}
+
 const char* ConfigurationManager::getMoonrakerURL() const {
     return _moonrakerUrl;
 }
@@ -344,6 +353,7 @@ void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     out.led_enabled = _ledEnabled ? 1 : 0;
     out.keypad_enabled = _keypadEnabled ? 1 : 0;
     out.tft_enabled = _tftEnabled ? 1 : 0;
+    strncpy(out.tft_driver, _tftDriver, sizeof(out.tft_driver) - 1);
     strncpy(out.moonraker_url, _moonrakerUrl, sizeof(out.moonraker_url) - 1);
     strncpy(out.nfc_reader, _nfcReader, sizeof(out.nfc_reader) - 1);
     strncpy(out.hostname, _hostname, sizeof(out.hostname) - 1);
@@ -375,6 +385,7 @@ bool ConfigurationManager::saveToNVS(const ConfigUpdate& update) {
     prefs.putUChar(NVS_KEY_LED_ON, update.led_enabled);
     prefs.putUChar(NVS_KEY_KEYPAD_ON, update.keypad_enabled);
     prefs.putUChar(NVS_KEY_TFT_ON, update.tft_enabled);
+    prefs.putString(NVS_KEY_TFT_DRIVER, update.tft_driver);
     prefs.putString(NVS_KEY_MOONRAKER_URL, update.moonraker_url);
     prefs.putBool(NVS_KEY_PRUSALINK_ON, update.prusalink_on != 0);
     prefs.putString(NVS_KEY_PRUSALINK_URL, update.prusalink_url);

--- a/src/ConfigurationManager.h
+++ b/src/ConfigurationManager.h
@@ -27,6 +27,7 @@ struct ConfigUpdate {
     uint8_t led_enabled;
     uint8_t keypad_enabled;
     uint8_t tft_enabled;
+    char tft_driver[8];   // "st7789" or "gc9a01"
     // Klipper / Moonraker
     char moonraker_url[128];
     // PrusaLink integration
@@ -79,6 +80,7 @@ public:
     bool isLedEnabled() const;
     bool isKeypadEnabled() const;
     bool isTftEnabled() const;
+    const char* getTftDriver() const;
 
     // Web config support
     void getCurrentConfig(ConfigUpdate& out) const;
@@ -127,6 +129,7 @@ private:
     bool _ledEnabled = false;
     bool _keypadEnabled = false;
     bool _tftEnabled = false;
+    char _tftDriver[8] = "st7789";
 
     bool _initialized = false;
 };

--- a/src/TFTConfig.h
+++ b/src/TFTConfig.h
@@ -4,26 +4,32 @@
 #include "BoardPins.h"
 
 // ---------------------------------------------------------------------------
-// LovyanGFX display config — one class per board, selected at compile time.
+// LovyanGFX display config — runtime panel selection (ST7789 or GC9A01).
 //
-// Tested target: 240x240 ST7789 (common cheap round/square TFT).
-// To use a different driver (ILI9341, GC9A01, etc.) change the _panel_instance
-// type and adjust _width/_height below. Everything else stays the same.
+// Both panels are 240x240 SPI. Same pins, same bus, different driver IC.
+// The panel type is selected at construction via a string parameter
+// read from NVS ("st7789" or "gc9a01").
 //
-// SPI bus used:
+// SPI bus:
 //   WROOM  — VSPI (bus 3): pins 22/23 freed from LCD when TFT replaces LCD
-//   S3-Zero — SPI2 (FSPI): pins 13/15/16 (PN5180 is on separate SPI instance)
+//   S3-Zero — SPI2 (FSPI): side header pins
 // ---------------------------------------------------------------------------
+
+enum class TFTDriver : uint8_t {
+    ST7789 = 0,
+    GC9A01 = 1
+};
 
 #if defined(BOARD_ESP32_S3)
 
 class LGFX : public lgfx::LGFX_Device {
-    lgfx::Panel_ST7789  _panel_instance;
+    lgfx::Panel_ST7789  _panel_st7789;
+    lgfx::Panel_GC9A01  _panel_gc9a01;
     lgfx::Bus_SPI       _bus_instance;
     lgfx::Light_PWM     _light_instance;
 
 public:
-    LGFX() {
+    LGFX(TFTDriver driver = TFTDriver::ST7789) {
         // SPI bus
         {
             auto cfg = _bus_instance.config();
@@ -33,77 +39,23 @@ public:
             cfg.freq_read  = 16000000;
             cfg.pin_sclk   = PIN_TFT_SCLK;
             cfg.pin_mosi   = PIN_TFT_MOSI;
-            cfg.pin_miso   = PIN_TFT_MISO; // -1 if not connected
-            cfg.pin_dc     = PIN_TFT_DC;
-            _bus_instance.config(cfg);
-            _panel_instance.setBus(&_bus_instance);
-        }
-
-        // Panel
-        {
-            auto cfg = _panel_instance.config();
-            cfg.pin_cs   = PIN_TFT_CS;
-            cfg.pin_rst  = PIN_TFT_RST;
-            cfg.pin_busy = -1;
-            cfg.memory_width  = 240;
-            cfg.memory_height = 240;
-            cfg.panel_width   = 240;
-            cfg.panel_height  = 240;
-            cfg.offset_x      = 0;
-            cfg.offset_y      = 0;
-            cfg.offset_rotation = 0;
-            cfg.dummy_read_pixel = 8;
-            cfg.dummy_read_bits  = 1;
-            cfg.readable     = false;
-            cfg.invert       = true;  // ST7789 typically needs invert=true
-            cfg.rgb_order    = false;
-            cfg.dlen_16bit   = false;
-            cfg.bus_shared   = false;
-            _panel_instance.config(cfg);
-        }
-
-        // Backlight
-        {
-            auto cfg = _light_instance.config();
-            cfg.pin_bl      = PIN_TFT_BL;
-            cfg.invert      = false;
-            cfg.freq        = 44100;
-            cfg.pwm_channel = 7;
-            _light_instance.config(cfg);
-            _panel_instance.setLight(&_light_instance);
-        }
-
-        setPanel(&_panel_instance);
-    }
-};
-
-#else // WROOM
-
-class LGFX : public lgfx::LGFX_Device {
-    lgfx::Panel_ST7789  _panel_instance;
-    lgfx::Bus_SPI       _bus_instance;
-    lgfx::Light_PWM     _light_instance;
-
-public:
-    LGFX() {
-        // SPI bus — VSPI. PN5180 uses HSPI via dedicated SPIClass instance.
-        {
-            auto cfg = _bus_instance.config();
-            cfg.spi_host   = VSPI_HOST;
-            cfg.spi_mode   = 0;
-            cfg.freq_write = 40000000;
-            cfg.freq_read  = 16000000;
-            cfg.pin_sclk   = PIN_TFT_SCLK;
-            cfg.pin_mosi   = PIN_TFT_MOSI;
             cfg.pin_miso   = PIN_TFT_MISO;
             cfg.pin_dc     = PIN_TFT_DC;
             _bus_instance.config(cfg);
-            _panel_instance.setBus(&_bus_instance);
         }
 
-        // Panel
+        // Select panel and configure
+        lgfx::Panel_Device* panel = nullptr;
+        if (driver == TFTDriver::GC9A01) {
+            panel = &_panel_gc9a01;
+        } else {
+            panel = &_panel_st7789;
+        }
+
+        panel->setBus(&_bus_instance);
+
         {
-            auto cfg = _panel_instance.config();
+            auto cfg = panel->config();
             cfg.pin_cs   = PIN_TFT_CS;
             cfg.pin_rst  = PIN_TFT_RST;
             cfg.pin_busy = -1;
@@ -121,7 +73,7 @@ public:
             cfg.rgb_order    = false;
             cfg.dlen_16bit   = false;
             cfg.bus_shared   = false;
-            _panel_instance.config(cfg);
+            panel->config(cfg);
         }
 
         // Backlight
@@ -132,10 +84,80 @@ public:
             cfg.freq        = 44100;
             cfg.pwm_channel = 7;
             _light_instance.config(cfg);
-            _panel_instance.setLight(&_light_instance);
+            panel->setLight(&_light_instance);
         }
 
-        setPanel(&_panel_instance);
+        setPanel(panel);
+    }
+};
+
+#else // WROOM
+
+class LGFX : public lgfx::LGFX_Device {
+    lgfx::Panel_ST7789  _panel_st7789;
+    lgfx::Panel_GC9A01  _panel_gc9a01;
+    lgfx::Bus_SPI       _bus_instance;
+    lgfx::Light_PWM     _light_instance;
+
+public:
+    LGFX(TFTDriver driver = TFTDriver::ST7789) {
+        // SPI bus — VSPI. PN5180 uses HSPI via dedicated SPIClass instance.
+        {
+            auto cfg = _bus_instance.config();
+            cfg.spi_host   = VSPI_HOST;
+            cfg.spi_mode   = 0;
+            cfg.freq_write = 40000000;
+            cfg.freq_read  = 16000000;
+            cfg.pin_sclk   = PIN_TFT_SCLK;
+            cfg.pin_mosi   = PIN_TFT_MOSI;
+            cfg.pin_miso   = PIN_TFT_MISO;
+            cfg.pin_dc     = PIN_TFT_DC;
+            _bus_instance.config(cfg);
+        }
+
+        lgfx::Panel_Device* panel = nullptr;
+        if (driver == TFTDriver::GC9A01) {
+            panel = &_panel_gc9a01;
+        } else {
+            panel = &_panel_st7789;
+        }
+
+        panel->setBus(&_bus_instance);
+
+        {
+            auto cfg = panel->config();
+            cfg.pin_cs   = PIN_TFT_CS;
+            cfg.pin_rst  = PIN_TFT_RST;
+            cfg.pin_busy = -1;
+            cfg.memory_width  = 240;
+            cfg.memory_height = 240;
+            cfg.panel_width   = 240;
+            cfg.panel_height  = 240;
+            cfg.offset_x      = 0;
+            cfg.offset_y      = 0;
+            cfg.offset_rotation = 0;
+            cfg.dummy_read_pixel = 8;
+            cfg.dummy_read_bits  = 1;
+            cfg.readable     = false;
+            cfg.invert       = true;
+            cfg.rgb_order    = false;
+            cfg.dlen_16bit   = false;
+            cfg.bus_shared   = false;
+            panel->config(cfg);
+        }
+
+        // Backlight
+        {
+            auto cfg = _light_instance.config();
+            cfg.pin_bl      = PIN_TFT_BL;
+            cfg.invert      = false;
+            cfg.freq        = 44100;
+            cfg.pwm_channel = 7;
+            _light_instance.config(cfg);
+            panel->setLight(&_light_instance);
+        }
+
+        setPanel(panel);
     }
 };
 

--- a/src/TFTManager.cpp
+++ b/src/TFTManager.cpp
@@ -29,8 +29,9 @@ static const uint32_t COLOR_ACCENT    = 0x4FC3F7;
 // ---------------------------------------------------------------------------
 // Constructor
 // ---------------------------------------------------------------------------
-TFTManager::TFTManager()
-    : _sprite(&_tft),
+TFTManager::TFTManager(TFTDriver driver)
+    : _tft(driver),
+      _sprite(&_tft),
       _messageQueue(nullptr),
       _taskHandle(nullptr),
       _screenTimeoutMs(DEFAULT_SCREEN_TIMEOUT_MS),
@@ -41,7 +42,8 @@ TFTManager::TFTManager()
       _breathDirection(-1),
       _lastBreathMs(0),
       _isBreathing(false),
-      _breathColor(0xFFFFFF) {}
+      _breathColor(0xFFFFFF),
+      _driver(driver) {}
 
 // ---------------------------------------------------------------------------
 // begin / startTask
@@ -350,8 +352,8 @@ void TFTManager::renderSpoolScanned(const DisplaySpoolData& spool) {
     // "SpoolSense" in header
     _sprite.setTextColor(COLOR_ACCENT);
     _sprite.setTextSize(1);
-    _sprite.setTextDatum(ML_DATUM);
-    _sprite.drawString("SpoolSense", 30, 14);
+    _sprite.setTextDatum(MC_DATUM);
+    _sprite.drawString("SpoolSense", _tft.width() / 2, 14);
 
     // ---- Spool graphic ----
     uint32_t fillColor = hexToRgb(spool.colorHex);

--- a/src/TFTManager.h
+++ b/src/TFTManager.h
@@ -45,7 +45,7 @@ struct TFTMessage {
 // ---------------------------------------------------------------------------
 class TFTManager : public DisplayI {
 public:
-    TFTManager();
+    TFTManager(TFTDriver driver = TFTDriver::ST7789);
 
     void begin();
     void startTask();
@@ -96,7 +96,8 @@ private:
     uint32_t dimColor(uint32_t color, uint8_t brightness); // for low-spool breathing
 
     LGFX _tft;
-    LGFX_Sprite _sprite; // full-screen sprite for flicker-free rendering
+    LGFX_Sprite _sprite;
+    TFTDriver _driver;
 
     QueueHandle_t _messageQueue;
     TaskHandle_t _taskHandle;

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -712,6 +712,7 @@ void WebServerManager::handleApiGetConfig() {
     doc["nfc_reader"] = cfg.nfc_reader;
     doc["hostname"] = cfg.hostname;
     doc["tft_enabled"] = cfg.tft_enabled;
+    doc["tft_driver"] = cfg.tft_driver;
     doc["ap_mode"] = _apMode;
     if (_apMode) {
         extern char g_apSSID[];
@@ -749,6 +750,7 @@ void WebServerManager::handleApiPostConfig() {
     update.led_enabled = doc["led_enabled"] | (uint8_t)0;
     update.keypad_enabled = doc["keypad_enabled"] | (uint8_t)0;
     update.tft_enabled = doc["tft_enabled"] | (uint8_t)0;
+    strncpy(update.tft_driver, doc["tft_driver"] | "st7789", sizeof(update.tft_driver) - 1);
     // TFT and LCD share GPIO 22/23 on WROOM — auto-disable LCD when TFT enabled
     if (update.tft_enabled && update.lcd_enabled) {
         update.lcd_enabled = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,8 +45,8 @@ static constexpr uint16_t HTTP_PORT = 80;
 // Always declared; only initialized if isLcdEnabled() at runtime
 LCDManager lcdManager(0x27, 16, 2);
 
-// TFT display — replaces LCD when enabled via NVS
-TFTManager tftManager;
+// TFT display — constructed in setup() after NVS config loads (needs driver type)
+TFTManager* tftManagerPtr = nullptr;
 
 // Always declared; only initialized if isLedEnabled() at runtime
 LEDManager ledManager;
@@ -71,8 +71,8 @@ void startAPMode() {
   Serial.printf("AP started: %s @ 192.168.4.1\n", g_apSSID);
 
   auto& config = ConfigurationManager::getInstance();
-  if (config.isTftEnabled()) {
-    tftManager.showError(g_apSSID);
+  if (config.isTftEnabled() && tftManagerPtr) {
+    tftManagerPtr->showError(g_apSSID);
   } else if (config.isLcdEnabled()) {
     lcdManager.updateScreen(g_apSSID, "Go to 192.168.4.1");
   }
@@ -93,8 +93,8 @@ void initWiFi() {
   Serial.print("Connecting to WiFi: ");
   Serial.println(config.getWiFiSSID());
 
-  if (config.isTftEnabled()) {
-    tftManager.showWifiConnecting();
+  if (config.isTftEnabled() && tftManagerPtr) {
+    tftManagerPtr->showWifiConnecting();
   } else if (config.isLcdEnabled()) {
     lcdManager.updateScreen("Connecting WiFi", "");
   }
@@ -114,8 +114,8 @@ void initWiFi() {
     Serial.print("WiFi connected! IP: ");
     Serial.println(WiFi.localIP());
 
-    if (config.isTftEnabled()) {
-      tftManager.showWifiConnected(WiFi.localIP().toString().c_str());
+    if (config.isTftEnabled() && tftManagerPtr) {
+      tftManagerPtr->showWifiConnected(WiFi.localIP().toString().c_str());
     } else if (config.isLcdEnabled()) {
       lcdManager.updateScreen("WiFi OK", WiFi.localIP().toString().c_str());
     }
@@ -129,8 +129,8 @@ void initWiFi() {
     struct tm timeinfo;
     if (!getLocalTime(&timeinfo)) {
       Serial.println("Failed to obtain time");
-      if (config.isTftEnabled()) {
-        tftManager.showError("NTP FAILED");
+      if (config.isTftEnabled() && tftManagerPtr) {
+        tftManagerPtr->showError("NTP FAILED");
       } else if (config.isLcdEnabled()) {
         lcdManager.updateScreen("NTP FAILED", "");
       }
@@ -161,8 +161,8 @@ void checkWiFi() {
     // WiFi just dropped
     Serial.println("WiFi: Connection lost — starting reconnection");
     auto& config = ConfigurationManager::getInstance();
-    if (config.isTftEnabled()) {
-      tftManager.showText("WiFi Lost", "Reconnecting...");
+    if (config.isTftEnabled() && tftManagerPtr) {
+      tftManagerPtr->showText("WiFi Lost", "Reconnecting...");
     } else if (config.isLcdEnabled()) {
       lcdManager.updateScreen("WiFi Lost", "Reconnecting...");
     }
@@ -187,8 +187,8 @@ void checkWiFi() {
     // WiFi just reconnected
     Serial.printf("WiFi: Reconnected! IP: %s\n", WiFi.localIP().toString().c_str());
     auto& config = ConfigurationManager::getInstance();
-    if (config.isTftEnabled()) {
-      tftManager.showText("WiFi OK", WiFi.localIP().toString().c_str());
+    if (config.isTftEnabled() && tftManagerPtr) {
+      tftManagerPtr->showText("WiFi OK", WiFi.localIP().toString().c_str());
     } else if (config.isLcdEnabled()) {
       lcdManager.updateScreen("WiFi OK", WiFi.localIP().toString().c_str());
     }
@@ -229,10 +229,15 @@ void setup() {
   }
 
   if (config.isTftEnabled()) {
-    // TFT display — mutually exclusive with LCD on WROOM
-    tftManager.begin();
-    tftManager.startTask();
-    tftManager.showBoot(FIRMWARE_VERSION);
+    // TFT display — select driver from NVS (st7789 or gc9a01)
+    TFTDriver tftDriver = TFTDriver::ST7789;
+    if (strcmp(config.getTftDriver(), "gc9a01") == 0) {
+        tftDriver = TFTDriver::GC9A01;
+    }
+    tftManagerPtr = new TFTManager(tftDriver);
+    tftManagerPtr->begin();
+    tftManagerPtr->startTask();
+    tftManagerPtr->showBoot(FIRMWARE_VERSION);
     Serial.println("TFT initialized");
   } else if (config.isLcdEnabled()) {
     // Initialize I2C with custom pins for LCD
@@ -254,7 +259,7 @@ void setup() {
   // Initialize ApplicationManager (message queue) with display reference
   DisplayI* activeDisplay = nullptr;
   if (config.isTftEnabled()) {
-    activeDisplay = &tftManager;
+    activeDisplay = tftManagerPtr;
   } else if (config.isLcdEnabled()) {
     activeDisplay = &lcdManager;
   }
@@ -343,7 +348,7 @@ void setup() {
   }
 
   if (config.isTftEnabled()) {
-    tftManager.showReady();
+    if (tftManagerPtr) tftManagerPtr->showReady();
   } else if (config.isLcdEnabled()) {
     ApplicationManager::getInstance().showStatusScreen();
   }


### PR DESCRIPTION
## Summary
- GC9A01 round TFT (240x240) support as an alternative to the ST7789 square TFT
- Same pins, same SPI bus, same resolution — runtime selectable via config page
- TFT Driver dropdown (ST7789 square / GC9A01 round) appears when TFT Display is enabled
- Both panel types compiled into a single binary, selected at boot from NVS
- Centered "SpoolSense" header text (was left-aligned on spool scan view)

## Test plan
- [x] GC9A01 wired to WROOM, boots and displays correctly
- [x] Config page shows TFT Driver dropdown when TFT enabled
- [x] Tag scan displays spool data on round screen
- [ ] ST7789 still works after this change (swap screen back and change config)
- [ ] S3-Zero builds clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime support for multiple TFT display drivers: ST7789 and GC9A01.
  * Configuration interface now includes a TFT Driver dropdown for hardware selection.
  * TFT driver selection persists across device restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->