### PR TITLE
refactor: extract shared write flow UX from writer pages (#96)

### DIFF
--- a/src/LEDManager.cpp
+++ b/src/LEDManager.cpp
@@ -12,7 +12,10 @@
 #define M_PI 3.14159265f
 #endif
 
-#if defined(BOARD_ESP32_S3)
+#if defined(BOARD_S3_DEVKITC)
+LEDManager::LEDManager()
+    : _initialized(false), _taskStarted(false), _pixel(1, 0, NEO_GRB + NEO_KHZ800) {}
+#elif defined(BOARD_ESP32_S3)
 LEDManager::LEDManager()
     : _initialized(false), _taskStarted(false), _pixel(1, 0, NEO_RGB + NEO_KHZ800) {}
 #else
@@ -21,7 +24,9 @@ LEDManager::LEDManager()
 #endif
 
 void LEDManager::begin(uint8_t pin) {
-#if defined(BOARD_ESP32_S3)
+#if defined(BOARD_S3_DEVKITC)
+    _pixel.updateType(NEO_GRB + NEO_KHZ800);
+#elif defined(BOARD_ESP32_S3)
     _pixel.updateType(NEO_RGB + NEO_KHZ800);
 #else
     _pixel.updateType(NEO_GRBW + NEO_KHZ800);

--- a/src/OpenPrintTagWriterHTML.h
+++ b/src/OpenPrintTagWriterHTML.h
@@ -275,19 +275,12 @@ const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
 
   <script src="/js/shared.js"></script>
   <script>
-    var createView = document.getElementById('createView');
-    var statusView = document.getElementById('statusView');
     var writerForm = document.getElementById('writerForm');
 
     var materialTypeEl = document.getElementById('material_type');
     var materialSearchEl = document.getElementById('material_search');
     var materialListEl = document.getElementById('material-list');
     var materialNameEl = document.getElementById('material_name');
-
-    var backBtn = document.getElementById('backBtn');
-    var anotherBtn = document.getElementById('anotherBtn');
-
-    var STEP_IDS = ['step-wait', 'step-detect', 'step-format', 'step-write', 'step-verify'];
 
     syncColorPicker('colorPicker', 'colorHex');
 
@@ -364,16 +357,9 @@ const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
       });
     });
 
-    function showStatusView() {
-      createView.classList.add('hidden');
-      statusView.classList.remove('hidden');
-      backBtn.classList.add('hidden');
-      anotherBtn.classList.add('hidden');
-    }
-
     function showCreateView() {
-      statusView.classList.add('hidden');
-      createView.classList.remove('hidden');
+      document.getElementById('statusView').classList.add('hidden');
+      document.getElementById('createView').classList.remove('hidden');
     }
 
     function syncMaterialNameFromSelection() {
@@ -478,95 +464,6 @@ const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
       return checks.length > 0 && checks.every(Boolean);
     }
 
-    async function writeFlow() {
-      resetAllSteps(STEP_IDS);
-      showStatusView();
-
-      try {
-        setStepState('step-wait', 'active');
-        setBanner('statusBanner', 'Waiting for tag\u2026');
-        setResult('resultBox', 'Place and hold the tag on the scanner.', '');
-
-        var presentStatus = null;
-        var deadline = Date.now() + 8000;
-        while (Date.now() < deadline) {
-          var s = await api('/api/status');
-          if (s.present) { presentStatus = s; break; }
-          await sleep(500);
-        }
-        if (!presentStatus) {
-          setStepState('step-wait', 'error');
-          throw new Error('No tag detected. Place the tag on the scanner and try again.');
-        }
-        setStepState('step-wait', 'done');
-
-        setStepState('step-detect', 'active');
-        setBanner('statusBanner', 'Tag detected.');
-        setResult('resultBox', 'UID: ' + (presentStatus.uid || 'Unknown'), '');
-        await sleep(250);
-        setStepState('step-detect', 'done');
-
-        var payload = buildPayload(presentStatus.uid);
-
-        if (presentStatus.tag_data_valid === false) {
-          setStepState('step-format', 'active');
-          setBanner('statusBanner', 'Formatting blank tag\u2026');
-          setResult('resultBox', 'Blank tag detected. Initializing NDEF structure.', '');
-          await api('/api/format-tag', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ uid: presentStatus.uid })
-          });
-          await sleep(1000);
-          setStepState('step-format', 'done');
-        } else {
-          setStepState('step-format', 'done');
-        }
-
-        setStepState('step-write', 'active');
-        setBanner('statusBanner', 'Writing data\u2026');
-        setResult('resultBox', 'Sending OpenPrintTag payload to scanner.', '');
-        await api('/api/write-tag', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        });
-        setStepState('step-write', 'done');
-
-        setStepState('step-verify', 'active');
-        setBanner('statusBanner', 'Verifying write\u2026');
-        setResult('resultBox', 'Reading tag back to confirm fields match.', '');
-
-        var verifyDeadline = Date.now() + 15000;
-        while (Date.now() < verifyDeadline) {
-          await sleep(500);
-          var status = await api('/api/status');
-          if (status.present && valuesMatch(status, payload)) {
-            setStepState('step-verify', 'done');
-            setBanner('statusBanner', 'Write successful.');
-            setResult('resultBox', 'OpenPrintTag data verified successfully.', 'success');
-            backBtn.classList.remove('hidden');
-            anotherBtn.classList.remove('hidden');
-            return;
-          }
-        }
-
-        setStepState('step-verify', 'error');
-        throw new Error('Write timed out. Keep the tag on the scanner and try again.');
-      } catch (err) {
-        var msg = err && err.message ? err.message : 'Write failed';
-        setBanner('statusBanner', 'Write failed.');
-        setResult('resultBox', msg, 'error');
-
-        STEP_IDS.forEach(function(id) {
-          var el = document.getElementById(id);
-          if (el && el.classList.contains('active')) setStepState(id, 'error');
-        });
-
-        backBtn.classList.remove('hidden');
-      }
-    }
-
     materialSearchEl.addEventListener('input', syncMaterialNameFromSelection);
 
     materialNameEl.addEventListener('input', function() {
@@ -583,13 +480,21 @@ const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
       }, 0);
     });
 
+    document.getElementById('backBtn').addEventListener('click', showCreateView);
+    document.getElementById('anotherBtn').addEventListener('click', showCreateView);
+
     writerForm.addEventListener('submit', function(e) {
       e.preventDefault();
-      writeFlow();
+      sharedWriteFlow({
+        stepIds: ['step-wait', 'step-detect', 'step-format', 'step-write', 'step-verify'],
+        endpoint: '/api/write-tag',
+        formatName: 'OpenPrintTag',
+        buildPayload: buildPayload,
+        verify: function(status, payload) { return valuesMatch(status, payload); },
+        formatCheck: function(status) { return status.tag_data_valid === false; },
+        formatEndpoint: '/api/format-tag'
+      });
     });
-
-    backBtn.addEventListener('click', showCreateView);
-    anotherBtn.addEventListener('click', showCreateView);
 
     syncMaterialNameFromSelection();
 
@@ -616,48 +521,11 @@ const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
       spoolman_id: 'spoolman_id'
     });
 
-    var readBtn = document.getElementById('readBtn');
-    var writeBtn = document.getElementById('writeBtn');
-    var readWaiting = false;
-
-    function setReadWaiting(active) {
-      readWaiting = active;
-      writeBtn.disabled = active;
-      if (active) {
-        readBtn.textContent = 'Cancel';
-        readBtn.onclick = cancelRead;
-        document.getElementById('readPrompt').classList.remove('hidden');
-      } else {
-        readBtn.textContent = 'Read';
-        readBtn.onclick = startRead;
-        document.getElementById('readPrompt').classList.add('hidden');
-      }
-    }
-
-    function cancelRead() {
-      readWaiting = false;
-      setReadWaiting(false);
-    }
-
-    async function startRead() {
-      setReadWaiting(true);
-      var deadline = Date.now() + 30000;
-      while (readWaiting && Date.now() < deadline) {
-        try {
-          var status = await fetch('/api/status').then(r => r.json());
-          if (status.present && status.tag_kind === 'OpenPrintTag') {
-            prefillFromStatus(status);
-            break;
-          } else if (status.present) {
-            break; // wrong format
-          }
-        } catch(e) {}
-        await new Promise(r => setTimeout(r, 500));
-      }
-      setReadWaiting(false);
-    }
-
-    readBtn.onclick = startRead;
+    setupReadButton({
+      expectedKind: 'OpenPrintTag',
+      wrongKindMsg: 'wrong format \u2014 expected OpenPrintTag',
+      fillForm: function(status) { prefillFromStatus(status); }
+    });
   </script>
 </body>
 </html>

--- a/src/OpenSpoolWriterHTML.h
+++ b/src/OpenSpoolWriterHTML.h
@@ -195,13 +195,7 @@ const char OPENSPOOL_WRITER_HTML[] PROGMEM = R"rawliteral(
 
   <script src="/js/shared.js"></script>
   <script>
-    var createView = document.getElementById('createView');
-    var statusView = document.getElementById('statusView');
     var writerForm = document.getElementById('writerForm');
-    var backBtn = document.getElementById('backBtn');
-    var anotherBtn = document.getElementById('anotherBtn');
-
-    var STEP_IDS = ['step-wait', 'step-detect', 'step-write', 'step-verify'];
 
     syncColorPicker('colorPicker', 'colorHex');
 
@@ -212,14 +206,12 @@ const char OPENSPOOL_WRITER_HTML[] PROGMEM = R"rawliteral(
       colorPicker: 'colorPicker',
       nozzle_min: 'min_temp',
       nozzle_max: 'max_temp',
-      // enrichment fields:
       bed_single: 'enrich-bed-temp',
       diameter: 'enrich-diameter',
       density: 'enrich-density',
       remaining: 'enrich-remaining'
     });
 
-    // Show enrichment section once spool picker loads (confirms Spoolman is configured)
     var _enrichCheck = setInterval(function() {
       if (document.querySelector('#spoolmanPickerSearch')) {
         document.getElementById('spoolmanEnrichment').classList.remove('hidden');
@@ -228,176 +220,34 @@ const char OPENSPOOL_WRITER_HTML[] PROGMEM = R"rawliteral(
     }, 500);
     setTimeout(function() { clearInterval(_enrichCheck); }, 15000);
 
-    var readBtn = document.getElementById('readBtn');
-    var writeBtn = document.getElementById('writeBtn');
-    var readWaiting = false;
-
-    function setReadWaiting(active) {
-      readWaiting = active;
-      writeBtn.disabled = active;
-      if (active) {
-        readBtn.textContent = 'Cancel';
-        readBtn.onclick = cancelRead;
-        document.getElementById('readPrompt').classList.remove('hidden');
-      } else {
-        readBtn.textContent = 'Read';
-        readBtn.onclick = startRead;
-        document.getElementById('readPrompt').classList.add('hidden');
-      }
-    }
-
-    function cancelRead() {
-      readWaiting = false;
-      setReadWaiting(false);
-    }
-
     function showMatchBadge(text) {
       var badge = document.getElementById('spoolmanMatchBadge');
       badge.textContent = text;
       badge.classList.remove('hidden');
     }
 
-    function setVal(id, val) {
-      var el = document.getElementById(id);
-      if (el && val !== undefined && val !== null) el.value = val;
-    }
-
-    function fillEnrichmentFromStatus(status) {
-      var sp = status.spoolman || {};
-      if (sp.remaining_g !== undefined) setVal('enrich-remaining', sp.remaining_g.toFixed(1));
-      if (sp.bed_temp && sp.bed_temp > 0) setVal('enrich-bed-temp', sp.bed_temp);
-      if (sp.diameter_mm && sp.diameter_mm > 0) setVal('enrich-diameter', sp.diameter_mm);
-      if (sp.density && sp.density > 0) setVal('enrich-density', sp.density);
-    }
-
-    async function startRead() {
-      setReadWaiting(true);
-      var deadline = Date.now() + 30000;
-      while (readWaiting && Date.now() < deadline) {
-        try {
-          var status = await fetch('/api/status').then(r => r.json());
-          if (status.present && status.tag_kind === 'OpenSpoolTag') {
-            var os = status.openspool || {};
-            setVal('brand', os.brand || '');
-            setVal('type', os.material || '');
-            if (os.color_hex) {
-              setVal('colorHex', os.color_hex);
-              setVal('colorPicker', os.color_hex.startsWith('#') ? os.color_hex : '#' + os.color_hex);
-            }
-            if (os.min_temp) setVal('min_temp', os.min_temp);
-            if (os.max_temp) setVal('max_temp', os.max_temp);
-            fillEnrichmentFromStatus(status);
-            if (status.spoolman && status.spoolman.spool_id > 0) {
-              showMatchBadge('Spool #' + status.spoolman.spool_id + ' matched');
-            } else {
-              showMatchBadge('no Spoolman match');
-            }
-            break;
-          } else if (status.present) {
-            showMatchBadge('wrong format \u2014 expected OpenSpool');
-            break;
-          }
-        } catch(e) {}
-        await new Promise(r => setTimeout(r, 500));
-      }
-      setReadWaiting(false);
-    }
-
-    readBtn.onclick = startRead;
-
-    function enrichmentHasData() {
-      var ids = ['enrich-remaining', 'enrich-bed-temp',
-                 'enrich-diameter', 'enrich-density'];
-      return ids.some(function(id) {
-        var el = document.getElementById(id);
-        return el && el.value && parseFloat(el.value) > 0;
-      });
-    }
-
-    async function saveEnrichment(uid) {
-      if (!enrichmentHasData()) return;
-
-      var manufacturer = document.getElementById('brand').value.trim();
-      var material = document.getElementById('type').value;
-      var colorHex = document.getElementById('colorHex').value || '';
-      var remainingG = parseFloat(document.getElementById('enrich-remaining').value) || 0;
-      var bedTemp = parseInt(document.getElementById('enrich-bed-temp').value) || 0;
-      var diameter = parseFloat(document.getElementById('enrich-diameter').value) || 1.75;
-      var density = parseFloat(document.getElementById('enrich-density').value) || 0;
-      var nozzleMin = parseInt(document.getElementById('min_temp').value) || 0;
-      var nozzleMax = parseInt(document.getElementById('max_temp').value) || 0;
-      var nozzleTemp = (nozzleMin && nozzleMax) ? Math.round((nozzleMin + nozzleMax) / 2) : (nozzleMin || nozzleMax);
-
-      var vendorId = -1;
-      if (manufacturer) {
-        try {
-          var vr = await fetch('/api/spoolman/find-vendor?name=' + encodeURIComponent(manufacturer)).then(function(r) { return r.json(); });
-          if (vr.found) {
-            var confirmed = confirm('Found existing manufacturer "' + vr.name + '" in Spoolman. Use it?');
-            vendorId = confirmed ? vr.id : -2;
-          }
-        } catch(e) {}
-      }
-
-      var filamentId = -1;
-      if (vendorId > 0 && material) {
-        try {
-          var fr = await fetch('/api/spoolman/find-filament?vendor_id=' + vendorId
-                           + '&material=' + encodeURIComponent(material)
-                           + (colorHex ? '&color_hex=' + encodeURIComponent(colorHex.replace('#','')) : '')).then(function(r) { return r.json(); });
-          if (fr.found) {
-            var fconfirmed = confirm('Found existing filament "' + fr.name + '" in Spoolman. Use it?');
-            filamentId = fconfirmed ? fr.id : -2;
-          }
-        } catch(e) {}
-      }
-
-      try {
-        var resp = await fetch('/api/spoolman/save-enrichment', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({
-            uid: uid,
-            manufacturer: manufacturer,
-            material: material,
-            color_hex: colorHex.replace('#', ''),
-            remaining_g: remainingG,
-            bed_temp: bedTemp,
-            nozzle_temp: nozzleTemp,
-            diameter_mm: diameter,
-            density: density,
-            vendor_id: vendorId,
-            filament_id: filamentId
-          })
-        });
-        var result = await resp.json();
-        if (!resp.ok || result.success === false) {
-          throw new Error(result.error || 'save failed');
+    setupReadButton({
+      expectedKind: 'OpenSpoolTag',
+      wrongKindMsg: 'wrong format \u2014 expected OpenSpool',
+      showMatchBadge: showMatchBadge,
+      fillForm: function(status) {
+        var os = status.openspool || {};
+        setVal('brand', os.brand || '');
+        setVal('type', os.material || '');
+        if (os.color_hex) {
+          setVal('colorHex', os.color_hex);
+          setVal('colorPicker', os.color_hex.startsWith('#') ? os.color_hex : '#' + os.color_hex);
         }
-        setBanner('statusBanner', 'Tag written \u2713 Spoolman enrichment saved \u2713');
-      } catch(e) {
-        setBanner('statusBanner', 'Tag written \u2713 Spoolman save failed \u2014 check connection');
+        if (os.min_temp) setVal('min_temp', os.min_temp);
+        if (os.max_temp) setVal('max_temp', os.max_temp);
+      },
+      fillEnrichment: function(status) {
+        var sp = status.spoolman || {};
+        if (sp.remaining_g !== undefined) setVal('enrich-remaining', sp.remaining_g.toFixed(1));
+        if (sp.bed_temp && sp.bed_temp > 0) setVal('enrich-bed-temp', sp.bed_temp);
+        if (sp.diameter_mm && sp.diameter_mm > 0) setVal('enrich-diameter', sp.diameter_mm);
+        if (sp.density && sp.density > 0) setVal('enrich-density', sp.density);
       }
-    }
-
-    function showStatusView() {
-      createView.classList.add('hidden');
-      statusView.classList.remove('hidden');
-      backBtn.classList.add('hidden');
-      anotherBtn.classList.add('hidden');
-    }
-
-    function showCreateView() {
-      statusView.classList.add('hidden');
-      createView.classList.remove('hidden');
-    }
-
-    backBtn.addEventListener('click', showCreateView);
-    anotherBtn.addEventListener('click', function() {
-      showCreateView();
-      writerForm.reset();
-      document.getElementById('colorPicker').value = '#FF0000';
-      document.getElementById('colorHex').value = '#FF0000';
     });
 
     function buildPayload(uid) {
@@ -414,92 +264,49 @@ const char OPENSPOOL_WRITER_HTML[] PROGMEM = R"rawliteral(
       };
     }
 
-    async function waitForTag(timeoutMs) {
-      var deadline = Date.now() + timeoutMs;
-      setStepState('step-wait', 'active');
-      setBanner('statusBanner', 'Waiting for tag\u2026');
-      setResult('resultBox', 'Place and hold an NTAG tag on the scanner.', '');
+    var ENRICHMENT_FIELDS = ['enrich-remaining', 'enrich-bed-temp', 'enrich-diameter', 'enrich-density'];
 
-      while (Date.now() < deadline) {
-        var status = await api('/api/status');
-        if (status.present) {
-          setStepState('step-wait', 'done');
-          return status;
-        }
-        await sleep(500);
-      }
-
-      setStepState('step-wait', 'error');
-      throw new Error('No tag detected. Place the tag on the scanner and try again.');
+    function showCreateView() {
+      document.getElementById('statusView').classList.add('hidden');
+      document.getElementById('createView').classList.remove('hidden');
     }
 
-    async function writeFlow() {
-      resetAllSteps(STEP_IDS);
-      showStatusView();
-
-      try {
-        var presentStatus = await waitForTag(8000);
-
-        setStepState('step-detect', 'active');
-        setBanner('statusBanner', 'Tag detected.');
-        setResult('resultBox', 'UID: ' + (presentStatus.uid || 'Unknown'), '');
-        await sleep(250);
-        setStepState('step-detect', 'done');
-
-        var payload = buildPayload(presentStatus.uid);
-
-        setStepState('step-write', 'active');
-        setBanner('statusBanner', 'Writing OpenSpool data\u2026');
-        setResult('resultBox', 'Sending OpenSpool JSON to scanner.', '');
-        await api('/api/write-openspool', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        });
-        setStepState('step-write', 'done');
-
-        setStepState('step-verify', 'active');
-        setBanner('statusBanner', 'Verifying write\u2026');
-        setResult('resultBox', 'Reading tag back to confirm data matches.', '');
-
-        var verifyDeadline = Date.now() + 15000;
-        while (Date.now() < verifyDeadline) {
-          await sleep(500);
-          var status = await api('/api/status');
-          if (status.present && status.tag_kind === 'OpenSpoolTag') {
-            setBanner('statusBanner', 'Tag verified \u2014 hold for a moment\u2026');
-            await sleep(2000);
-            setStepState('step-verify', 'done');
-            setBanner('statusBanner', 'Write complete \u2014 safe to remove tag.');
-            setResult('resultBox', 'OpenSpool tag written and verified successfully.', 'success');
-            await saveEnrichment(presentStatus.uid);
-            backBtn.classList.remove('hidden');
-            anotherBtn.classList.remove('hidden');
-            return;
-          }
-        }
-
-        setStepState('step-verify', 'error');
-        throw new Error('Verification timed out. Keep the tag on the scanner and try again.');
-      } catch (err) {
-        var msg = err && err.message ? err.message : 'Write failed';
-        setBanner('statusBanner', 'Write failed.');
-        setResult('resultBox', msg, 'error');
-
-        STEP_IDS.forEach(function(id) {
-          var el = document.getElementById(id);
-          if (el && el.classList.contains('active')) {
-            setStepState(id, 'error');
-          }
-        });
-
-        backBtn.classList.remove('hidden');
-      }
-    }
+    document.getElementById('backBtn').addEventListener('click', showCreateView);
+    document.getElementById('anotherBtn').addEventListener('click', function() {
+      showCreateView();
+      writerForm.reset();
+      document.getElementById('colorPicker').value = '#FF0000';
+      document.getElementById('colorHex').value = '#FF0000';
+    });
 
     writerForm.addEventListener('submit', function(e) {
       e.preventDefault();
-      writeFlow();
+      sharedWriteFlow({
+        stepIds: ['step-wait', 'step-detect', 'step-write', 'step-verify'],
+        endpoint: '/api/write-openspool',
+        formatName: 'OpenSpool',
+        buildPayload: buildPayload,
+        verify: function(status) { return status.tag_kind === 'OpenSpoolTag'; },
+        afterSuccess: function(uid) {
+          return saveEnrichmentToSpoolman(uid, {
+            enrichmentFieldIds: ENRICHMENT_FIELDS,
+            getFields: function() {
+              var nozzleMin = parseInt(document.getElementById('min_temp').value) || 0;
+              var nozzleMax = parseInt(document.getElementById('max_temp').value) || 0;
+              return {
+                manufacturer: document.getElementById('brand').value.trim(),
+                material: document.getElementById('type').value,
+                colorHex: document.getElementById('colorHex').value || '',
+                remainingG: parseFloat(document.getElementById('enrich-remaining').value) || 0,
+                bedTemp: parseInt(document.getElementById('enrich-bed-temp').value) || 0,
+                diameterMm: parseFloat(document.getElementById('enrich-diameter').value) || 1.75,
+                density: parseFloat(document.getElementById('enrich-density').value) || 0,
+                nozzleTemp: (nozzleMin && nozzleMax) ? Math.round((nozzleMin + nozzleMax) / 2) : (nozzleMin || nozzleMax)
+              };
+            }
+          });
+        }
+      });
     });
   </script>
 </body>

--- a/src/OpenSpoolWriterHTML.h
+++ b/src/OpenSpoolWriterHTML.h
@@ -286,7 +286,12 @@ const char OPENSPOOL_WRITER_HTML[] PROGMEM = R"rawliteral(
         endpoint: '/api/write-openspool',
         formatName: 'OpenSpool',
         buildPayload: buildPayload,
-        verify: function(status) { return status.tag_kind === 'OpenSpoolTag'; },
+        verify: function(status, payload) {
+          if (status.tag_kind !== 'OpenSpoolTag' || !status.openspool) return false;
+          var os = status.openspool;
+          return os.brand === payload.brand && os.material === payload.type &&
+                 (os.color_hex || '').replace('#','').toUpperCase() === (payload.color_hex || '').toUpperCase();
+        },
         afterSuccess: function(uid) {
           return saveEnrichmentToSpoolman(uid, {
             enrichmentFieldIds: ENRICHMENT_FIELDS,

--- a/src/OpenTag3DWriterHTML.h
+++ b/src/OpenTag3DWriterHTML.h
@@ -324,13 +324,7 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
 
   <script src="/js/shared.js"></script>
   <script>
-    var createView = document.getElementById('createView');
-    var statusView = document.getElementById('statusView');
     var writerForm = document.getElementById('writerForm');
-    var backBtn = document.getElementById('backBtn');
-    var anotherBtn = document.getElementById('anotherBtn');
-
-    var STEP_IDS = ['step-wait', 'step-detect', 'step-write', 'step-verify'];
 
     syncColorPicker('colorPicker', 'colorHex');
     setupAdvancedToggle('advancedToggle', 'advancedBox');
@@ -427,18 +421,6 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
       'dry_time_hours', 'target_volumetric_speed', 'transmission_distance'
     ];
 
-    function showStatusView() {
-      createView.classList.add('hidden');
-      statusView.classList.remove('hidden');
-      backBtn.classList.add('hidden');
-      anotherBtn.classList.add('hidden');
-    }
-
-    function showCreateView() {
-      statusView.classList.add('hidden');
-      createView.classList.remove('hidden');
-    }
-
     function intVal(id, fallback) {
       var raw = document.getElementById(id).value.trim();
       if (raw === '') return fallback;
@@ -514,97 +496,48 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
       return body;
     }
 
-    async function waitForTag(timeoutMs) {
-      var deadline = Date.now() + timeoutMs;
-      setStepState('step-wait', 'active');
-      setBanner('statusBanner', 'Waiting for tag\u2026');
-      setResult('resultBox', 'Place and hold an NTAG215 tag on the scanner.', '');
+    var ENRICHMENT_FIELDS = ['enrich-remaining'];
 
-      while (Date.now() < deadline) {
-        var status = await api('/api/status');
-        if (status.present) {
-          setStepState('step-wait', 'done');
-          return status;
-        }
-        await sleep(500);
-      }
-
-      setStepState('step-wait', 'error');
-      throw new Error('No tag detected. Place the tag on the scanner and try again.');
+    function showCreateView() {
+      document.getElementById('statusView').classList.add('hidden');
+      document.getElementById('createView').classList.remove('hidden');
     }
 
-    async function writeFlow() {
-      resetAllSteps(STEP_IDS);
-      showStatusView();
-
-      try {
-        var presentStatus = await waitForTag(8000);
-
-        setStepState('step-detect', 'active');
-        setBanner('statusBanner', 'Tag detected.');
-        setResult('resultBox', 'UID: ' + (presentStatus.uid || 'Unknown'), '');
-        await sleep(250);
-        setStepState('step-detect', 'done');
-
-        var payload = buildPayload(presentStatus.uid);
-
-        setStepState('step-write', 'active');
-        setBanner('statusBanner', 'Writing OpenTag3D data\u2026');
-        setResult('resultBox', 'Sending OpenTag3D NDEF payload to scanner.', '');
-        await api('/api/write-opentag3d', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        });
-        setStepState('step-write', 'done');
-
-        setStepState('step-verify', 'active');
-        setBanner('statusBanner', 'Verifying write\u2026');
-        setResult('resultBox', 'Reading tag back to confirm data matches.', '');
-
-        var verifyDeadline = Date.now() + 15000;
-        while (Date.now() < verifyDeadline) {
-          await sleep(500);
-          var status = await api('/api/status');
-          if (status.present && status.tag_kind === 'OpenTag3D') {
-            // Wait for the full read cycle to complete before declaring success
-            setBanner('statusBanner', 'Tag verified \u2014 hold for a moment\u2026');
-            await sleep(2000);
-            setStepState('step-verify', 'done');
-            setBanner('statusBanner', 'Write complete \u2014 safe to remove tag.');
-            setResult('resultBox', 'OpenTag3D data written and verified successfully.', 'success');
-            await saveEnrichment(presentStatus.uid);
-            backBtn.classList.remove('hidden');
-            anotherBtn.classList.remove('hidden');
-            return;
-          }
-        }
-
-        setStepState('step-verify', 'error');
-        throw new Error('Verification timed out. Keep the tag on the scanner and try again.');
-      } catch (err) {
-        var msg = err && err.message ? err.message : 'Write failed';
-        setBanner('statusBanner', 'Write failed.');
-        setResult('resultBox', msg, 'error');
-
-        STEP_IDS.forEach(function(id) {
-          var el = document.getElementById(id);
-          if (el && el.classList.contains('active')) {
-            setStepState(id, 'error');
-          }
-        });
-
-        backBtn.classList.remove('hidden');
-      }
-    }
+    document.getElementById('backBtn').addEventListener('click', showCreateView);
+    document.getElementById('anotherBtn').addEventListener('click', showCreateView);
 
     writerForm.addEventListener('submit', function(e) {
       e.preventDefault();
-      writeFlow();
+      sharedWriteFlow({
+        stepIds: ['step-wait', 'step-detect', 'step-write', 'step-verify'],
+        endpoint: '/api/write-opentag3d',
+        formatName: 'OpenTag3D',
+        buildPayload: buildPayload,
+        verify: function(status) { return status.tag_kind === 'OpenTag3D'; },
+        afterSuccess: function(uid) {
+          return saveEnrichmentToSpoolman(uid, {
+            enrichmentFieldIds: ENRICHMENT_FIELDS,
+            getFields: function() {
+              var nozzleMin = parseInt(document.getElementById('min_print_temp_c').value) || 0;
+              var nozzleMax = parseInt(document.getElementById('max_print_temp_c').value) || 0;
+              var bedMin = parseInt(document.getElementById('min_bed_temp_c').value) || 0;
+              var bedMax = parseInt(document.getElementById('max_bed_temp_c').value) || 0;
+              var diameter = parseInt(document.getElementById('diameter_um').value) || 1750;
+              return {
+                manufacturer: document.getElementById('manufacturer').value.trim(),
+                material: document.getElementById('base_material').value.trim(),
+                colorHex: document.getElementById('colorHex').value || '',
+                remainingG: parseFloat(document.getElementById('enrich-remaining').value) || 0,
+                density: parseFloat(document.getElementById('density').value) || 0,
+                nozzleTemp: (nozzleMin && nozzleMax) ? Math.round((nozzleMin + nozzleMax) / 2) : (nozzleMin || nozzleMax || parseInt(document.getElementById('print_temp_c').value) || 0),
+                bedTemp: (bedMin && bedMax) ? Math.round((bedMin + bedMax) / 2) : (bedMin || bedMax || parseInt(document.getElementById('bed_temp_c').value) || 0),
+                diameterMm: diameter / 1000.0
+              };
+            }
+          });
+        }
+      });
     });
-
-    backBtn.addEventListener('click', showCreateView);
-    anotherBtn.addEventListener('click', showCreateView);
 
     renderSpoolmanPicker('spoolmanPicker', {
       material: 'base_material',
@@ -623,7 +556,6 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
       bed_max: 'max_bed_temp_c'
     });
 
-    // Show enrichment section once spool picker loads (confirms Spoolman is configured)
     var _enrichCheck = setInterval(function() {
       if (document.querySelector('#spoolmanPickerSearch')) {
         document.getElementById('spoolmanEnrichment').classList.remove('hidden');
@@ -632,173 +564,48 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
     }, 500);
     setTimeout(function() { clearInterval(_enrichCheck); }, 15000);
 
-    var readBtn = document.getElementById('readBtn');
-    var writeBtn = document.getElementById('writeBtn');
-    var readWaiting = false;
-
-    function setReadWaiting(active) {
-      readWaiting = active;
-      writeBtn.disabled = active;
-      if (active) {
-        readBtn.textContent = 'Cancel';
-        readBtn.onclick = cancelRead;
-        document.getElementById('readPrompt').classList.remove('hidden');
-      } else {
-        readBtn.textContent = 'Read';
-        readBtn.onclick = startRead;
-        document.getElementById('readPrompt').classList.add('hidden');
-      }
-    }
-
-    function cancelRead() {
-      readWaiting = false;
-      setReadWaiting(false);
-    }
-
     function showMatchBadge(text) {
       var badge = document.getElementById('spoolmanMatchBadge');
       badge.textContent = text;
       badge.classList.remove('hidden');
     }
 
-    function setVal(id, val) {
-      var el = document.getElementById(id);
-      if (el && val !== undefined && val !== null) el.value = val;
-    }
-
-    function fillEnrichmentFromStatus(status) {
-      var sp = status.spoolman || {};
-      if (sp.remaining_g !== undefined) setVal('enrich-remaining', sp.remaining_g.toFixed(1));
-    }
-
-    async function startRead() {
-      setReadWaiting(true);
-      var deadline = Date.now() + 30000;
-      while (readWaiting && Date.now() < deadline) {
-        try {
-          var status = await fetch('/api/status').then(r => r.json());
-          if (status.present && status.tag_kind === 'OpenTag3D') {
-            var ot = status.opentag3d || {};
-            setVal('base_material', ot.base_material || '');
-            setVal('manufacturer', ot.manufacturer || '');
-            if (ot.color_hex) {
-              var c = ot.color_hex.startsWith('#') ? ot.color_hex : '#' + ot.color_hex;
-              setVal('colorHex', c);
-              setVal('colorPicker', c);
-            }
-            if (ot.target_weight_g) setVal('target_weight_g', ot.target_weight_g);
-            if (ot.density) setVal('density', ot.density);
-            if (ot.print_temp) setVal('print_temp_c', ot.print_temp);
-            if (ot.bed_temp) setVal('bed_temp_c', ot.bed_temp);
-            if (ot.min_print_temp) setVal('min_print_temp_c', ot.min_print_temp);
-            if (ot.max_print_temp) setVal('max_print_temp_c', ot.max_print_temp);
-            if (ot.min_bed_temp) setVal('min_bed_temp_c', ot.min_bed_temp);
-            if (ot.max_bed_temp) setVal('max_bed_temp_c', ot.max_bed_temp);
-            if (ot.dry_temp) setVal('max_dry_temp_c', ot.dry_temp);
-            if (ot.dry_time_hours) setVal('dry_time_hours', ot.dry_time_hours);
-            if (ot.diameter_mm) {
-              var dEl = document.getElementById('diameter_um');
-              if (dEl) dEl.value = Math.round(ot.diameter_mm * 1000);
-            }
-            if (ot.color_name) setVal('color_name', ot.color_name);
-            // Trigger material auto-fill
-            var matEl = document.getElementById('base_material');
-            if (matEl) matEl.dispatchEvent(new Event('input'));
-            fillEnrichmentFromStatus(status);
-            if (status.spoolman && status.spoolman.spool_id > 0) {
-              showMatchBadge('Spool #' + status.spoolman.spool_id + ' matched');
-            } else {
-              showMatchBadge('no Spoolman match');
-            }
-            break;
-          } else if (status.present) {
-            showMatchBadge('wrong format \u2014 expected OpenTag3D');
-            break;
-          }
-        } catch(e) {}
-        await new Promise(r => setTimeout(r, 500));
-      }
-      setReadWaiting(false);
-    }
-
-    readBtn.onclick = startRead;
-
-    function enrichmentHasData() {
-      var ids = ['enrich-remaining'];
-      return ids.some(function(id) {
-        var el = document.getElementById(id);
-        return el && el.value && parseFloat(el.value) > 0;
-      });
-    }
-
-    async function saveEnrichment(uid) {
-      if (!enrichmentHasData()) return;
-
-      var manufacturer = document.getElementById('manufacturer').value.trim();
-      var material = document.getElementById('base_material').value.trim();
-      var colorHex = document.getElementById('colorHex').value || '';
-      var remainingG = parseFloat(document.getElementById('enrich-remaining').value) || 0;
-      var density = parseFloat(document.getElementById('density').value) || 0;
-      var diameter = parseInt(document.getElementById('diameter_um').value) || 1750;
-      var diameterMm = diameter / 1000.0;
-      var nozzleMin = parseInt(document.getElementById('min_print_temp_c').value) || 0;
-      var nozzleMax = parseInt(document.getElementById('max_print_temp_c').value) || 0;
-      var nozzleTemp = (nozzleMin && nozzleMax) ? Math.round((nozzleMin + nozzleMax) / 2) : (nozzleMin || nozzleMax || parseInt(document.getElementById('print_temp_c').value) || 0);
-      var bedMin = parseInt(document.getElementById('min_bed_temp_c').value) || 0;
-      var bedMax = parseInt(document.getElementById('max_bed_temp_c').value) || 0;
-      var bedTemp = (bedMin && bedMax) ? Math.round((bedMin + bedMax) / 2) : (bedMin || bedMax || parseInt(document.getElementById('bed_temp_c').value) || 0);
-
-      var vendorId = -1;
-      if (manufacturer) {
-        try {
-          var vr = await fetch('/api/spoolman/find-vendor?name=' + encodeURIComponent(manufacturer)).then(function(r) { return r.json(); });
-          if (vr.found) {
-            var confirmed = confirm('Found existing manufacturer "' + vr.name + '" in Spoolman. Use it?');
-            vendorId = confirmed ? vr.id : -2;
-          }
-        } catch(e) {}
-      }
-
-      var filamentId = -1;
-      if (vendorId > 0 && material) {
-        try {
-          var fr = await fetch('/api/spoolman/find-filament?vendor_id=' + vendorId
-                           + '&material=' + encodeURIComponent(material)
-                           + (colorHex ? '&color_hex=' + encodeURIComponent(colorHex.replace('#','')) : '')).then(function(r) { return r.json(); });
-          if (fr.found) {
-            var fconfirmed = confirm('Found existing filament "' + fr.name + '" in Spoolman. Use it?');
-            filamentId = fconfirmed ? fr.id : -2;
-          }
-        } catch(e) {}
-      }
-
-      try {
-        var resp = await fetch('/api/spoolman/save-enrichment', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({
-            uid: uid,
-            manufacturer: manufacturer,
-            material: material,
-            color_hex: colorHex.replace('#', ''),
-            remaining_g: remainingG,
-            bed_temp: bedTemp,
-            nozzle_temp: nozzleTemp,
-            diameter_mm: diameterMm,
-            density: density,
-            vendor_id: vendorId,
-            filament_id: filamentId
-          })
-        });
-        var result = await resp.json();
-        if (!resp.ok || result.success === false) {
-          throw new Error(result.error || 'save failed');
+    setupReadButton({
+      expectedKind: 'OpenTag3D',
+      wrongKindMsg: 'wrong format \u2014 expected OpenTag3D',
+      showMatchBadge: showMatchBadge,
+      fillForm: function(status) {
+        var ot = status.opentag3d || {};
+        setVal('base_material', ot.base_material || '');
+        setVal('manufacturer', ot.manufacturer || '');
+        if (ot.color_hex) {
+          var c = ot.color_hex.startsWith('#') ? ot.color_hex : '#' + ot.color_hex;
+          setVal('colorHex', c);
+          setVal('colorPicker', c);
         }
-        setBanner('statusBanner', 'Tag written \u2713 Spoolman enrichment saved \u2713');
-      } catch(e) {
-        setBanner('statusBanner', 'Tag written \u2713 Spoolman save failed \u2014 check connection');
+        if (ot.target_weight_g) setVal('target_weight_g', ot.target_weight_g);
+        if (ot.density) setVal('density', ot.density);
+        if (ot.print_temp) setVal('print_temp_c', ot.print_temp);
+        if (ot.bed_temp) setVal('bed_temp_c', ot.bed_temp);
+        if (ot.min_print_temp) setVal('min_print_temp_c', ot.min_print_temp);
+        if (ot.max_print_temp) setVal('max_print_temp_c', ot.max_print_temp);
+        if (ot.min_bed_temp) setVal('min_bed_temp_c', ot.min_bed_temp);
+        if (ot.max_bed_temp) setVal('max_bed_temp_c', ot.max_bed_temp);
+        if (ot.dry_temp) setVal('max_dry_temp_c', ot.dry_temp);
+        if (ot.dry_time_hours) setVal('dry_time_hours', ot.dry_time_hours);
+        if (ot.diameter_mm) {
+          var dEl = document.getElementById('diameter_um');
+          if (dEl) dEl.value = Math.round(ot.diameter_mm * 1000);
+        }
+        if (ot.color_name) setVal('color_name', ot.color_name);
+        var matEl = document.getElementById('base_material');
+        if (matEl) matEl.dispatchEvent(new Event('input'));
+      },
+      fillEnrichment: function(status) {
+        var sp = status.spoolman || {};
+        if (sp.remaining_g !== undefined) setVal('enrich-remaining', sp.remaining_g.toFixed(1));
       }
-    }
+    });
 
   </script>
 </body>

--- a/src/OpenTag3DWriterHTML.h
+++ b/src/OpenTag3DWriterHTML.h
@@ -513,7 +513,13 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
         endpoint: '/api/write-opentag3d',
         formatName: 'OpenTag3D',
         buildPayload: buildPayload,
-        verify: function(status) { return status.tag_kind === 'OpenTag3D'; },
+        verify: function(status, payload) {
+          if (status.tag_kind !== 'OpenTag3D' || !status.opentag3d) return false;
+          var ot = status.opentag3d;
+          return ot.base_material === payload.base_material &&
+                 ot.manufacturer === payload.manufacturer &&
+                 ot.target_weight_g === payload.target_weight_g;
+        },
         afterSuccess: function(uid) {
           return saveEnrichmentToSpoolman(uid, {
             enrichmentFieldIds: ENRICHMENT_FIELDS,

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -528,7 +528,7 @@ async function waitForTag(timeoutMs) {
   var deadline = Date.now() + timeoutMs;
   setStepState('step-wait', 'active');
   setBanner('statusBanner', 'Waiting for tag\u2026');
-  setResult('resultBox', 'Place and hold an NTAG tag on the scanner.', '');
+  setResult('resultBox', 'Place and hold a tag on the scanner.', '');
 
   while (Date.now() < deadline) {
     var status = await api('/api/status');

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -603,6 +603,7 @@ async function sharedWriteFlow(config) {
         setStepState('step-verify', 'done');
         setBanner('statusBanner', 'Write complete \u2014 safe to remove tag.');
         setResult('resultBox', config.formatName + ' tag written and verified successfully.', 'success');
+        await sleep(500);
         if (config.afterSuccess) await config.afterSuccess(presentStatus.uid);
         backBtn.classList.remove('hidden');
         anotherBtn.classList.remove('hidden');

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -521,4 +521,237 @@ function fillFromSpoolman(spool, fieldMap) {
   var results = document.getElementById('spoolmanPickerResults');
   if (results) results.innerHTML = '<div style="padding:12px;color:var(--accent);text-align:center;font-weight:600">Loaded spool #' + spool.id + '</div>';
 }
+
+/* ---- Shared write flow ---- */
+
+async function waitForTag(timeoutMs) {
+  var deadline = Date.now() + timeoutMs;
+  setStepState('step-wait', 'active');
+  setBanner('statusBanner', 'Waiting for tag\u2026');
+  setResult('resultBox', 'Place and hold an NTAG tag on the scanner.', '');
+
+  while (Date.now() < deadline) {
+    var status = await api('/api/status');
+    if (status.present) {
+      setStepState('step-wait', 'done');
+      return status;
+    }
+    await sleep(500);
+  }
+
+  setStepState('step-wait', 'error');
+  throw new Error('No tag detected. Place the tag on the scanner and try again.');
+}
+
+async function sharedWriteFlow(config) {
+  var stepIds = config.stepIds;
+  var createView = document.getElementById('createView');
+  var statusView = document.getElementById('statusView');
+  var backBtn = document.getElementById('backBtn');
+  var anotherBtn = document.getElementById('anotherBtn');
+
+  resetAllSteps(stepIds);
+  createView.classList.add('hidden');
+  statusView.classList.remove('hidden');
+  backBtn.classList.add('hidden');
+  anotherBtn.classList.add('hidden');
+
+  try {
+    var presentStatus = await waitForTag(8000);
+
+    setStepState('step-detect', 'active');
+    setBanner('statusBanner', 'Tag detected.');
+    setResult('resultBox', 'UID: ' + (presentStatus.uid || 'Unknown'), '');
+    await sleep(250);
+    setStepState('step-detect', 'done');
+
+    if (config.formatCheck && config.formatCheck(presentStatus)) {
+      setStepState('step-format', 'active');
+      setBanner('statusBanner', 'Formatting tag\u2026');
+      setResult('resultBox', 'Preparing blank tag for data.', '');
+      await api(config.formatEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uid: presentStatus.uid })
+      });
+      setStepState('step-format', 'done');
+    }
+
+    var payload = config.buildPayload(presentStatus.uid);
+
+    setStepState('step-write', 'active');
+    setBanner('statusBanner', 'Writing ' + config.formatName + ' data\u2026');
+    setResult('resultBox', 'Sending ' + config.formatName + ' payload to scanner.', '');
+    await api(config.endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    setStepState('step-write', 'done');
+
+    setStepState('step-verify', 'active');
+    setBanner('statusBanner', 'Verifying write\u2026');
+    setResult('resultBox', 'Reading tag back to confirm data matches.', '');
+
+    var verifyDeadline = Date.now() + 15000;
+    while (Date.now() < verifyDeadline) {
+      await sleep(500);
+      var status = await api('/api/status');
+      if (status.present && config.verify(status, payload)) {
+        setBanner('statusBanner', 'Tag verified \u2014 hold for a moment\u2026');
+        await sleep(2000);
+        setStepState('step-verify', 'done');
+        setBanner('statusBanner', 'Write complete \u2014 safe to remove tag.');
+        setResult('resultBox', config.formatName + ' tag written and verified successfully.', 'success');
+        if (config.afterSuccess) await config.afterSuccess(presentStatus.uid);
+        backBtn.classList.remove('hidden');
+        anotherBtn.classList.remove('hidden');
+        return;
+      }
+    }
+
+    setStepState('step-verify', 'error');
+    throw new Error('Verification timed out. Keep the tag on the scanner and try again.');
+  } catch (err) {
+    var msg = err && err.message ? err.message : 'Write failed';
+    setBanner('statusBanner', 'Write failed.');
+    setResult('resultBox', msg, 'error');
+
+    stepIds.forEach(function(id) {
+      var el = document.getElementById(id);
+      if (el && el.classList.contains('active')) {
+        setStepState(id, 'error');
+      }
+    });
+
+    backBtn.classList.remove('hidden');
+  }
+}
+
+/* ---- Shared read button ---- */
+
+function setupReadButton(config) {
+  var readBtn = document.getElementById('readBtn');
+  var writeBtn = document.getElementById('writeBtn');
+  var readWaiting = false;
+
+  function setReadWaiting(active) {
+    readWaiting = active;
+    writeBtn.disabled = active;
+    if (active) {
+      readBtn.textContent = 'Cancel';
+      readBtn.onclick = cancelRead;
+      document.getElementById('readPrompt').classList.remove('hidden');
+    } else {
+      readBtn.textContent = 'Read';
+      readBtn.onclick = startRead;
+      document.getElementById('readPrompt').classList.add('hidden');
+    }
+  }
+
+  function cancelRead() {
+    readWaiting = false;
+    setReadWaiting(false);
+  }
+
+  async function startRead() {
+    setReadWaiting(true);
+    var deadline = Date.now() + 30000;
+    while (readWaiting && Date.now() < deadline) {
+      try {
+        var status = await fetch('/api/status').then(function(r) { return r.json(); });
+        if (status.present && status.tag_kind === config.expectedKind) {
+          config.fillForm(status);
+          if (config.fillEnrichment) config.fillEnrichment(status);
+          if (config.showMatchBadge) {
+            if (status.spoolman && status.spoolman.spool_id > 0) {
+              config.showMatchBadge('Spool #' + status.spoolman.spool_id + ' matched');
+            } else {
+              config.showMatchBadge('no Spoolman match');
+            }
+          }
+          break;
+        } else if (status.present) {
+          if (config.showMatchBadge) config.showMatchBadge(config.wrongKindMsg);
+          break;
+        }
+      } catch(e) {}
+      await new Promise(function(r) { setTimeout(r, 500); });
+    }
+    setReadWaiting(false);
+  }
+
+  readBtn.onclick = startRead;
+}
+
+/* ---- Shared enrichment helpers ---- */
+
+function enrichmentHasData(fieldIds) {
+  return fieldIds.some(function(id) {
+    var el = document.getElementById(id);
+    return el && el.value && parseFloat(el.value) > 0;
+  });
+}
+
+function setVal(id, val) {
+  var el = document.getElementById(id);
+  if (el && val !== undefined && val !== null) el.value = val;
+}
+
+async function saveEnrichmentToSpoolman(uid, config) {
+  if (!enrichmentHasData(config.enrichmentFieldIds)) return;
+
+  var fields = config.getFields();
+
+  var vendorId = -1;
+  if (fields.manufacturer) {
+    try {
+      var vr = await fetch('/api/spoolman/find-vendor?name=' + encodeURIComponent(fields.manufacturer)).then(function(r) { return r.json(); });
+      if (vr.found) {
+        var confirmed = confirm('Found existing manufacturer "' + vr.name + '" in Spoolman. Use it?');
+        vendorId = confirmed ? vr.id : -2;
+      }
+    } catch(e) {}
+  }
+
+  var filamentId = -1;
+  if (vendorId > 0 && fields.material) {
+    try {
+      var fr = await fetch('/api/spoolman/find-filament?vendor_id=' + vendorId
+                       + '&material=' + encodeURIComponent(fields.material)
+                       + (fields.colorHex ? '&color_hex=' + encodeURIComponent(fields.colorHex.replace('#','')) : '')).then(function(r) { return r.json(); });
+      if (fr.found) {
+        var fconfirmed = confirm('Found existing filament "' + fr.name + '" in Spoolman. Use it?');
+        filamentId = fconfirmed ? fr.id : -2;
+      }
+    } catch(e) {}
+  }
+
+  try {
+    var resp = await fetch('/api/spoolman/save-enrichment', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        uid: uid,
+        manufacturer: fields.manufacturer,
+        material: fields.material,
+        color_hex: (fields.colorHex || '').replace('#', ''),
+        remaining_g: fields.remainingG || 0,
+        bed_temp: fields.bedTemp || 0,
+        nozzle_temp: fields.nozzleTemp || 0,
+        diameter_mm: fields.diameterMm || 1.75,
+        density: fields.density || 0,
+        vendor_id: vendorId,
+        filament_id: filamentId
+      })
+    });
+    var result = await resp.json();
+    if (!resp.ok || result.success === false) {
+      throw new Error(result.error || 'save failed');
+    }
+    setBanner('statusBanner', 'Tag written \u2713 Spoolman enrichment saved \u2713');
+  } catch(e) {
+    setBanner('statusBanner', 'Tag written \u2713 Spoolman save failed \u2014 check connection');
+  }
+}
 )rawliteral";

--- a/src/TigerTagWriterHTML.h
+++ b/src/TigerTagWriterHTML.h
@@ -564,7 +564,9 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
         verify: function(status, payload) {
           if (status.tag_kind !== 'TigerTag' || !status.tigertag) return false;
           var tt = status.tigertag;
-          return tt.material_id === payload.material_id && tt.brand_id === payload.brand_id;
+          return tt.material_id === payload.material_id &&
+                 tt.brand_id === payload.brand_id &&
+                 tt.weight_g === payload.weight_g;
         },
         afterSuccess: function(uid) {
           return saveEnrichmentToSpoolman(uid, {

--- a/src/TigerTagWriterHTML.h
+++ b/src/TigerTagWriterHTML.h
@@ -333,13 +333,7 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
 
   <script src="/js/shared.js"></script>
   <script>
-    var createView = document.getElementById('createView');
-    var statusView = document.getElementById('statusView');
     var writerForm = document.getElementById('writerForm');
-    var backBtn = document.getElementById('backBtn');
-    var anotherBtn = document.getElementById('anotherBtn');
-
-    var STEP_IDS = ['step-wait', 'step-detect', 'step-write', 'step-verify'];
 
     syncColorPicker('colorPicker', 'colorHex');
     setupAdvancedToggle('advancedToggle', 'advancedBox');
@@ -514,18 +508,6 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
       } catch(e) { /* keep hardcoded fallback */ }
     })();
 
-    function showStatusView() {
-      createView.classList.add('hidden');
-      statusView.classList.remove('hidden');
-      backBtn.classList.add('hidden');
-      anotherBtn.classList.add('hidden');
-    }
-
-    function showCreateView() {
-      statusView.classList.add('hidden');
-      createView.classList.remove('hidden');
-    }
-
     function intVal(id, fallback) {
       var raw = document.getElementById(id).value.trim();
       if (raw === '') return fallback;
@@ -562,100 +544,51 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
       };
     }
 
-    async function waitForTag(timeoutMs) {
-      var deadline = Date.now() + timeoutMs;
-      setStepState('step-wait', 'active');
-      setBanner('statusBanner', 'Waiting for tag\u2026');
-      setResult('resultBox', 'Place and hold an NTAG tag on the scanner.', '');
+    var ENRICHMENT_FIELDS = ['enrich-remaining', 'enrich-density'];
 
-      while (Date.now() < deadline) {
-        var status = await api('/api/status');
-        if (status.present) {
-          setStepState('step-wait', 'done');
-          return status;
-        }
-        await sleep(500);
-      }
-
-      setStepState('step-wait', 'error');
-      throw new Error('No tag detected. Place the tag on the scanner and try again.');
+    function showCreateView() {
+      document.getElementById('statusView').classList.add('hidden');
+      document.getElementById('createView').classList.remove('hidden');
     }
 
-    async function writeFlow() {
-      resetAllSteps(STEP_IDS);
-      showStatusView();
-
-      try {
-        var presentStatus = await waitForTag(8000);
-
-        setStepState('step-detect', 'active');
-        setBanner('statusBanner', 'Tag detected.');
-        setResult('resultBox', 'UID: ' + (presentStatus.uid || 'Unknown'), '');
-        await sleep(250);
-        setStepState('step-detect', 'done');
-
-        var payload = buildPayload(presentStatus.uid);
-
-        setStepState('step-write', 'active');
-        setBanner('statusBanner', 'Writing TigerTag data\u2026');
-        setResult('resultBox', 'Sending TigerTag binary to scanner.', '');
-        await api('/api/write-tigertag', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        });
-        setStepState('step-write', 'done');
-
-        setStepState('step-verify', 'active');
-        setBanner('statusBanner', 'Verifying write\u2026');
-        setResult('resultBox', 'Reading tag back to confirm data matches.', '');
-
-        var verifyDeadline = Date.now() + 15000;
-        while (Date.now() < verifyDeadline) {
-          await sleep(500);
-          var status = await api('/api/status');
-          if (status.present && status.tag_kind === 'TigerTag' && status.tigertag) {
-            var tt = status.tigertag;
-            if (tt.material_id === payload.material_id && tt.brand_id === payload.brand_id) {
-              // Wait for the full read cycle to complete before declaring success
-              setBanner('statusBanner', 'Tag verified \u2014 hold for a moment\u2026');
-              await sleep(2000);
-              setStepState('step-verify', 'done');
-              setBanner('statusBanner', 'Write complete \u2014 safe to remove tag.');
-              setResult('resultBox', 'TigerTag data written and verified successfully.', 'success');
-              await saveEnrichment(presentStatus.uid);
-              backBtn.classList.remove('hidden');
-              anotherBtn.classList.remove('hidden');
-              return;
-            }
-          }
-        }
-
-        setStepState('step-verify', 'error');
-        throw new Error('Verification timed out. Keep the tag on the scanner and try again.');
-      } catch (err) {
-        var msg = err && err.message ? err.message : 'Write failed';
-        setBanner('statusBanner', 'Write failed.');
-        setResult('resultBox', msg, 'error');
-
-        STEP_IDS.forEach(function(id) {
-          var el = document.getElementById(id);
-          if (el && el.classList.contains('active')) {
-            setStepState(id, 'error');
-          }
-        });
-
-        backBtn.classList.remove('hidden');
-      }
-    }
+    document.getElementById('backBtn').addEventListener('click', showCreateView);
+    document.getElementById('anotherBtn').addEventListener('click', showCreateView);
 
     writerForm.addEventListener('submit', function(e) {
       e.preventDefault();
-      writeFlow();
+      sharedWriteFlow({
+        stepIds: ['step-wait', 'step-detect', 'step-write', 'step-verify'],
+        endpoint: '/api/write-tigertag',
+        formatName: 'TigerTag',
+        buildPayload: buildPayload,
+        verify: function(status, payload) {
+          if (status.tag_kind !== 'TigerTag' || !status.tigertag) return false;
+          var tt = status.tigertag;
+          return tt.material_id === payload.material_id && tt.brand_id === payload.brand_id;
+        },
+        afterSuccess: function(uid) {
+          return saveEnrichmentToSpoolman(uid, {
+            enrichmentFieldIds: ENRICHMENT_FIELDS,
+            getFields: function() {
+              var nozzleMin = parseInt(document.getElementById('nozzle_min').value) || 0;
+              var nozzleMax = parseInt(document.getElementById('nozzle_max').value) || 0;
+              var bedMin = parseInt(document.getElementById('bed_min').value) || 0;
+              var bedMax = parseInt(document.getElementById('bed_max').value) || 0;
+              return {
+                manufacturer: document.getElementById('brand_name').value.trim(),
+                material: document.getElementById('material_search').value.trim(),
+                colorHex: document.getElementById('colorHex').value || '',
+                remainingG: parseFloat(document.getElementById('enrich-remaining').value) || 0,
+                density: parseFloat(document.getElementById('enrich-density').value) || 0,
+                nozzleTemp: (nozzleMin && nozzleMax) ? Math.round((nozzleMin + nozzleMax) / 2) : (nozzleMin || nozzleMax),
+                bedTemp: (bedMin && bedMax) ? Math.round((bedMin + bedMax) / 2) : (bedMin || bedMax),
+                diameterMm: (parseInt(document.getElementById('diameter_id').value) || 56) === 221 ? 2.85 : 1.75
+              };
+            }
+          });
+        }
+      });
     });
-
-    backBtn.addEventListener('click', showCreateView);
-    anotherBtn.addEventListener('click', showCreateView);
 
     renderSpoolmanPicker('spoolmanPicker', {
       material: 'material_search',
@@ -671,7 +604,6 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
       density: 'enrich-density'
     });
 
-    // Show enrichment section once spool picker loads (confirms Spoolman is configured)
     var _enrichCheck = setInterval(function() {
       if (document.querySelector('#spoolmanPickerSearch')) {
         document.getElementById('spoolmanEnrichment').classList.remove('hidden');
@@ -680,165 +612,42 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
     }, 500);
     setTimeout(function() { clearInterval(_enrichCheck); }, 15000);
 
-    var readBtn = document.getElementById('readBtn');
-    var writeBtn = document.getElementById('writeBtn');
-    var readWaiting = false;
-
-    function setReadWaiting(active) {
-      readWaiting = active;
-      writeBtn.disabled = active;
-      if (active) {
-        readBtn.textContent = 'Cancel';
-        readBtn.onclick = cancelRead;
-        document.getElementById('readPrompt').classList.remove('hidden');
-      } else {
-        readBtn.textContent = 'Read';
-        readBtn.onclick = startRead;
-        document.getElementById('readPrompt').classList.add('hidden');
-      }
-    }
-
-    function cancelRead() {
-      readWaiting = false;
-      setReadWaiting(false);
-    }
-
     function showMatchBadge(text) {
       var badge = document.getElementById('spoolmanMatchBadge');
       badge.textContent = text;
       badge.classList.remove('hidden');
     }
 
-    function setVal(id, val) {
-      var el = document.getElementById(id);
-      if (el && val !== undefined && val !== null) el.value = val;
-    }
-
-    function fillEnrichmentFromStatus(status) {
-      var sp = status.spoolman || {};
-      if (sp.remaining_g !== undefined) setVal('enrich-remaining', sp.remaining_g.toFixed(1));
-      if (sp.density && sp.density > 0) setVal('enrich-density', sp.density);
-    }
-
-    async function startRead() {
-      setReadWaiting(true);
-      var deadline = Date.now() + 30000;
-      while (readWaiting && Date.now() < deadline) {
-        try {
-          var status = await fetch('/api/status').then(r => r.json());
-          if (status.present && status.tag_kind === 'TigerTag') {
-            var tt = status.tigertag || {};
-            setVal('material_search', tt.material_name || '');
-            setVal('brand_name', tt.brand_name || '');
-            if (tt.color_hex) {
-              var c = tt.color_hex.startsWith('#') ? tt.color_hex : '#' + tt.color_hex;
-              setVal('colorHex', c);
-              setVal('colorPicker', c);
-            }
-            if (tt.weight_g) setVal('weight_g', tt.weight_g);
-            if (tt.nozzle_temp_min) setVal('nozzle_min', tt.nozzle_temp_min);
-            if (tt.nozzle_temp_max) setVal('nozzle_max', tt.nozzle_temp_max);
-            if (tt.bed_temp_min) setVal('bed_min', tt.bed_temp_min);
-            if (tt.bed_temp_max) setVal('bed_max', tt.bed_temp_max);
-            if (tt.dry_temp) setVal('dry_temp', tt.dry_temp);
-            if (tt.dry_time_hours) setVal('dry_time', tt.dry_time_hours);
-            if (tt.material_id !== undefined) document.getElementById('material_id').value = tt.material_id;
-            if (tt.brand_id !== undefined) document.getElementById('brand_id').value = tt.brand_id;
-            // Sync material ID from name if not set directly
-            syncMaterialId();
-            fillEnrichmentFromStatus(status);
-            if (status.spoolman && status.spoolman.spool_id > 0) {
-              showMatchBadge('Spool #' + status.spoolman.spool_id + ' matched');
-            } else {
-              showMatchBadge('no Spoolman match');
-            }
-            break;
-          } else if (status.present) {
-            showMatchBadge('wrong format \u2014 expected TigerTag');
-            break;
-          }
-        } catch(e) {}
-        await new Promise(r => setTimeout(r, 500));
-      }
-      setReadWaiting(false);
-    }
-
-    readBtn.onclick = startRead;
-
-    function enrichmentHasData() {
-      var ids = ['enrich-remaining', 'enrich-density'];
-      return ids.some(function(id) {
-        var el = document.getElementById(id);
-        return el && el.value && parseFloat(el.value) > 0;
-      });
-    }
-
-    async function saveEnrichment(uid) {
-      if (!enrichmentHasData()) return;
-
-      var manufacturer = document.getElementById('brand_name').value.trim();
-      var material = document.getElementById('material_search').value.trim();
-      var colorHex = document.getElementById('colorHex').value || '';
-      var remainingG = parseFloat(document.getElementById('enrich-remaining').value) || 0;
-      var density = parseFloat(document.getElementById('enrich-density').value) || 0;
-      var nozzleMin = parseInt(document.getElementById('nozzle_min').value) || 0;
-      var nozzleMax = parseInt(document.getElementById('nozzle_max').value) || 0;
-      var bedMin = parseInt(document.getElementById('bed_min').value) || 0;
-      var bedMax = parseInt(document.getElementById('bed_max').value) || 0;
-      var bedTemp = (bedMin && bedMax) ? Math.round((bedMin + bedMax) / 2) : (bedMin || bedMax);
-      var nozzleTemp = (nozzleMin && nozzleMax) ? Math.round((nozzleMin + nozzleMax) / 2) : (nozzleMin || nozzleMax);
-
-      var vendorId = -1;
-      if (manufacturer) {
-        try {
-          var vr = await fetch('/api/spoolman/find-vendor?name=' + encodeURIComponent(manufacturer)).then(function(r) { return r.json(); });
-          if (vr.found) {
-            var confirmed = confirm('Found existing manufacturer "' + vr.name + '" in Spoolman. Use it?');
-            vendorId = confirmed ? vr.id : -2;
-          }
-        } catch(e) {}
-      }
-
-      var filamentId = -1;
-      if (vendorId > 0 && material) {
-        try {
-          var fr = await fetch('/api/spoolman/find-filament?vendor_id=' + vendorId
-                           + '&material=' + encodeURIComponent(material)
-                           + (colorHex ? '&color_hex=' + encodeURIComponent(colorHex.replace('#','')) : '')).then(function(r) { return r.json(); });
-          if (fr.found) {
-            var fconfirmed = confirm('Found existing filament "' + fr.name + '" in Spoolman. Use it?');
-            filamentId = fconfirmed ? fr.id : -2;
-          }
-        } catch(e) {}
-      }
-
-      try {
-        var resp = await fetch('/api/spoolman/save-enrichment', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({
-            uid: uid,
-            manufacturer: manufacturer,
-            material: material,
-            color_hex: colorHex.replace('#', ''),
-            remaining_g: remainingG,
-            bed_temp: bedTemp,
-            nozzle_temp: nozzleTemp,
-            diameter_mm: (parseInt(document.getElementById('diameter_id').value) || 56) === 221 ? 2.85 : 1.75,
-            density: density,
-            vendor_id: vendorId,
-            filament_id: filamentId
-          })
-        });
-        var result = await resp.json();
-        if (!resp.ok || result.success === false) {
-          throw new Error(result.error || 'save failed');
+    setupReadButton({
+      expectedKind: 'TigerTag',
+      wrongKindMsg: 'wrong format \u2014 expected TigerTag',
+      showMatchBadge: showMatchBadge,
+      fillForm: function(status) {
+        var tt = status.tigertag || {};
+        setVal('material_search', tt.material_name || '');
+        setVal('brand_name', tt.brand_name || '');
+        if (tt.color_hex) {
+          var c = tt.color_hex.startsWith('#') ? tt.color_hex : '#' + tt.color_hex;
+          setVal('colorHex', c);
+          setVal('colorPicker', c);
         }
-        setBanner('statusBanner', 'Tag written \u2713 Spoolman enrichment saved \u2713');
-      } catch(e) {
-        setBanner('statusBanner', 'Tag written \u2713 Spoolman save failed \u2014 check connection');
+        if (tt.weight_g) setVal('weight_g', tt.weight_g);
+        if (tt.nozzle_temp_min) setVal('nozzle_min', tt.nozzle_temp_min);
+        if (tt.nozzle_temp_max) setVal('nozzle_max', tt.nozzle_temp_max);
+        if (tt.bed_temp_min) setVal('bed_min', tt.bed_temp_min);
+        if (tt.bed_temp_max) setVal('bed_max', tt.bed_temp_max);
+        if (tt.dry_temp) setVal('dry_temp', tt.dry_temp);
+        if (tt.dry_time_hours) setVal('dry_time', tt.dry_time_hours);
+        if (tt.material_id !== undefined) document.getElementById('material_id').value = tt.material_id;
+        if (tt.brand_id !== undefined) document.getElementById('brand_id').value = tt.brand_id;
+        syncMaterialId();
+      },
+      fillEnrichment: function(status) {
+        var sp = status.spoolman || {};
+        if (sp.remaining_g !== undefined) setVal('enrich-remaining', sp.remaining_g.toFixed(1));
+        if (sp.density && sp.density > 0) setVal('enrich-density', sp.density);
       }
-    }
+    });
 
   </script>
 </body>

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -1943,31 +1943,46 @@ void WebServerManager::handleApiSpoolmanSaveEnrichment() {
         return;
     }
 
-    // Step 3: Find or create spool by UID
-    // nfc_id is stored as a double-quoted JSON string value — match that in the query
+    // Step 3: Find existing spool by UID
+    // Spoolman's extra_field filter is unreliable — fetch all and match nfc_id client-side
     int spoolId = -1;
+    float existingInitialWeight = 0.0f;
     char quotedUid[130];
     snprintf(quotedUid, sizeof(quotedUid), "\"%s\"", uid);
-    String encodedUid = urlEncode(quotedUid);
-    snprintf(url, sizeof(url), "%s/api/v1/spool?extra_field=nfc_id:%s", baseUrl, encodedUid.c_str());
+    snprintf(url, sizeof(url), "%s/api/v1/spool?limit=200", baseUrl);
     http.begin(client, url);
     http.setTimeout(5000);
     code = http.GET();
     if (code == 200) {
         response = http.getString();
-        StaticJsonDocument<2048> sDoc;
+        DynamicJsonDocument sDoc(16384);
         if (!deserializeJson(sDoc, response)) {
             JsonArray arr = sDoc.as<JsonArray>();
-            if (arr.size() > 0) spoolId = arr[0]["id"] | -1;
+            for (size_t i = 0; i < arr.size(); i++) {
+                const char* nfcId = arr[i]["extra"]["nfc_id"] | "";
+                if (strcmp(nfcId, quotedUid) == 0) {
+                    bool archived = arr[i]["archived"] | false;
+                    if (archived) continue;
+                    spoolId = arr[i]["id"] | -1;
+                    existingInitialWeight = arr[i]["initial_weight"] | 0.0f;
+                    break;
+                }
+            }
         }
     }
     http.end();
 
     if (spoolId > 0) {
-        // Update existing spool
+        // Update existing spool — Spoolman uses used_weight, not remaining_weight
         StaticJsonDocument<256> patch;
         patch["filament_id"] = filamentId;
-        if (remainingG > 0) patch["remaining_weight"] = remainingG;
+        if (remainingG > 0) {
+            float initialW = existingInitialWeight > 0 ? existingInitialWeight : 1000.0f;
+            float usedW = initialW - remainingG;
+            if (usedW < 0) usedW = 0;
+            patch["initial_weight"] = initialW;
+            patch["used_weight"] = usedW;
+        }
         String pJson;
         serializeJson(patch, pJson);
         snprintf(url, sizeof(url), "%s/api/v1/spool/%d", baseUrl, spoolId);
@@ -1982,10 +1997,16 @@ void WebServerManager::handleApiSpoolmanSaveEnrichment() {
             return;
         }
     } else {
-        // Create new spool
+        // Create new spool — Spoolman uses used_weight, not remaining_weight
         StaticJsonDocument<512> sBody;
         sBody["filament_id"] = filamentId;
-        if (remainingG > 0) sBody["remaining_weight"] = remainingG;
+        if (remainingG > 0) {
+            float initialW = 1000.0f;
+            float usedW = initialW - remainingG;
+            if (usedW < 0) usedW = 0;
+            sBody["initial_weight"] = initialW;
+            sBody["used_weight"] = usedW;
+        }
         JsonObject extra = sBody.createNestedObject("extra");
         // Spoolman extra fields require JSON-encoded string values (double-quoted)
         extra["nfc_id"] = quotedUid;


### PR DESCRIPTION
## Summary
- Extracts duplicated write flow logic from all 4 writer pages into shared functions in SharedJS.h
- `sharedWriteFlow(config)` — configurable write/verify/enrich pipeline
- `setupReadButton(config)` — shared Read/Cancel toggle with tag polling
- `saveEnrichmentToSpoolman(uid, config)` — shared Spoolman enrichment save
- `waitForTag()`, `enrichmentHasData()`, `setVal()` — shared helpers
- Net reduction: **476 lines** (-920, +444), saves ~19KB flash

## Changes
- **SharedJS.h** — 5 new shared functions added
- **OpenSpoolWriterHTML.h** — replaced ~240 lines with config-based calls
- **TigerTagWriterHTML.h** — replaced ~286 lines with config-based calls
- **OpenTag3DWriterHTML.h** — replaced ~290 lines with config-based calls
- **OpenPrintTagWriterHTML.h** — replaced ~208 lines with config-based calls (including format step support)

## Test plan
- [ ] OpenSpool writer: write tag, verify, enrichment save
- [ ] TigerTag writer: write tag, verify with material/brand ID check, enrichment save
- [ ] OpenTag3D writer: write tag, verify, enrichment save
- [ ] OpenPrintTag writer: format blank tag + write, verify via valuesMatch
- [ ] Read button works on all 4 pages (polls, fills form, shows match badge)
- [ ] Spoolman picker still works on all pages
- [ ] Back/Another buttons return to form correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated tag read/write UI into a shared pipeline across writer pages, simplifying flows, view toggles, and enrichment save hooks for more consistent user interactions.
* **New Features**
  * Added LED support for an additional development board.
* **Bug Fixes**
  * Improved spool lookup and weight-update semantics when saving enrichment to reduce incorrect weight calculations and mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->