### PR TITLE
fix: std::atomic for cross-core flags, NTP retry on boot failure (#108, #109)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .pio/
 .vscode/
+.editorconfig
 include/UserConfig.h
 serial.log
 test/

--- a/src/HomeAssistantManager.h
+++ b/src/HomeAssistantManager.h
@@ -2,6 +2,7 @@
 #define HOME_ASSISTANT_MANAGER_H
 
 #include <cstdint>
+#include <atomic>
 #include "NFCTypes.h"
 
 #ifndef NATIVE_TEST
@@ -56,12 +57,12 @@ private:
     PubSubClient mqttClient;
     TaskHandle_t taskHandle = nullptr;
     SemaphoreHandle_t taskControlMutex = nullptr;
-    volatile bool stopRequested_ = false;
+    std::atomic<bool> stopRequested_{false};
     volatile int lastMqttState_ = -1;
 #endif
 
     QueueHandle_t publishQueue = nullptr;
-    volatile bool connected_ = false;
+    std::atomic<bool> connected_{false};
 
     // Reconnect backoff
     uint32_t reconnectDelay_ = 1000;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,6 +147,19 @@ void initWiFi() {
   }
 }
 
+void retryNTP() {
+  static bool timeObtained = false;
+  static unsigned long lastAttempt = 0;
+
+  if (timeObtained || g_apModeActive) return;
+  if (time(nullptr) > 1700000000) { timeObtained = true; return; }
+  if (millis() - lastAttempt < 30000) return;
+
+  lastAttempt = millis();
+  Serial.println("NTP: Retrying...");
+  configTime(0, 0, "pool.ntp.org");
+}
+
 void checkWiFi() {
   // Skip in AP mode — no WiFi to reconnect
   if (g_apModeActive) return;
@@ -386,6 +399,9 @@ void loop() {
 
   // WiFi reconnection watchdog (non-AP mode only, throttled to WIFI_CHECK_INTERVAL_MS)
   checkWiFi();
+
+  // NTP retry if boot-time sync failed (30s interval, non-blocking)
+  retryNTP();
 
   // LCD and NFC scanning are handled by their own tasks
   delay(10);


### PR DESCRIPTION
## Summary
- **std::atomic** — changed `volatile bool stopRequested_` and `volatile bool connected_` to `std::atomic<bool>` in HomeAssistantManager for proper cross-core memory ordering (#108)
- **NTP retry** — if NTP fails at boot, retries every 30 seconds non-blocking from loop() until time is obtained (#109)
- **gitignore** — added .editorconfig

## Test plan
- [x] esp32dev builds clean
- [x] esp32s3zero builds clean
- [x] Native tests pass (18/18)
- [ ] Verify NTP retry works by booting without network, then connecting WiFi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Implemented automatic retry mechanism for system time synchronization to improve reliability when initial boot-time sync fails, with intelligent throttling to prevent excessive retry attempts and unnecessary resource consumption.

**Refactor**
- Enhanced internal thread-safety mechanisms and synchronization logic for improved concurrent operation handling, better component coordination, and increased overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->