### PR TITLE
fix: addToRecentSpools mutex guard, drain write queue before restart (#106, #107)

### DIFF
--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -2255,7 +2255,11 @@ void NFCManager::requestCurrentSpool() {
 }
 
 void NFCManager::addToRecentSpools() {
+    if (tagMutex == nullptr) return;
+    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(50)) != pdTRUE) return;
+
     if (!currentSpool.tag_data_valid) {
+        xSemaphoreGive(tagMutex);
         return;
     }
 
@@ -2268,7 +2272,7 @@ void NFCManager::addToRecentSpools() {
         }
     }
 
-    // Create new entry from current spool
+    // Snapshot data under mutex
     RecentSpoolEntry newEntry;
     memset(&newEntry, 0, sizeof(newEntry));
     strncpy(newEntry.spool_id, currentSpool.spool_id, sizeof(newEntry.spool_id) - 1);
@@ -2292,6 +2296,8 @@ void NFCManager::addToRecentSpools() {
     int32_t smId = -1;
     opt_get_gp_spoolman_id(&currentSpool.tag_data, &smId);
     newEntry.spoolman_id = smId;
+
+    xSemaphoreGive(tagMutex);
 
     if (existingIndex >= 0) {
         // Spool exists - shift entries to remove it from current position
@@ -2431,4 +2437,9 @@ void NFCManager::updateRecentSpoolSyncStatus(const char* spool_id, bool synced) 
     }
 
     xSemaphoreGive(tagMutex);
+}
+
+bool NFCManager::isWriteQueueEmpty() const {
+    if (!writeQueue) return true;
+    return uxQueueMessagesWaiting(writeQueue) == 0;
 }

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -81,6 +81,7 @@ public:
     bool getNfcReaderInfo(char* buf, size_t len) const;
     void pauseScanTask();
     void resumeScanTask();
+    bool isWriteQueueEmpty() const;
 
     // Dependency injection for testing
     void setConnection(NFCConnectionI* conn) { connection_ = conn; }

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -781,10 +781,13 @@ void WebServerManager::handleApiPostConfig() {
     Serial.println("WebServerManager: Config saved, rebooting...");
     _server.send(200, "application/json", "{\"success\":true}");
 
-    // Suspend scan task to prevent new NFC writes, then wait for any
-    // in-progress write to finish before restarting (#27)
+    // Wait for write queue to drain before restarting (#107)
+    // Scan task must keep running to process queued writes
+    for (int i = 0; i < 20 && !NFCManager::getInstance().isWriteQueueEmpty(); i++) {
+        delay(100);
+    }
     NFCManager::getInstance().pauseScanTask();
-    delay(500);
+    delay(200);
     ESP.restart();
 }
 
@@ -845,8 +848,15 @@ void WebServerManager::handleApiUploadFirmwareComplete() {
     } else {
         _server.send(200, "application/json", "{\"success\":true}");
         Serial.println("OTA: Rebooting...");
-        // Scan task already paused during upload; wait for any in-flight NFC I/O (#27)
-        delay(500);
+        // Resume scan task briefly to drain any pending writes (#107)
+        if (!NFCManager::getInstance().isWriteQueueEmpty()) {
+            NFCManager::getInstance().resumeScanTask();
+            for (int i = 0; i < 20 && !NFCManager::getInstance().isWriteQueueEmpty(); i++) {
+                delay(100);
+            }
+            NFCManager::getInstance().pauseScanTask();
+        }
+        delay(200);
         ESP.restart();
     }
 }


### PR DESCRIPTION
## Summary
- **Mutex guard on addToRecentSpools** — acquires `tagMutex` before reading `currentSpool` data to prevent stale reads from concurrent access (#106)
- **Drain write queue before ESP.restart()** — config save and OTA restart now wait up to 2 seconds for pending NFC writes to complete before rebooting, preventing tag corruption (#107)
- **isWriteQueueEmpty()** — new NFCManager method to check if writes are pending

## Test plan
- [x] esp32dev builds clean
- [x] esp32s3devkitc builds clean
- [ ] Trigger OTA update while tag write is queued — verify write completes before reboot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced NFC operation reliability during system reboots and firmware updates. The system now properly waits for pending NFC write operations to complete before restarting, improving data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->