### PR TITLE
refactor: reduce cyclomatic complexity in NFCManager + WebServerManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/installer-plan.md
 docs/opentag3d_architecture.md
 docs/tigertag-architecture.md
 docs/deep-thoughts.md
+docs/REFACTORING_GUIDE.md
 CODE-CLEANUP.md
 docs/writer-ui-plan.md
 research/

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -187,6 +187,232 @@ void NFCManager::scanTaskFunc(void* param) {
     self->scanLoop();
 }
 
+// ── ISO14443A tag read + classification ─────────────────────
+// Reads pages 4-13, tries TigerTag → OpenTag3D → OpenSpool → GenericUID.
+// Updates currentSpool state and sends the appropriate message.
+
+void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength, const TagScanResult& scan) {
+    bool isTigerTag = false;
+    bool isOpenTag3D = false;
+    bool isOpenSpool = false;
+    TigerTagData tigerData;
+    OpenSpoolData openSpoolData;
+    opentag3d_t ot3dData;
+    memset(&tigerData, 0, sizeof(tigerData));
+    memset(&ot3dData, 0, sizeof(ot3dData));
+
+    uint8_t pageData[40] = {0};
+    uint16_t bytesRead = connection_->readISO14443Pages(4, 10, pageData, sizeof(pageData));
+
+    // Try TigerTag first (binary magic at offset 0)
+    if (bytesRead >= 14 && tigerTagCheckMagic(pageData, bytesRead)) {
+        if (bytesRead >= 38) {
+            tigerData = tigerTagParse(pageData, bytesRead);
+            isTigerTag = tigerData.valid;
+        } else {
+            Serial.printf("NFCManager: TigerTag magic matched but only got %d bytes (need 38)\n", bytesRead);
+        }
+    }
+
+    // Scan NDEF TLV for OpenTag3D or OpenSpool
+    if (!isTigerTag && bytesRead >= 4) {
+        uint16_t pos = 0;
+        while (pos < bytesRead) {
+            uint8_t tlvType = pageData[pos++];
+            if (tlvType == 0x00) continue;
+            if (tlvType == 0xFE) break;
+            if (pos >= bytesRead) break;
+
+            uint16_t tlvLen = pageData[pos++];
+            if (tlvLen == 0xFF) {
+                if (pos + 2 > bytesRead) break;
+                tlvLen = (uint16_t)(pageData[pos] << 8) | pageData[pos + 1];
+                pos += 2;
+            }
+
+            if (tlvType == 0x03) {
+                uint16_t ndefStart = pos;
+                if (ndefStart >= bytesRead) break;
+
+                uint8_t ndefFlags = pageData[ndefStart];
+                uint8_t tnf = ndefFlags & 0x07;
+                if (tnf == 0x02 && ndefStart + 1 < bytesRead) {
+                    uint8_t typeLen = pageData[ndefStart + 1];
+                    bool sr = (ndefFlags & 0x10) != 0;
+                    uint16_t headerSize = 2 + (sr ? 1 : 4);
+                    if (ndefStart + headerSize + typeLen <= bytesRead) {
+                        const char* mime = OT3D_MIME_TYPE;
+                        size_t mimeLen = strlen(mime);
+                        if (typeLen == mimeLen &&
+                            memcmp(pageData + ndefStart + headerSize, mime, mimeLen) == 0) {
+                            uint32_t payloadLen = 0;
+                            if (sr) {
+                                payloadLen = pageData[ndefStart + 2];
+                            } else {
+                                payloadLen = ((uint32_t)pageData[ndefStart + 2] << 24) |
+                                             ((uint32_t)pageData[ndefStart + 3] << 16) |
+                                             ((uint32_t)pageData[ndefStart + 4] << 8) |
+                                             pageData[ndefStart + 5];
+                            }
+
+                            uint16_t payloadOffset = ndefStart + headerSize + typeLen;
+                            uint16_t availableInFirstRead = (payloadOffset < bytesRead) ? bytesRead - payloadOffset : 0;
+
+                            uint8_t fullPayload[OT3D_EXTENDED_MIN];
+                            uint16_t payloadBytes = 0;
+
+                            if (availableInFirstRead >= payloadLen) {
+                                memcpy(fullPayload, pageData + payloadOffset, payloadLen);
+                                payloadBytes = (uint16_t)payloadLen;
+                            } else {
+                                uint8_t payloadStartPage = 4 + (payloadOffset / 4);
+                                uint16_t totalPagesNeeded = (uint16_t)((payloadLen + 3) / 4) + 1;
+                                if (totalPagesNeeded > 50) totalPagesNeeded = 50;
+
+                                uint8_t extendedData[200] = {0};
+                                uint16_t extendedRead = connection_->readISO14443Pages(
+                                    payloadStartPage, (uint8_t)totalPagesNeeded, extendedData, sizeof(extendedData));
+
+                                uint16_t offsetInPage = payloadOffset % 4;
+                                if (extendedRead > offsetInPage) {
+                                    payloadBytes = extendedRead - offsetInPage;
+                                    if (payloadBytes > payloadLen) payloadBytes = (uint16_t)payloadLen;
+                                    if (payloadBytes > sizeof(fullPayload)) payloadBytes = sizeof(fullPayload);
+                                    memcpy(fullPayload, extendedData + offsetInPage, payloadBytes);
+                                }
+                            }
+
+                            if (payloadBytes >= OT3D_CORE_SIZE) {
+                                opentag3d_result_t res = opentag3d_decode(fullPayload, payloadBytes, &ot3dData);
+                                if (res == OT3D_OK || res == OT3D_VERSION_WARNING) {
+                                    isOpenTag3D = true;
+                                    if (res == OT3D_VERSION_WARNING) {
+                                        Serial.printf("NFCManager: OpenTag3D tag version %u ahead of supported %u — parsing anyway\n",
+                                                      ot3dData.tag_version, OT3D_SUPPORTED_VERSION);
+                                    }
+                                } else if (res == OT3D_VERSION_ERROR) {
+                                    Serial.printf("NFCManager: OpenTag3D major version too new (%u) — cannot parse\n",
+                                                  ot3dData.tag_version);
+                                }
+                            }
+                        }
+
+                        // Check for OpenSpool (application/json + "protocol":"openspool")
+                        if (!isOpenTag3D) {
+                            const char* jsonMime = "application/json";
+                            size_t jsonMimeLen = strlen(jsonMime);
+                            if (typeLen == jsonMimeLen &&
+                                memcmp(pageData + ndefStart + headerSize, jsonMime, jsonMimeLen) == 0) {
+                                uint32_t osPayloadLen = 0;
+                                if (sr) {
+                                    osPayloadLen = pageData[ndefStart + 2];
+                                } else {
+                                    osPayloadLen = ((uint32_t)pageData[ndefStart + 2] << 24) |
+                                                   ((uint32_t)pageData[ndefStart + 3] << 16) |
+                                                   ((uint32_t)pageData[ndefStart + 4] << 8) |
+                                                   pageData[ndefStart + 5];
+                                }
+                                uint16_t osOffset = ndefStart + headerSize + typeLen;
+                                uint8_t osPayload[256] = {0};
+                                uint16_t osBytes = 0;
+
+                                if (osOffset + osPayloadLen <= bytesRead) {
+                                    osBytes = (uint16_t)osPayloadLen;
+                                    if (osBytes > sizeof(osPayload)) osBytes = sizeof(osPayload);
+                                    memcpy(osPayload, pageData + osOffset, osBytes);
+                                } else {
+                                    uint8_t osStartPage = 4 + (osOffset / 4);
+                                    uint16_t osPagesNeeded = (uint16_t)((osPayloadLen + 3) / 4) + 1;
+                                    if (osPagesNeeded > 50) osPagesNeeded = 50;
+                                    uint8_t osExtData[256] = {0};
+                                    uint16_t osExtRead = connection_->readISO14443Pages(
+                                        osStartPage, (uint8_t)osPagesNeeded, osExtData, sizeof(osExtData));
+                                    uint16_t osOffInPage = osOffset % 4;
+                                    if (osExtRead > osOffInPage) {
+                                        osBytes = osExtRead - osOffInPage;
+                                        if (osBytes > osPayloadLen) osBytes = (uint16_t)osPayloadLen;
+                                        if (osBytes > sizeof(osPayload)) osBytes = sizeof(osPayload);
+                                        memcpy(osPayload, osExtData + osOffInPage, osBytes);
+                                    }
+                                }
+
+                                if (osBytes > 0 && parseOpenSpool(osPayload, osBytes, openSpoolData)) {
+                                    isOpenSpool = true;
+                                }
+                            }
+                        }
+                    }
+                }
+                break;
+            } else {
+                pos += tlvLen;
+            }
+        }
+    }
+
+    // Update shared state under mutex
+    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+        memcpy(currentSpool.spool_id, scan.uid_hex, sizeof(scan.uid_hex));
+        memcpy(currentSpool.uid, uid, uidLength);
+        currentSpool.uid_length = uidLength;
+        currentSpool.present = true;
+        currentSpool.blank_tag_present = false;
+        memcpy(lastSeenUid, uid, uidLength);
+        lastSeenUidLength = uidLength;
+        lastSeenValid = true;
+        lastSeenMs = millis();
+
+        if (isTigerTag) {
+            currentSpool.kind = TagKind::TigerTag;
+            currentSpool.tag_data_valid = false;
+            lastTigerTag_ = tigerData;
+            lastTigerTagValid_ = true;
+            lastOpenTag3DValid_ = false;
+            Serial.printf("NFCManager: TigerTag detected — %s %s %s\n",
+                          tigerData.brand_name, tigerData.material_name, tigerData.aspect1_name);
+        } else if (isOpenTag3D) {
+            currentSpool.kind = TagKind::OpenTag3D;
+            currentSpool.tag_data_valid = false;
+            lastOpenTag3D_ = ot3dData;
+            lastOpenTag3DValid_ = true;
+            lastTigerTagValid_ = false;
+            lastOpenSpoolValid_ = false;
+            Serial.printf("NFCManager: OpenTag3D detected — %s %s %.2fmm %ug\n",
+                          ot3dData.manufacturer, ot3dData.base_material,
+                          opentag3d_diameter_mm(&ot3dData), ot3dData.target_weight_g);
+        } else if (isOpenSpool) {
+            currentSpool.kind = TagKind::OpenSpoolTag;
+            currentSpool.tag_data_valid = false;
+            lastOpenSpool_ = openSpoolData;
+            lastOpenSpoolValid_ = true;
+            lastTigerTagValid_ = false;
+            lastOpenTag3DValid_ = false;
+            Serial.printf("NFCManager: OpenSpool detected — %s %s #%s\n",
+                          openSpoolData.brand, openSpoolData.material, openSpoolData.color_hex);
+        } else {
+            currentSpool.kind = TagKind::GenericUidTag;
+            currentSpool.tag_data_valid = false;
+            lastTigerTagValid_ = false;
+            lastOpenTag3DValid_ = false;
+            lastOpenSpoolValid_ = false;
+        }
+        xSemaphoreGive(tagMutex);
+    } else {
+        Serial.println("NFCManager: Could not acquire tagMutex");
+    }
+
+    // Send format-specific message
+    if (isTigerTag) {
+        sendTigerTagMessage(tigerData);
+    } else if (isOpenTag3D) {
+        sendOpenTag3DMessage(ot3dData);
+    } else if (isOpenSpool) {
+        sendOpenSpoolMessage(currentSpool.spool_id, openSpoolData);
+    } else {
+        sendGenericTagMessage();
+    }
+}
+
 void NFCManager::scanLoop() {
     uint32_t scanCount = 0;
     uint32_t detectCount = 0;
@@ -320,227 +546,7 @@ void NFCManager::scanLoop() {
                     Serial.printf("NFCManager: Bambu Lab tag — UID=%s (encrypted, no data access)\n", scan.uid_hex);
                     sendGenericTagMessage();
                 } else if (scan.kind == TagKind::GenericUidTag) {
-                    // ISO14443A tag — try TigerTag, then OpenTag3D, then OpenSpool, fall back to UID-only
-                    bool isTigerTag = false;
-                    bool isOpenTag3D = false;
-                    bool isOpenSpool = false;
-                    TigerTagData tigerData;
-                    OpenSpoolData openSpoolData;
-                    opentag3d_t ot3dData;
-                    memset(&tigerData, 0, sizeof(tigerData));
-                    memset(&ot3dData, 0, sizeof(ot3dData));
-
-                    // Read pages 4-13 (40 bytes) — enough for TigerTag magic check + NDEF header scan
-                    uint8_t pageData[40] = {0};
-                    uint16_t bytesRead = connection_->readISO14443Pages(4, 10, pageData, sizeof(pageData));
-
-                    // Try TigerTag first (binary magic at offset 0)
-                    if (bytesRead >= 14 && tigerTagCheckMagic(pageData, bytesRead)) {
-                        if (bytesRead >= 38) {
-                            tigerData = tigerTagParse(pageData, bytesRead);
-                            isTigerTag = tigerData.valid;
-                        } else {
-                            Serial.printf("NFCManager: TigerTag magic matched but only got %d bytes (need 38)\n", bytesRead);
-                        }
-                    }
-
-                    // If not TigerTag, check for OpenTag3D NDEF record
-                    if (!isTigerTag && bytesRead >= 4) {
-                        uint16_t pos = 0;
-                        while (pos < bytesRead) {
-                            uint8_t tlvType = pageData[pos++];
-                            if (tlvType == 0x00) continue;
-                            if (tlvType == 0xFE) break;
-                            if (pos >= bytesRead) break;
-
-                            uint16_t tlvLen = pageData[pos++];
-                            if (tlvLen == 0xFF) {
-                                if (pos + 2 > bytesRead) break;
-                                tlvLen = (uint16_t)(pageData[pos] << 8) | pageData[pos + 1];
-                                pos += 2;
-                            }
-
-                            if (tlvType == 0x03) {
-                                uint16_t ndefStart = pos;
-                                if (ndefStart >= bytesRead) break;
-
-                                uint8_t ndefFlags = pageData[ndefStart];
-                                uint8_t tnf = ndefFlags & 0x07;
-                                if (tnf == 0x02 && ndefStart + 1 < bytesRead) {
-                                    uint8_t typeLen = pageData[ndefStart + 1];
-                                    bool sr = (ndefFlags & 0x10) != 0;
-                                    uint16_t headerSize = 2 + (sr ? 1 : 4);
-                                    if (ndefStart + headerSize + typeLen <= bytesRead) {
-                                        const char* mime = OT3D_MIME_TYPE;
-                                        size_t mimeLen = strlen(mime);
-                                        if (typeLen == mimeLen &&
-                                            memcmp(pageData + ndefStart + headerSize, mime, mimeLen) == 0) {
-                                            uint32_t payloadLen = 0;
-                                            if (sr) {
-                                                payloadLen = pageData[ndefStart + 2];
-                                            } else {
-                                                payloadLen = ((uint32_t)pageData[ndefStart + 2] << 24) |
-                                                             ((uint32_t)pageData[ndefStart + 3] << 16) |
-                                                             ((uint32_t)pageData[ndefStart + 4] << 8) |
-                                                             pageData[ndefStart + 5];
-                                            }
-
-                                            uint16_t payloadOffset = ndefStart + headerSize + typeLen;
-                                            uint16_t availableInFirstRead = (payloadOffset < bytesRead) ? bytesRead - payloadOffset : 0;
-
-                                            uint8_t fullPayload[OT3D_EXTENDED_MIN];
-                                            uint16_t payloadBytes = 0;
-
-                                            if (availableInFirstRead >= payloadLen) {
-                                                memcpy(fullPayload, pageData + payloadOffset, payloadLen);
-                                                payloadBytes = (uint16_t)payloadLen;
-                                            } else {
-                                                uint8_t payloadStartPage = 4 + (payloadOffset / 4);
-                                                uint16_t totalPagesNeeded = (uint16_t)((payloadLen + 3) / 4) + 1;
-                                                if (totalPagesNeeded > 50) totalPagesNeeded = 50;
-
-                                                uint8_t extendedData[200] = {0};
-                                                uint16_t extendedRead = connection_->readISO14443Pages(
-                                                    payloadStartPage, (uint8_t)totalPagesNeeded, extendedData, sizeof(extendedData));
-
-                                                uint16_t offsetInPage = payloadOffset % 4;
-                                                if (extendedRead > offsetInPage) {
-                                                    payloadBytes = extendedRead - offsetInPage;
-                                                    if (payloadBytes > payloadLen) payloadBytes = (uint16_t)payloadLen;
-                                                    if (payloadBytes > sizeof(fullPayload)) payloadBytes = sizeof(fullPayload);
-                                                    memcpy(fullPayload, extendedData + offsetInPage, payloadBytes);
-                                                }
-                                            }
-
-                                            if (payloadBytes >= OT3D_CORE_SIZE) {
-                                                opentag3d_result_t res = opentag3d_decode(fullPayload, payloadBytes, &ot3dData);
-                                                if (res == OT3D_OK || res == OT3D_VERSION_WARNING) {
-                                                    isOpenTag3D = true;
-                                                    if (res == OT3D_VERSION_WARNING) {
-                                                        Serial.printf("NFCManager: OpenTag3D tag version %u ahead of supported %u — parsing anyway\n",
-                                                                      ot3dData.tag_version, OT3D_SUPPORTED_VERSION);
-                                                    }
-                                                } else if (res == OT3D_VERSION_ERROR) {
-                                                    Serial.printf("NFCManager: OpenTag3D major version too new (%u) — cannot parse\n",
-                                                                  ot3dData.tag_version);
-                                                }
-                                            }
-                                        }
-
-                                        // Check for OpenSpool (application/json + "protocol":"openspool")
-                                        if (!isOpenTag3D) {
-                                            const char* jsonMime = "application/json";
-                                            size_t jsonMimeLen = strlen(jsonMime);
-                                            if (typeLen == jsonMimeLen &&
-                                                memcmp(pageData + ndefStart + headerSize, jsonMime, jsonMimeLen) == 0) {
-                                                uint32_t osPayloadLen = 0;
-                                                if (sr) {
-                                                    osPayloadLen = pageData[ndefStart + 2];
-                                                } else {
-                                                    osPayloadLen = ((uint32_t)pageData[ndefStart + 2] << 24) |
-                                                                   ((uint32_t)pageData[ndefStart + 3] << 16) |
-                                                                   ((uint32_t)pageData[ndefStart + 4] << 8) |
-                                                                   pageData[ndefStart + 5];
-                                                }
-                                                uint16_t osOffset = ndefStart + headerSize + typeLen;
-                                                uint8_t osPayload[256] = {0};
-                                                uint16_t osBytes = 0;
-
-                                                if (osOffset + osPayloadLen <= bytesRead) {
-                                                    osBytes = (uint16_t)osPayloadLen;
-                                                    if (osBytes > sizeof(osPayload)) osBytes = sizeof(osPayload);
-                                                    memcpy(osPayload, pageData + osOffset, osBytes);
-                                                } else {
-                                                    uint8_t osStartPage = 4 + (osOffset / 4);
-                                                    uint16_t osPagesNeeded = (uint16_t)((osPayloadLen + 3) / 4) + 1;
-                                                    if (osPagesNeeded > 50) osPagesNeeded = 50;
-                                                    uint8_t osExtData[256] = {0};
-                                                    uint16_t osExtRead = connection_->readISO14443Pages(
-                                                        osStartPage, (uint8_t)osPagesNeeded, osExtData, sizeof(osExtData));
-                                                    uint16_t osOffInPage = osOffset % 4;
-                                                    if (osExtRead > osOffInPage) {
-                                                        osBytes = osExtRead - osOffInPage;
-                                                        if (osBytes > osPayloadLen) osBytes = (uint16_t)osPayloadLen;
-                                                        if (osBytes > sizeof(osPayload)) osBytes = sizeof(osPayload);
-                                                        memcpy(osPayload, osExtData + osOffInPage, osBytes);
-                                                    }
-                                                }
-
-                                                if (osBytes > 0 && parseOpenSpool(osPayload, osBytes, openSpoolData)) {
-                                                    isOpenSpool = true;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                break;
-                            } else {
-                                pos += tlvLen;
-                            }
-                        }
-                    }
-
-                    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-                        memcpy(currentSpool.spool_id, scan.uid_hex, sizeof(scan.uid_hex));
-                        memcpy(currentSpool.uid, uid, uidLength);
-                        currentSpool.uid_length = uidLength;
-                        currentSpool.present = true;
-                        currentSpool.blank_tag_present = false;
-                        memcpy(lastSeenUid, uid, uidLength);
-                        lastSeenUidLength = uidLength;
-                        lastSeenValid = true;
-                        lastSeenMs = millis();
-
-                        if (isTigerTag) {
-                            currentSpool.kind = TagKind::TigerTag;
-                            currentSpool.tag_data_valid = false;
-                            lastTigerTag_ = tigerData;
-                            lastTigerTagValid_ = true;
-                            lastOpenTag3DValid_ = false;
-                            Serial.printf("NFCManager: TigerTag detected — %s %s %s\n",
-                                          tigerData.brand_name, tigerData.material_name,
-                                          tigerData.aspect1_name);
-                        } else if (isOpenTag3D) {
-                            currentSpool.kind = TagKind::OpenTag3D;
-                            currentSpool.tag_data_valid = false;
-                            lastOpenTag3D_ = ot3dData;
-                            lastOpenTag3DValid_ = true;
-                            lastTigerTagValid_ = false;
-                            lastOpenSpoolValid_ = false;
-                            Serial.printf("NFCManager: OpenTag3D detected — %s %s %.2fmm %ug\n",
-                                          ot3dData.manufacturer, ot3dData.base_material,
-                                          opentag3d_diameter_mm(&ot3dData), ot3dData.target_weight_g);
-                        } else if (isOpenSpool) {
-                            currentSpool.kind = TagKind::OpenSpoolTag;
-                            currentSpool.tag_data_valid = false;
-                            lastOpenSpool_ = openSpoolData;
-                            lastOpenSpoolValid_ = true;
-                            lastTigerTagValid_ = false;
-                            lastOpenTag3DValid_ = false;
-                            Serial.printf("NFCManager: OpenSpool detected — %s %s #%s\n",
-                                          openSpoolData.brand, openSpoolData.material,
-                                          openSpoolData.color_hex);
-                        } else {
-                            currentSpool.kind = TagKind::GenericUidTag;
-                            currentSpool.tag_data_valid = false;
-                            lastTigerTagValid_ = false;
-                            lastOpenTag3DValid_ = false;
-                            lastOpenSpoolValid_ = false;
-                        }
-                        xSemaphoreGive(tagMutex);
-                    } else {
-                        Serial.println("NFCManager: Could not acquire tagMutex");
-                    }
-
-                    if (isTigerTag) {
-                        sendTigerTagMessage(tigerData);
-                    } else if (isOpenTag3D) {
-                        sendOpenTag3DMessage(ot3dData);
-                    } else if (isOpenSpool) {
-                        sendOpenSpoolMessage(currentSpool.spool_id, openSpoolData);
-                    } else {
-                        sendGenericTagMessage();
-                    }
+                    readAndProcessISO14443Tag(uid, uidLength, scan);
                 } else {
 
                 // ISO15693 — attempt OpenPrintTag parse

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -1589,413 +1589,311 @@ static opt_error_t applyWriteUpdate(opt_tag_t& tag, const NFCWriteRequest& reque
     }
 }
 
-bool NFCManager::executeWrite(const NFCWriteRequest& request) {
-    // Handle FORMAT_NEW — formatNewSpool() manages its own mutex
-    if (request.type == NFCWriteType::FORMAT_NEW) {
-        // Validate under mutex
-        if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
-            Serial.println("NFCManager: FORMAT_NEW - could not acquire tagMutex");
-            return false;
-        }
-        if (request.expected_spool_id[0] != '\0' &&
-            strcmp(currentSpool.spool_id, request.expected_spool_id) != 0) {
-            xSemaphoreGive(tagMutex);
-            Serial.println("NFCManager: FORMAT_NEW rejected - UID mismatch");
-            return false;
-        }
-        xSemaphoreGive(tagMutex);
+// ── Write helpers ────────────────────────────────────────────
 
-        // formatNewSpool() does NFC I/O without mutex, takes mutex at end for state copy
+static uint16_t buildNdefTlv(const char* mimeType, const uint8_t* payload, uint16_t payloadLen,
+                              uint8_t* outBuf, uint16_t outBufSize) {
+    uint8_t mimeLen = (uint8_t)strlen(mimeType);
+    bool sr = (payloadLen <= 255);
+    uint8_t ndefHeaderSize = 2 + (sr ? 1 : 4);
+    uint16_t ndefRecordLen = ndefHeaderSize + mimeLen + payloadLen;
+
+    bool longTlv = (ndefRecordLen > 254);
+    uint16_t tlvHeaderSize = 1 + (longTlv ? 3 : 1);
+    uint16_t totalSize = tlvHeaderSize + ndefRecordLen + 1;
+    uint16_t paddedSize = totalSize + ((4 - (totalSize % 4)) % 4);
+
+    if (paddedSize > outBufSize) return 0;
+
+    uint16_t idx = 0;
+    outBuf[idx++] = 0x03;
+    if (longTlv) {
+        outBuf[idx++] = 0xFF;
+        outBuf[idx++] = (uint8_t)(ndefRecordLen >> 8);
+        outBuf[idx++] = (uint8_t)(ndefRecordLen & 0xFF);
+    } else {
+        outBuf[idx++] = (uint8_t)ndefRecordLen;
+    }
+
+    uint8_t ndefFlags = 0xC0 | 0x02;
+    if (sr) ndefFlags |= 0x10;
+    outBuf[idx++] = ndefFlags;
+    outBuf[idx++] = mimeLen;
+    if (sr) {
+        outBuf[idx++] = (uint8_t)payloadLen;
+    } else {
+        outBuf[idx++] = (uint8_t)((payloadLen >> 24) & 0xFF);
+        outBuf[idx++] = (uint8_t)((payloadLen >> 16) & 0xFF);
+        outBuf[idx++] = (uint8_t)((payloadLen >> 8) & 0xFF);
+        outBuf[idx++] = (uint8_t)(payloadLen & 0xFF);
+    }
+
+    memcpy(outBuf + idx, mimeType, mimeLen);
+    idx += mimeLen;
+    memcpy(outBuf + idx, payload, payloadLen);
+    idx += payloadLen;
+    outBuf[idx++] = 0xFE;
+    while (idx < paddedSize) outBuf[idx++] = 0x00;
+    return paddedSize;
+}
+
+bool NFCManager::validateWriteUid(const char* expectedUid, const char* writeType) {
+    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        Serial.printf("NFCManager: %s - could not acquire tagMutex\n", writeType);
+        return false;
+    }
+    if (expectedUid[0] != '\0' && strcmp(currentSpool.spool_id, expectedUid) != 0) {
+        xSemaphoreGive(tagMutex);
+        Serial.printf("NFCManager: %s rejected - UID mismatch\n", writeType);
+        return false;
+    }
+    xSemaphoreGive(tagMutex);
+    return true;
+}
+
+void NFCManager::forceRescan() {
+    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+        currentSpool.present = false;
+        xSemaphoreGive(tagMutex);
+    }
+}
+
+// ── Per-format write functions ──────────────────────────────
+
+bool NFCManager::executeTigerTagWrite(const NFCWriteRequest& request) {
+    if (!validateWriteUid(request.expected_spool_id, "WRITE_TIGERTAG")) return false;
+
+    bool ok = connection_->writeISO14443Pages(4, 10, request.data.tigertag_data, 40);
+    if (ok) {
+        Serial.println("NFCManager: WRITE_TIGERTAG succeeded");
+        forceRescan();
+    } else {
+        Serial.println("NFCManager: WRITE_TIGERTAG failed");
+    }
+    return ok;
+}
+
+bool NFCManager::executeOpenTag3DWrite(const NFCWriteRequest& request) {
+    if (!validateWriteUid(request.expected_spool_id, "WRITE_OPENTAG3D")) return false;
+
+    if (!rawWritePending_ || rawWriteBufferSize_ < sizeof(opentag3d_t)) {
+        Serial.println("NFCManager: WRITE_OPENTAG3D - no raw data available");
+        return false;
+    }
+
+    opentag3d_t ot3d;
+    memcpy(&ot3d, rawWriteBuffer_, sizeof(opentag3d_t));
+    rawWritePending_ = false;
+
+    size_t encodeSize = ot3d.has_extended ? OT3D_EXTENDED_MIN : OT3D_CORE_SIZE;
+    uint8_t payloadBuf[OT3D_EXTENDED_MIN];
+    int payloadLen = opentag3d_encode(&ot3d, payloadBuf, encodeSize);
+    if (payloadLen <= 0) {
+        Serial.println("NFCManager: WRITE_OPENTAG3D - encode failed");
+        return false;
+    }
+
+    uint8_t ndefBuf[256];
+    uint16_t ndefLen = buildNdefTlv(OT3D_MIME_TYPE, payloadBuf, (uint16_t)payloadLen, ndefBuf, sizeof(ndefBuf));
+    if (ndefLen == 0) {
+        Serial.printf("NFCManager: WRITE_OPENTAG3D - NDEF too large\n");
+        return false;
+    }
+
+    uint8_t pagesNeeded = (uint8_t)(ndefLen / 4);
+    Serial.printf("NFCManager: WRITE_OPENTAG3D - writing %u bytes (%u pages)\n", ndefLen, pagesNeeded);
+    bool ok = connection_->writeISO14443Pages(4, pagesNeeded, ndefBuf, ndefLen);
+    if (ok) {
+        Serial.printf("NFCManager: WRITE_OPENTAG3D succeeded (%u bytes, %u pages)\n", ndefLen, pagesNeeded);
+        forceRescan();
+    } else {
+        Serial.println("NFCManager: WRITE_OPENTAG3D failed");
+    }
+    return ok;
+}
+
+bool NFCManager::executeOpenSpoolWrite(const NFCWriteRequest& request) {
+    if (!validateWriteUid(request.expected_spool_id, "WRITE_OPENSPOOL")) return false;
+
+    if (!rawWritePending_ || rawWriteBufferSize_ == 0) {
+        Serial.println("NFCManager: WRITE_OPENSPOOL - no raw data available");
+        return false;
+    }
+
+    const uint8_t* jsonPayload = rawWriteBuffer_;
+    uint16_t payloadLen = (uint16_t)rawWriteBufferSize_;
+    rawWritePending_ = false;
+
+    uint8_t ndefBuf[256];
+    uint16_t ndefLen = buildNdefTlv("application/json", jsonPayload, payloadLen, ndefBuf, sizeof(ndefBuf));
+    if (ndefLen == 0) {
+        Serial.printf("NFCManager: WRITE_OPENSPOOL - NDEF too large\n");
+        return false;
+    }
+
+    uint8_t pagesNeeded = (uint8_t)(ndefLen / 4);
+    Serial.printf("NFCManager: WRITE_OPENSPOOL - writing %u bytes (%u pages)\n", ndefLen, pagesNeeded);
+    bool ok = connection_->writeISO14443Pages(4, pagesNeeded, ndefBuf, ndefLen);
+    if (ok) {
+        Serial.printf("NFCManager: WRITE_OPENSPOOL succeeded (%u bytes, %u pages)\n", ndefLen, pagesNeeded);
+        forceRescan();
+    } else {
+        Serial.println("NFCManager: WRITE_OPENSPOOL failed");
+    }
+    return ok;
+}
+
+bool NFCManager::executeAtomicWrite(const NFCWriteRequest& request) {
+    if (!atomicWriteFields_.pending) {
+        Serial.println("NFCManager: WRITE_ATOMIC - no atomic fields pending");
+        return false;
+    }
+
+    AtomicWriteFields f = atomicWriteFields_;
+    atomicWriteFields_.pending = false;
+
+    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        Serial.println("NFCManager: WRITE_ATOMIC - could not acquire tagMutex");
+        return false;
+    }
+    if (!currentSpool.tag_data_valid) {
+        xSemaphoreGive(tagMutex);
+        return false;
+    }
+    if (request.expected_spool_id[0] != '\0' &&
+        strcmp(currentSpool.spool_id, request.expected_spool_id) != 0) {
+        Serial.printf("NFCManager: WRITE_ATOMIC rejected: expected %s but found %s\n",
+            request.expected_spool_id, currentSpool.spool_id);
+        xSemaphoreGive(tagMutex);
+        return false;
+    }
+
+    uint8_t  cur_mat_type = 0;     opt_get_material_type(&currentSpool.tag_data, &cur_mat_type);
+    uint8_t  cur_color[4] = {255,255,255,255}; opt_get_primary_color(&currentSpool.tag_data, cur_color);
+    float    cur_full_wt = 1000.0f; opt_get_actual_full_weight(&currentSpool.tag_data, &cur_full_wt);
+    float    cur_consumed = 0.0f;   opt_get_consumed_weight(&currentSpool.tag_data, &cur_consumed);
+    char     cur_brand[33] = {0};   opt_get_brand_name(&currentSpool.tag_data, cur_brand, sizeof(cur_brand));
+    float    cur_density = 0.0f;    opt_get_density(&currentSpool.tag_data, &cur_density);
+    float    cur_diameter = 0.0f;   opt_get_filament_diameter(&currentSpool.tag_data, &cur_diameter);
+    char     cur_mat_name[33] = {0}; opt_get_material_name(&currentSpool.tag_data, cur_mat_name, sizeof(cur_mat_name));
+    int32_t  cur_sm_id = -1;        opt_get_gp_spoolman_id(&currentSpool.tag_data, &cur_sm_id);
+    int16_t  cur_min_pt = 0, cur_max_pt = 0, cur_pre_t = 0, cur_min_bt = 0, cur_max_bt = 0;
+    opt_get_min_print_temp(&currentSpool.tag_data, &cur_min_pt);
+    opt_get_max_print_temp(&currentSpool.tag_data, &cur_max_pt);
+    opt_get_preheat_temp(&currentSpool.tag_data, &cur_pre_t);
+    opt_get_min_bed_temp(&currentSpool.tag_data, &cur_min_bt);
+    opt_get_max_bed_temp(&currentSpool.tag_data, &cur_max_bt);
+    xSemaphoreGive(tagMutex);
+
+    opt_init(&writeScratchTag_);
+    opt_error_t err = opt_format_empty_tag(&writeScratchTag_, 312, 32);
+    if (err != OPT_OK) {
+        Serial.printf("NFCManager: WRITE_ATOMIC format failed: %s\n", opt_error_str(err));
+        return false;
+    }
+
+    opt_set_material_class(&writeScratchTag_, OPT_MATERIAL_CLASS_FFF);
+
+    #define ATOMIC_SET(name, call) do { \
+        err = (call); \
+        if (err != OPT_OK) { \
+            Serial.printf("NFCManager: WRITE_ATOMIC " name " failed: %s\n", opt_error_str(err)); \
+        } \
+    } while(0)
+
+    ATOMIC_SET("material_type",  opt_set_material_type(&writeScratchTag_, f.has_material_type ? f.material_type : cur_mat_type));
+    ATOMIC_SET("color",          opt_set_primary_color(&writeScratchTag_, f.has_color ? f.color : cur_color));
+    ATOMIC_SET("initial_weight", opt_set_actual_full_weight(&writeScratchTag_, f.has_initial_weight ? f.initial_weight_g : cur_full_wt));
+    ATOMIC_SET("consumed_weight",opt_set_consumed_weight(&writeScratchTag_, f.has_consumed_weight ? f.consumed_weight : cur_consumed));
+    if (f.has_brand_name || cur_brand[0] != '\0')
+        ATOMIC_SET("brand_name", opt_set_brand_name(&writeScratchTag_, f.has_brand_name ? f.brand_name : cur_brand));
+    if (f.has_density || cur_density > 0.0f)
+        ATOMIC_SET("density",    opt_set_density(&writeScratchTag_, f.has_density ? f.density : cur_density));
+    if (f.has_diameter || cur_diameter > 0.0f)
+        ATOMIC_SET("diameter",   opt_set_filament_diameter(&writeScratchTag_, f.has_diameter ? f.diameter_mm : cur_diameter));
+    if (f.has_material_name || cur_mat_name[0] != '\0')
+        ATOMIC_SET("material_name", opt_set_material_name(&writeScratchTag_, f.has_material_name ? f.material_name : cur_mat_name));
+    if (f.has_min_print_temp || cur_min_pt != 0)
+        ATOMIC_SET("min_print_temp", opt_set_min_print_temp(&writeScratchTag_, f.has_min_print_temp ? f.min_print_temp : cur_min_pt));
+    if (f.has_max_print_temp || cur_max_pt != 0)
+        ATOMIC_SET("max_print_temp", opt_set_max_print_temp(&writeScratchTag_, f.has_max_print_temp ? f.max_print_temp : cur_max_pt));
+    if (f.has_preheat_temp || cur_pre_t != 0)
+        ATOMIC_SET("preheat_temp",   opt_set_preheat_temp(&writeScratchTag_, f.has_preheat_temp ? f.preheat_temp : cur_pre_t));
+    if (f.has_min_bed_temp || cur_min_bt != 0)
+        ATOMIC_SET("min_bed_temp",   opt_set_min_bed_temp(&writeScratchTag_, f.has_min_bed_temp ? f.min_bed_temp : cur_min_bt));
+    if (f.has_max_bed_temp || cur_max_bt != 0)
+        ATOMIC_SET("max_bed_temp",   opt_set_max_bed_temp(&writeScratchTag_, f.has_max_bed_temp ? f.max_bed_temp : cur_max_bt));
+    int32_t sm_id = f.has_spoolman_id ? f.spoolman_id : cur_sm_id;
+    if (sm_id > 0)
+        ATOMIC_SET("spoolman_id",    opt_set_gp_spoolman_id(&writeScratchTag_, sm_id));
+    #undef ATOMIC_SET
+
+    Serial.println("NFCManager: WRITE_ATOMIC writing to NFC...");
+    opt_nfc_hal_t* hal = connection_->getHal();
+    err = opt_write_to_nfc(&writeScratchTag_, hal);
+    if (err != OPT_OK) {
+        Serial.printf("NFCManager: WRITE_ATOMIC NFC write failed: %s\n", opt_error_str(err));
+        return false;
+    }
+
+    bool verified = false;
+    for (int retry = 0; retry < 3; retry++) {
+        vTaskDelay(pdMS_TO_TICKS(50 * (retry + 1)));
+        err = opt_read_from_nfc(&writeScratchTag_, hal, 0, 78);
+        if (err == OPT_OK) {
+            err = opt_parse_ndef(&writeScratchTag_);
+            if (err == OPT_OK) { verified = true; break; }
+        }
+        Serial.printf("NFCManager: WRITE_ATOMIC verify retry %d: %s\n", retry + 1, opt_error_str(err));
+    }
+    if (!verified) {
+        Serial.println("NFCManager: WRITE_ATOMIC verification failed");
+        return false;
+    }
+
+    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        Serial.println("NFCManager: WRITE_ATOMIC succeeded but commit lock failed");
+        return false;
+    }
+    currentSpool.tag_data = writeScratchTag_;
+    currentSpool.tag_data_valid = true;
+    currentSpool.blank_tag_present = false;
+    currentSpool.kind = TagKind::OpenPrintTag;
+    addToRecentSpools();
+    sendSpoolDetectedMessage();
+    xSemaphoreGive(tagMutex);
+
+    Serial.println("NFCManager: WRITE_ATOMIC complete");
+    return true;
+}
+
+// ── executeWrite dispatcher ─────────────────────────────────
+
+bool NFCManager::executeWrite(const NFCWriteRequest& request) {
+    if (request.type == NFCWriteType::FORMAT_NEW) {
+        if (!validateWriteUid(request.expected_spool_id, "FORMAT_NEW")) return false;
         return formatNewSpool();
     }
 
-    // Handle WRITE_RAW_TAG — writeRawTag() manages its own mutex
     if (request.type == NFCWriteType::WRITE_RAW_TAG) {
         if (!rawWritePending_) {
             Serial.println("NFCManager: WRITE_RAW_TAG - no raw data pending");
             return false;
         }
-        // Validate under mutex
-        if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
-            Serial.println("NFCManager: WRITE_RAW_TAG - could not acquire tagMutex");
+        if (!validateWriteUid(request.expected_spool_id, "WRITE_RAW_TAG")) {
             rawWritePending_ = false;
             return false;
         }
-        if (request.expected_spool_id[0] != '\0' &&
-            strcmp(currentSpool.spool_id, request.expected_spool_id) != 0) {
-            xSemaphoreGive(tagMutex);
-            Serial.println("NFCManager: WRITE_RAW_TAG rejected - UID mismatch");
-            rawWritePending_ = false;
-            return false;
-        }
-        xSemaphoreGive(tagMutex);
-
         return writeRawTag();
     }
 
-    // Handle WRITE_TIGERTAG — write 40-byte binary to NTAG pages 4-13
-    if (request.type == NFCWriteType::WRITE_TIGERTAG) {
-        if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
-            Serial.println("NFCManager: WRITE_TIGERTAG - could not acquire tagMutex");
-            return false;
-        }
-        if (request.expected_spool_id[0] != '\0' &&
-            strcmp(currentSpool.spool_id, request.expected_spool_id) != 0) {
-            xSemaphoreGive(tagMutex);
-            Serial.println("NFCManager: WRITE_TIGERTAG rejected - UID mismatch");
-            return false;
-        }
-        xSemaphoreGive(tagMutex);
+    if (request.type == NFCWriteType::WRITE_TIGERTAG)  return executeTigerTagWrite(request);
+    if (request.type == NFCWriteType::WRITE_OPENTAG3D) return executeOpenTag3DWrite(request);
+    if (request.type == NFCWriteType::WRITE_OPENSPOOL)  return executeOpenSpoolWrite(request);
+    if (request.type == NFCWriteType::WRITE_ATOMIC)     return executeAtomicWrite(request);
 
-        // Write 40 bytes = 10 pages starting at page 4
-        bool ok = connection_->writeISO14443Pages(4, 10, request.data.tigertag_data, 40);
-        if (ok) {
-            Serial.println("NFCManager: WRITE_TIGERTAG succeeded");
-            // Force re-scan to pick up the new TigerTag data
-            if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-                currentSpool.present = false;
-                xSemaphoreGive(tagMutex);
-            }
-        } else {
-            Serial.println("NFCManager: WRITE_TIGERTAG failed");
-        }
-        return ok;
-    }
-
-    // Handle WRITE_OPENTAG3D — write NDEF-wrapped OpenTag3D payload to NTAG pages
-    if (request.type == NFCWriteType::WRITE_OPENTAG3D) {
-        if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
-            Serial.println("NFCManager: WRITE_OPENTAG3D - could not acquire tagMutex");
-            return false;
-        }
-        if (request.expected_spool_id[0] != '\0' &&
-            strcmp(currentSpool.spool_id, request.expected_spool_id) != 0) {
-            xSemaphoreGive(tagMutex);
-            Serial.println("NFCManager: WRITE_OPENTAG3D rejected - UID mismatch");
-            return false;
-        }
-        xSemaphoreGive(tagMutex);
-
-        // Decode opentag3d_t from rawWriteBuffer_
-        if (!rawWritePending_ || rawWriteBufferSize_ < sizeof(opentag3d_t)) {
-            Serial.println("NFCManager: WRITE_OPENTAG3D - no raw data available");
-            return false;
-        }
-
-        opentag3d_t ot3d;
-        memcpy(&ot3d, rawWriteBuffer_, sizeof(opentag3d_t));
-        rawWritePending_ = false;
-
-        // Encode to binary payload — use core-only size when no extended fields are set
-        // to reduce page count (32 pages vs 54) for better write reliability at range
-        size_t encodeSize = ot3d.has_extended ? OT3D_EXTENDED_MIN : OT3D_CORE_SIZE;
-        uint8_t payloadBuf[OT3D_EXTENDED_MIN];
-        int payloadLen = opentag3d_encode(&ot3d, payloadBuf, encodeSize);
-        if (payloadLen <= 0) {
-            Serial.println("NFCManager: WRITE_OPENTAG3D - encode failed");
-            return false;
-        }
-
-        // Build NDEF TLV wrapper
-        const char* mime = OT3D_MIME_TYPE;
-        uint8_t mimeLen = (uint8_t)strlen(mime);
-        // NDEF record: flags(1) + typeLen(1) + payloadLen(1, SR) + type(mimeLen) + payload
-        bool sr = (payloadLen <= 255);
-        uint8_t ndefHeaderSize = 2 + (sr ? 1 : 4);
-        uint16_t ndefRecordLen = ndefHeaderSize + mimeLen + (uint16_t)payloadLen;
-
-        // TLV: type(1) + length(1 or 3) + NDEF record + terminator(1)
-        bool longTlv = (ndefRecordLen > 254);
-        uint16_t tlvHeaderSize = 1 + (longTlv ? 3 : 1);
-        uint16_t totalSize = tlvHeaderSize + ndefRecordLen + 1;  // +1 for terminator
-
-        uint8_t ndefBuf[256];
-        if (totalSize > sizeof(ndefBuf)) {
-            Serial.printf("NFCManager: WRITE_OPENTAG3D - NDEF too large (%u bytes)\n", totalSize);
-            return false;
-        }
-
-        uint16_t idx = 0;
-
-        // TLV header
-        ndefBuf[idx++] = 0x03;  // NDEF Message TLV
-        if (longTlv) {
-            ndefBuf[idx++] = 0xFF;
-            ndefBuf[idx++] = (uint8_t)(ndefRecordLen >> 8);
-            ndefBuf[idx++] = (uint8_t)(ndefRecordLen & 0xFF);
-        } else {
-            ndefBuf[idx++] = (uint8_t)ndefRecordLen;
-        }
-
-        // NDEF record header
-        uint8_t ndefFlags = 0xC0 | 0x02;  // MB + ME + TNF=media-type
-        if (sr) ndefFlags |= 0x10;         // SR flag
-        ndefBuf[idx++] = ndefFlags;
-        ndefBuf[idx++] = mimeLen;
-        if (sr) {
-            ndefBuf[idx++] = (uint8_t)payloadLen;
-        } else {
-            ndefBuf[idx++] = (uint8_t)((payloadLen >> 24) & 0xFF);
-            ndefBuf[idx++] = (uint8_t)((payloadLen >> 16) & 0xFF);
-            ndefBuf[idx++] = (uint8_t)((payloadLen >> 8) & 0xFF);
-            ndefBuf[idx++] = (uint8_t)(payloadLen & 0xFF);
-        }
-
-        // MIME type
-        memcpy(ndefBuf + idx, mime, mimeLen);
-        idx += mimeLen;
-
-        // Payload
-        memcpy(ndefBuf + idx, payloadBuf, payloadLen);
-        idx += (uint16_t)payloadLen;
-
-        // Terminator TLV
-        ndefBuf[idx++] = 0xFE;
-
-        // Pad to page boundary (4 bytes per page)
-        while (idx % 4 != 0) ndefBuf[idx++] = 0x00;
-
-        // Write to NTAG pages starting at page 4
-        uint8_t pagesNeeded = (uint8_t)(idx / 4);
-        Serial.printf("NFCManager: WRITE_OPENTAG3D - writing %u bytes (%u pages), payload=%d\n", idx, pagesNeeded, payloadLen);
-        bool ok = connection_->writeISO14443Pages(4, pagesNeeded, ndefBuf, idx);
-        if (ok) {
-            Serial.printf("NFCManager: WRITE_OPENTAG3D succeeded (%u bytes, %u pages)\n", idx, pagesNeeded);
-            // Force re-scan to pick up the new OpenTag3D data
-            if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-                currentSpool.present = false;
-                xSemaphoreGive(tagMutex);
-            }
-        } else {
-            Serial.println("NFCManager: WRITE_OPENTAG3D failed");
-        }
-        return ok;
-    }
-
-    // Handle WRITE_OPENSPOOL — write NDEF-wrapped JSON payload to NTAG pages
-    if (request.type == NFCWriteType::WRITE_OPENSPOOL) {
-        if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
-            Serial.println("NFCManager: WRITE_OPENSPOOL - could not acquire tagMutex");
-            return false;
-        }
-        if (request.expected_spool_id[0] != '\0' &&
-            strcmp(currentSpool.spool_id, request.expected_spool_id) != 0) {
-            xSemaphoreGive(tagMutex);
-            Serial.println("NFCManager: WRITE_OPENSPOOL rejected - UID mismatch");
-            return false;
-        }
-        xSemaphoreGive(tagMutex);
-
-        if (!rawWritePending_ || rawWriteBufferSize_ == 0) {
-            Serial.println("NFCManager: WRITE_OPENSPOOL - no raw data available");
-            return false;
-        }
-
-        const uint8_t* jsonPayload = rawWriteBuffer_;
-        uint16_t payloadLen = (uint16_t)rawWriteBufferSize_;
-        rawWritePending_ = false;
-
-        const char* mime = "application/json";
-        uint8_t mimeLen = (uint8_t)strlen(mime);
-        bool sr = (payloadLen <= 255);
-        uint8_t ndefHeaderSize = 2 + (sr ? 1 : 4);
-        uint16_t ndefRecordLen = ndefHeaderSize + mimeLen + payloadLen;
-
-        bool longTlv = (ndefRecordLen > 254);
-        uint16_t tlvHeaderSize = 1 + (longTlv ? 3 : 1);
-        uint16_t totalSize = tlvHeaderSize + ndefRecordLen + 1;
-
-        uint8_t ndefBuf[256];
-        if (totalSize > sizeof(ndefBuf)) {
-            Serial.printf("NFCManager: WRITE_OPENSPOOL - NDEF too large (%u bytes)\n", totalSize);
-            return false;
-        }
-
-        uint16_t idx = 0;
-        ndefBuf[idx++] = 0x03;
-        if (longTlv) {
-            ndefBuf[idx++] = 0xFF;
-            ndefBuf[idx++] = (uint8_t)(ndefRecordLen >> 8);
-            ndefBuf[idx++] = (uint8_t)(ndefRecordLen & 0xFF);
-        } else {
-            ndefBuf[idx++] = (uint8_t)ndefRecordLen;
-        }
-
-        uint8_t ndefFlags = 0xC0 | 0x02;
-        if (sr) ndefFlags |= 0x10;
-        ndefBuf[idx++] = ndefFlags;
-        ndefBuf[idx++] = mimeLen;
-        if (sr) {
-            ndefBuf[idx++] = (uint8_t)payloadLen;
-        } else {
-            ndefBuf[idx++] = (uint8_t)((payloadLen >> 24) & 0xFF);
-            ndefBuf[idx++] = (uint8_t)((payloadLen >> 16) & 0xFF);
-            ndefBuf[idx++] = (uint8_t)((payloadLen >> 8) & 0xFF);
-            ndefBuf[idx++] = (uint8_t)(payloadLen & 0xFF);
-        }
-
-        memcpy(ndefBuf + idx, mime, mimeLen);
-        idx += mimeLen;
-        memcpy(ndefBuf + idx, jsonPayload, payloadLen);
-        idx += payloadLen;
-        ndefBuf[idx++] = 0xFE;
-
-        while (idx % 4 != 0) ndefBuf[idx++] = 0x00;
-
-        uint8_t pagesNeeded = (uint8_t)(idx / 4);
-        Serial.printf("NFCManager: WRITE_OPENSPOOL - writing %u bytes (%u pages)\n", idx, pagesNeeded);
-        bool ok = connection_->writeISO14443Pages(4, pagesNeeded, ndefBuf, idx);
-        if (ok) {
-            Serial.printf("NFCManager: WRITE_OPENSPOOL succeeded (%u bytes, %u pages)\n", idx, pagesNeeded);
-            if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-                currentSpool.present = false;
-                xSemaphoreGive(tagMutex);
-            }
-        } else {
-            Serial.println("NFCManager: WRITE_OPENSPOOL failed");
-        }
-        return ok;
-    }
-
-    // Handle WRITE_ATOMIC — build complete CBOR map from sidecar fields, write once
-    if (request.type == NFCWriteType::WRITE_ATOMIC) {
-        if (!atomicWriteFields_.pending) {
-            Serial.println("NFCManager: WRITE_ATOMIC - no atomic fields pending");
-            return false;
-        }
-
-        // Copy sidecar by value and clear pending immediately — prevents a
-        // concurrent HTTP call from overwriting fields mid-write
-        AtomicWriteFields f = atomicWriteFields_;
-        atomicWriteFields_.pending = false;
-
-        // Validate and snapshot under mutex
-        if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
-            Serial.println("NFCManager: WRITE_ATOMIC - could not acquire tagMutex");
-            return false;
-        }
-        if (!currentSpool.tag_data_valid) {
-            xSemaphoreGive(tagMutex);
-            return false;
-        }
-        if (request.expected_spool_id[0] != '\0' &&
-            strcmp(currentSpool.spool_id, request.expected_spool_id) != 0) {
-            Serial.printf("NFCManager: WRITE_ATOMIC rejected: expected %s but found %s\n",
-                request.expected_spool_id, currentSpool.spool_id);
-            xSemaphoreGive(tagMutex);
-            return false;
-        }
-        // Read defaults from the existing tag for any fields not provided
-        uint8_t  cur_mat_type = 0;     opt_get_material_type(&currentSpool.tag_data, &cur_mat_type);
-        uint8_t  cur_color[4] = {255,255,255,255}; opt_get_primary_color(&currentSpool.tag_data, cur_color);
-        float    cur_full_wt = 1000.0f; opt_get_actual_full_weight(&currentSpool.tag_data, &cur_full_wt);
-        float    cur_consumed = 0.0f;   opt_get_consumed_weight(&currentSpool.tag_data, &cur_consumed);
-        char     cur_brand[33] = {0};   opt_get_brand_name(&currentSpool.tag_data, cur_brand, sizeof(cur_brand));
-        float    cur_density = 0.0f;    opt_get_density(&currentSpool.tag_data, &cur_density);
-        float    cur_diameter = 0.0f;   opt_get_filament_diameter(&currentSpool.tag_data, &cur_diameter);
-        char     cur_mat_name[33] = {0}; opt_get_material_name(&currentSpool.tag_data, cur_mat_name, sizeof(cur_mat_name));
-        int32_t  cur_sm_id = -1;        opt_get_gp_spoolman_id(&currentSpool.tag_data, &cur_sm_id);
-        int16_t  cur_min_pt = 0, cur_max_pt = 0, cur_pre_t = 0, cur_min_bt = 0, cur_max_bt = 0;
-        opt_get_min_print_temp(&currentSpool.tag_data, &cur_min_pt);
-        opt_get_max_print_temp(&currentSpool.tag_data, &cur_max_pt);
-        opt_get_preheat_temp(&currentSpool.tag_data, &cur_pre_t);
-        opt_get_min_bed_temp(&currentSpool.tag_data, &cur_min_bt);
-        opt_get_max_bed_temp(&currentSpool.tag_data, &cur_max_bt);
-        xSemaphoreGive(tagMutex);
-
-        // Build a FRESH tag from scratch — avoids CBOR re-encoding overflow
-        // that happens when updating fields in an existing map
-        opt_init(&writeScratchTag_);
-        opt_error_t err = opt_format_empty_tag(&writeScratchTag_, 312, 32);
-        if (err != OPT_OK) {
-            Serial.printf("NFCManager: WRITE_ATOMIC format failed: %s\n", opt_error_str(err));
-            atomicWriteFields_.pending = false;
-            return false;
-        }
-
-        // Set material class (required by spec)
-        opt_set_material_class(&writeScratchTag_, OPT_MATERIAL_CLASS_FFF);
-
-        // Apply each field: use provided value if has_*, else use existing tag default
-        #define ATOMIC_SET(name, call) do { \
-            err = (call); \
-            if (err != OPT_OK) { \
-                Serial.printf("NFCManager: WRITE_ATOMIC " name " failed: %s\n", opt_error_str(err)); \
-            } \
-        } while(0)
-
-        ATOMIC_SET("material_type",  opt_set_material_type(&writeScratchTag_, f.has_material_type ? f.material_type : cur_mat_type));
-        ATOMIC_SET("color",          opt_set_primary_color(&writeScratchTag_, f.has_color ? f.color : cur_color));
-        ATOMIC_SET("initial_weight", opt_set_actual_full_weight(&writeScratchTag_, f.has_initial_weight ? f.initial_weight_g : cur_full_wt));
-        ATOMIC_SET("consumed_weight",opt_set_consumed_weight(&writeScratchTag_, f.has_consumed_weight ? f.consumed_weight : cur_consumed));
-        if (f.has_brand_name || cur_brand[0] != '\0')
-            ATOMIC_SET("brand_name", opt_set_brand_name(&writeScratchTag_, f.has_brand_name ? f.brand_name : cur_brand));
-        if (f.has_density || cur_density > 0.0f)
-            ATOMIC_SET("density",    opt_set_density(&writeScratchTag_, f.has_density ? f.density : cur_density));
-        if (f.has_diameter || cur_diameter > 0.0f)
-            ATOMIC_SET("diameter",   opt_set_filament_diameter(&writeScratchTag_, f.has_diameter ? f.diameter_mm : cur_diameter));
-        if (f.has_material_name || cur_mat_name[0] != '\0')
-            ATOMIC_SET("material_name", opt_set_material_name(&writeScratchTag_, f.has_material_name ? f.material_name : cur_mat_name));
-        if (f.has_min_print_temp || cur_min_pt != 0)
-            ATOMIC_SET("min_print_temp", opt_set_min_print_temp(&writeScratchTag_, f.has_min_print_temp ? f.min_print_temp : cur_min_pt));
-        if (f.has_max_print_temp || cur_max_pt != 0)
-            ATOMIC_SET("max_print_temp", opt_set_max_print_temp(&writeScratchTag_, f.has_max_print_temp ? f.max_print_temp : cur_max_pt));
-        if (f.has_preheat_temp || cur_pre_t != 0)
-            ATOMIC_SET("preheat_temp",   opt_set_preheat_temp(&writeScratchTag_, f.has_preheat_temp ? f.preheat_temp : cur_pre_t));
-        if (f.has_min_bed_temp || cur_min_bt != 0)
-            ATOMIC_SET("min_bed_temp",   opt_set_min_bed_temp(&writeScratchTag_, f.has_min_bed_temp ? f.min_bed_temp : cur_min_bt));
-        if (f.has_max_bed_temp || cur_max_bt != 0)
-            ATOMIC_SET("max_bed_temp",   opt_set_max_bed_temp(&writeScratchTag_, f.has_max_bed_temp ? f.max_bed_temp : cur_max_bt));
-        // Spoolman ID goes in aux region
-        int32_t sm_id = f.has_spoolman_id ? f.spoolman_id : cur_sm_id;
-        if (sm_id > 0)
-            ATOMIC_SET("spoolman_id",    opt_set_gp_spoolman_id(&writeScratchTag_, sm_id));
-        #undef ATOMIC_SET
-
-        // Single-pass NFC write — no sequential drops, no scan loop race
-        Serial.println("NFCManager: WRITE_ATOMIC writing to NFC...");
-        opt_nfc_hal_t* hal = connection_->getHal();
-        err = opt_write_to_nfc(&writeScratchTag_, hal);
-        if (err != OPT_OK) {
-            Serial.printf("NFCManager: WRITE_ATOMIC NFC write failed: %s\n", opt_error_str(err));
-            return false;
-        }
-
-        // Verify with retries — re-read tag to confirm write succeeded
-        bool verified = false;
-        const int maxRetries = 3;
-        for (int retry = 0; retry < maxRetries; retry++) {
-            vTaskDelay(pdMS_TO_TICKS(50 * (retry + 1)));
-            err = opt_read_from_nfc(&writeScratchTag_, hal, 0, 78);
-            if (err == OPT_OK) {
-                err = opt_parse_ndef(&writeScratchTag_);
-                if (err == OPT_OK) { verified = true; break; }
-            }
-            Serial.printf("NFCManager: WRITE_ATOMIC verify retry %d: %s\n", retry + 1, opt_error_str(err));
-        }
-        if (!verified) {
-            Serial.println("NFCManager: WRITE_ATOMIC verification failed — not committing");
-            return false;
-        }
-
-        // Commit verified data to shared state under mutex
-        if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
-            Serial.println("NFCManager: WRITE_ATOMIC succeeded but commit lock failed");
-            return false;
-        }
-        currentSpool.tag_data = writeScratchTag_;
-        currentSpool.tag_data_valid = true;
-        currentSpool.blank_tag_present = false;
-        currentSpool.kind = TagKind::OpenPrintTag;
-        addToRecentSpools();
-        sendSpoolDetectedMessage();
-        xSemaphoreGive(tagMutex);
-
-        Serial.println("NFCManager: WRITE_ATOMIC complete");
-        return true;
-    }
-
-    // For non-FORMAT writes: take mutex to validate + modify in-memory data, then release for NFC I/O
+    // OpenPrintTag field-update writes (REMOVE_WEIGHT, CHANGE_COLOR, etc.)
+    // These modify existing CBOR tag data in-place
     if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
         Serial.println("NFCManager: executeWrite - could not acquire tagMutex");
         return false;

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -187,6 +187,99 @@ void NFCManager::scanTaskFunc(void* param) {
     self->scanLoop();
 }
 
+// ── NDEF helpers ────────────────────────────────────────────
+
+struct NdefRecord {
+    const char* mimeType;    // pointer into pageData (not owned)
+    uint8_t mimeLen;
+    uint32_t payloadLen;
+    uint16_t payloadOffset;  // offset from start of pageData
+    bool found;
+};
+
+// Scan TLV records in pageData for an NDEF media-type record.
+// Returns the first NDEF record found with TNF=media-type (0x02).
+static NdefRecord findNdefMediaRecord(const uint8_t* pageData, uint16_t bytesRead) {
+    NdefRecord rec = {};
+    uint16_t pos = 0;
+    while (pos < bytesRead) {
+        uint8_t tlvType = pageData[pos++];
+        if (tlvType == 0x00) continue;
+        if (tlvType == 0xFE) break;
+        if (pos >= bytesRead) break;
+
+        uint16_t tlvLen = pageData[pos++];
+        if (tlvLen == 0xFF) {
+            if (pos + 2 > bytesRead) break;
+            tlvLen = (uint16_t)(pageData[pos] << 8) | pageData[pos + 1];
+            pos += 2;
+        }
+
+        if (tlvType != 0x03) { pos += tlvLen; continue; }
+
+        uint16_t ndefStart = pos;
+        if (ndefStart >= bytesRead) break;
+
+        uint8_t ndefFlags = pageData[ndefStart];
+        uint8_t tnf = ndefFlags & 0x07;
+        if (tnf != 0x02 || ndefStart + 1 >= bytesRead) break;
+
+        uint8_t typeLen = pageData[ndefStart + 1];
+        bool sr = (ndefFlags & 0x10) != 0;
+        uint16_t headerSize = 2 + (sr ? 1 : 4);
+        if (ndefStart + headerSize + typeLen > bytesRead) break;
+
+        uint32_t payloadLen = 0;
+        if (sr) {
+            payloadLen = pageData[ndefStart + 2];
+        } else {
+            payloadLen = ((uint32_t)pageData[ndefStart + 2] << 24) |
+                         ((uint32_t)pageData[ndefStart + 3] << 16) |
+                         ((uint32_t)pageData[ndefStart + 4] << 8) |
+                         pageData[ndefStart + 5];
+        }
+
+        rec.mimeType = (const char*)(pageData + ndefStart + headerSize);
+        rec.mimeLen = typeLen;
+        rec.payloadLen = payloadLen;
+        rec.payloadOffset = ndefStart + headerSize + typeLen;
+        rec.found = true;
+        break;
+    }
+    return rec;
+}
+
+// Read NDEF payload bytes, doing an extended page read if the initial 40-byte read
+// didn't contain the full payload. Returns bytes copied into outBuf.
+uint16_t NFCManager::readNdefPayload(const NdefRecord& rec, const uint8_t* pageData, uint16_t bytesRead,
+                                      uint8_t* outBuf, uint16_t outBufSize) {
+    if (!rec.found || rec.payloadLen == 0) return 0;
+
+    uint16_t available = (rec.payloadOffset < bytesRead) ? bytesRead - rec.payloadOffset : 0;
+    uint16_t needed = (rec.payloadLen > outBufSize) ? outBufSize : (uint16_t)rec.payloadLen;
+
+    if (available >= rec.payloadLen) {
+        memcpy(outBuf, pageData + rec.payloadOffset, needed);
+        return needed;
+    }
+
+    // Extended read — payload spans beyond the initial 40-byte read
+    uint8_t startPage = 4 + (rec.payloadOffset / 4);
+    uint16_t pagesNeeded = (uint16_t)((rec.payloadLen + 3) / 4) + 1;
+    if (pagesNeeded > 50) pagesNeeded = 50;
+
+    uint8_t extBuf[256] = {0};
+    uint16_t extRead = connection_->readISO14443Pages(startPage, (uint8_t)pagesNeeded, extBuf, sizeof(extBuf));
+    uint16_t offsetInPage = rec.payloadOffset % 4;
+    if (extRead <= offsetInPage) return 0;
+
+    uint16_t payloadBytes = extRead - offsetInPage;
+    if (payloadBytes > rec.payloadLen) payloadBytes = (uint16_t)rec.payloadLen;
+    if (payloadBytes > outBufSize) payloadBytes = outBufSize;
+    memcpy(outBuf, extBuf + offsetInPage, payloadBytes);
+    return payloadBytes;
+}
+
 // ── ISO14443A tag read + classification ─────────────────────
 // Reads pages 4-13, tries TigerTag → OpenTag3D → OpenSpool → GenericUID.
 // Updates currentSpool state and sends the appropriate message.
@@ -216,136 +309,36 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
 
     // Scan NDEF TLV for OpenTag3D or OpenSpool
     if (!isTigerTag && bytesRead >= 4) {
-        uint16_t pos = 0;
-        while (pos < bytesRead) {
-            uint8_t tlvType = pageData[pos++];
-            if (tlvType == 0x00) continue;
-            if (tlvType == 0xFE) break;
-            if (pos >= bytesRead) break;
-
-            uint16_t tlvLen = pageData[pos++];
-            if (tlvLen == 0xFF) {
-                if (pos + 2 > bytesRead) break;
-                tlvLen = (uint16_t)(pageData[pos] << 8) | pageData[pos + 1];
-                pos += 2;
-            }
-
-            if (tlvType == 0x03) {
-                uint16_t ndefStart = pos;
-                if (ndefStart >= bytesRead) break;
-
-                uint8_t ndefFlags = pageData[ndefStart];
-                uint8_t tnf = ndefFlags & 0x07;
-                if (tnf == 0x02 && ndefStart + 1 < bytesRead) {
-                    uint8_t typeLen = pageData[ndefStart + 1];
-                    bool sr = (ndefFlags & 0x10) != 0;
-                    uint16_t headerSize = 2 + (sr ? 1 : 4);
-                    if (ndefStart + headerSize + typeLen <= bytesRead) {
-                        const char* mime = OT3D_MIME_TYPE;
-                        size_t mimeLen = strlen(mime);
-                        if (typeLen == mimeLen &&
-                            memcmp(pageData + ndefStart + headerSize, mime, mimeLen) == 0) {
-                            uint32_t payloadLen = 0;
-                            if (sr) {
-                                payloadLen = pageData[ndefStart + 2];
-                            } else {
-                                payloadLen = ((uint32_t)pageData[ndefStart + 2] << 24) |
-                                             ((uint32_t)pageData[ndefStart + 3] << 16) |
-                                             ((uint32_t)pageData[ndefStart + 4] << 8) |
-                                             pageData[ndefStart + 5];
-                            }
-
-                            uint16_t payloadOffset = ndefStart + headerSize + typeLen;
-                            uint16_t availableInFirstRead = (payloadOffset < bytesRead) ? bytesRead - payloadOffset : 0;
-
-                            uint8_t fullPayload[OT3D_EXTENDED_MIN];
-                            uint16_t payloadBytes = 0;
-
-                            if (availableInFirstRead >= payloadLen) {
-                                memcpy(fullPayload, pageData + payloadOffset, payloadLen);
-                                payloadBytes = (uint16_t)payloadLen;
-                            } else {
-                                uint8_t payloadStartPage = 4 + (payloadOffset / 4);
-                                uint16_t totalPagesNeeded = (uint16_t)((payloadLen + 3) / 4) + 1;
-                                if (totalPagesNeeded > 50) totalPagesNeeded = 50;
-
-                                uint8_t extendedData[200] = {0};
-                                uint16_t extendedRead = connection_->readISO14443Pages(
-                                    payloadStartPage, (uint8_t)totalPagesNeeded, extendedData, sizeof(extendedData));
-
-                                uint16_t offsetInPage = payloadOffset % 4;
-                                if (extendedRead > offsetInPage) {
-                                    payloadBytes = extendedRead - offsetInPage;
-                                    if (payloadBytes > payloadLen) payloadBytes = (uint16_t)payloadLen;
-                                    if (payloadBytes > sizeof(fullPayload)) payloadBytes = sizeof(fullPayload);
-                                    memcpy(fullPayload, extendedData + offsetInPage, payloadBytes);
-                                }
-                            }
-
-                            if (payloadBytes >= OT3D_CORE_SIZE) {
-                                opentag3d_result_t res = opentag3d_decode(fullPayload, payloadBytes, &ot3dData);
-                                if (res == OT3D_OK || res == OT3D_VERSION_WARNING) {
-                                    isOpenTag3D = true;
-                                    if (res == OT3D_VERSION_WARNING) {
-                                        Serial.printf("NFCManager: OpenTag3D tag version %u ahead of supported %u — parsing anyway\n",
-                                                      ot3dData.tag_version, OT3D_SUPPORTED_VERSION);
-                                    }
-                                } else if (res == OT3D_VERSION_ERROR) {
-                                    Serial.printf("NFCManager: OpenTag3D major version too new (%u) — cannot parse\n",
-                                                  ot3dData.tag_version);
-                                }
-                            }
+        NdefRecord rec = findNdefMediaRecord(pageData, bytesRead);
+        if (rec.found) {
+            const char* ot3dMime = OT3D_MIME_TYPE;
+            if (rec.mimeLen == strlen(ot3dMime) && memcmp(rec.mimeType, ot3dMime, rec.mimeLen) == 0) {
+                uint8_t payload[OT3D_EXTENDED_MIN];
+                uint16_t payloadBytes = readNdefPayload(rec, pageData, bytesRead, payload, sizeof(payload));
+                if (payloadBytes >= OT3D_CORE_SIZE) {
+                    opentag3d_result_t res = opentag3d_decode(payload, payloadBytes, &ot3dData);
+                    if (res == OT3D_OK || res == OT3D_VERSION_WARNING) {
+                        isOpenTag3D = true;
+                        if (res == OT3D_VERSION_WARNING) {
+                            Serial.printf("NFCManager: OpenTag3D tag version %u ahead of supported %u — parsing anyway\n",
+                                          ot3dData.tag_version, OT3D_SUPPORTED_VERSION);
                         }
-
-                        // Check for OpenSpool (application/json + "protocol":"openspool")
-                        if (!isOpenTag3D) {
-                            const char* jsonMime = "application/json";
-                            size_t jsonMimeLen = strlen(jsonMime);
-                            if (typeLen == jsonMimeLen &&
-                                memcmp(pageData + ndefStart + headerSize, jsonMime, jsonMimeLen) == 0) {
-                                uint32_t osPayloadLen = 0;
-                                if (sr) {
-                                    osPayloadLen = pageData[ndefStart + 2];
-                                } else {
-                                    osPayloadLen = ((uint32_t)pageData[ndefStart + 2] << 24) |
-                                                   ((uint32_t)pageData[ndefStart + 3] << 16) |
-                                                   ((uint32_t)pageData[ndefStart + 4] << 8) |
-                                                   pageData[ndefStart + 5];
-                                }
-                                uint16_t osOffset = ndefStart + headerSize + typeLen;
-                                uint8_t osPayload[256] = {0};
-                                uint16_t osBytes = 0;
-
-                                if (osOffset + osPayloadLen <= bytesRead) {
-                                    osBytes = (uint16_t)osPayloadLen;
-                                    if (osBytes > sizeof(osPayload)) osBytes = sizeof(osPayload);
-                                    memcpy(osPayload, pageData + osOffset, osBytes);
-                                } else {
-                                    uint8_t osStartPage = 4 + (osOffset / 4);
-                                    uint16_t osPagesNeeded = (uint16_t)((osPayloadLen + 3) / 4) + 1;
-                                    if (osPagesNeeded > 50) osPagesNeeded = 50;
-                                    uint8_t osExtData[256] = {0};
-                                    uint16_t osExtRead = connection_->readISO14443Pages(
-                                        osStartPage, (uint8_t)osPagesNeeded, osExtData, sizeof(osExtData));
-                                    uint16_t osOffInPage = osOffset % 4;
-                                    if (osExtRead > osOffInPage) {
-                                        osBytes = osExtRead - osOffInPage;
-                                        if (osBytes > osPayloadLen) osBytes = (uint16_t)osPayloadLen;
-                                        if (osBytes > sizeof(osPayload)) osBytes = sizeof(osPayload);
-                                        memcpy(osPayload, osExtData + osOffInPage, osBytes);
-                                    }
-                                }
-
-                                if (osBytes > 0 && parseOpenSpool(osPayload, osBytes, openSpoolData)) {
-                                    isOpenSpool = true;
-                                }
-                            }
-                        }
+                    } else if (res == OT3D_VERSION_ERROR) {
+                        Serial.printf("NFCManager: OpenTag3D major version too new (%u) — cannot parse\n",
+                                      ot3dData.tag_version);
                     }
                 }
-                break;
-            } else {
-                pos += tlvLen;
+            }
+
+            if (!isOpenTag3D) {
+                const char* jsonMime = "application/json";
+                if (rec.mimeLen == strlen(jsonMime) && memcmp(rec.mimeType, jsonMime, rec.mimeLen) == 0) {
+                    uint8_t payload[256];
+                    uint16_t payloadBytes = readNdefPayload(rec, pageData, bytesRead, payload, sizeof(payload));
+                    if (payloadBytes > 0 && parseOpenSpool(payload, payloadBytes, openSpoolData)) {
+                        isOpenSpool = true;
+                    }
+                }
             }
         }
     }

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -406,161 +406,105 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
     }
 }
 
-void NFCManager::scanLoop() {
-    uint32_t scanCount = 0;
-    uint32_t detectCount = 0;
-    uint32_t failCount = 0;
+// ── Scan loop helpers ───────────────────────────────────────
 
-    Serial.println("NFCManager: scanLoop() started, polling every 50ms");
-
+bool NFCManager::prepareRF() {
+    if (consecutiveFailures_ >= RESTART_THRESHOLD) {
+        Serial.println("NFCManager: CRITICAL - too many consecutive failures, restarting ESP");
 #ifndef NATIVE_TEST
-    // Register this task with the ESP32 hardware watchdog.
-    // If scanLoop() hangs for >NFC_WDT_TIMEOUT_S (e.g., stuck in driver I/O),
-    // the watchdog triggers a system reset automatically.
-    esp_task_wdt_init(NFC_WDT_TIMEOUT_S, true);
-    esp_task_wdt_add(NULL);
+        delay(100);
+        ESP.restart();
 #endif
+    }
+    if (consecutiveFailures_ > 0 && (consecutiveFailures_ % RECOVERY_THRESHOLD) == 0) {
+        attemptRecovery();
+    }
 
-    // Initial reset + RF setup
-    connection_->reset();
-    connection_->setupRF();
-
-    // One-time startup diagnostic
-    connection_->logDiagnostics();
-
-    while (true) {
-#ifndef NATIVE_TEST
-        esp_task_wdt_reset();
-#endif
-        uint8_t uid[8];
-        uint8_t uidLength = 0;
-        scanCount++;
-
-        // Log heartbeat every 200 scans (~10 seconds)
-        //if (scanCount % 200 == 0) {
-        //    Serial.printf("NFCManager: heartbeat scan=%lu detected=%lu failed=%lu\n",
-        //                  scanCount, detectCount, failCount);
-        //}
-
-        // Watchdog: check if we've exceeded failure thresholds
-        if (consecutiveFailures_ >= RESTART_THRESHOLD) {
-            Serial.println("NFCManager: CRITICAL - too many consecutive failures, restarting ESP");
-#ifndef NATIVE_TEST
-            delay(100);  // let serial flush
-            ESP.restart();
-#endif
+    // Full hardware reset only when no tag present — reset cuts RF, de-powering passive tags
+    if (!lastSeenValid) {
+        connection_->reset();
+    }
+    if (!connection_->setupRF()) {
+        consecutiveFailures_++;
+        Serial.printf("NFCManager: setupRF() failed (consecutive=%lu, lastSeenValid=%d)\n",
+                      consecutiveFailures_, lastSeenValid ? 1 : 0);
+        if (lastSeenValid) {
+            Serial.println("NFCManager: clearing lastSeenValid to force hardware reset");
+            lastSeenValid = false;
         }
-        if (consecutiveFailures_ > 0 && (consecutiveFailures_ % RECOVERY_THRESHOLD) == 0) {
-            attemptRecovery();
-        }
+        return false;
+    }
 
-        // Re-arm RF field for each scan.
-        // Only do a full hardware reset when no tag is present — reset briefly cuts the RF
-        // field, de-powering any passive tag in the field and causing false TAG_REMOVED events.
-        // When a tag is already detected, only re-arm the transceiver state via setupRF().
-        if (!lastSeenValid) {
+    // Give tag time to power up after RF field reset
+    if (!lastSeenValid) {
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    consecutiveFailures_ = 0;
+    return true;
+}
+
+bool NFCManager::isSkippableDuplicate(const uint8_t* uid, uint8_t uidLength) {
+    if (isDuplicateSpool(uid, uidLength)) return true;
+
+    if (!suppressReDetection_) return false;
+
+    char uidHex[17];
+    for (uint8_t i = 0; i < uidLength && i < 8; i++) {
+        sprintf(uidHex + (i * 2), "%02X", uid[i]);
+    }
+    uidHex[uidLength * 2] = '\0';
+    return strcmp(uidHex, suppressReDetectionUid_) == 0;
+}
+
+void NFCManager::handleNewTag(uint8_t* uid, uint8_t uidLength) {
+    Serial.println("NFCManager: New spool detected, reading tag...");
+    TagScanResult scan = classifyTag(uid, uidLength);
+
+    if (scan.kind == TagKind::BambuTag) {
+        if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+            memcpy(currentSpool.spool_id, scan.uid_hex, sizeof(scan.uid_hex));
+            memcpy(currentSpool.uid, uid, uidLength);
+            currentSpool.uid_length = uidLength;
+            currentSpool.present = true;
+            currentSpool.blank_tag_present = false;
+            currentSpool.kind = TagKind::BambuTag;
+            currentSpool.tag_data_valid = false;
+            lastTigerTagValid_ = false;
+            memcpy(lastSeenUid, uid, uidLength);
+            lastSeenUidLength = uidLength;
+            lastSeenValid = true;
+            lastSeenMs = millis();
+            xSemaphoreGive(tagMutex);
+        }
+        Serial.printf("NFCManager: Bambu Lab tag — UID=%s (encrypted, no data access)\n", scan.uid_hex);
+        sendGenericTagMessage();
+        return;
+    }
+
+    if (scan.kind == TagKind::GenericUidTag) {
+        readAndProcessISO14443Tag(uid, uidLength, scan);
+        return;
+    }
+
+    // ISO15693 — attempt OpenPrintTag parse with retries
+    bool readOk = false;
+    for (int attempt = 0; attempt < 3 && !readOk; attempt++) {
+        if (attempt > 0) {
+            Serial.printf("NFCManager: Read attempt %d — resetting RF...\n", attempt + 1);
             connection_->reset();
+            bool rfOk = connection_->setupRF();
+            Serial.printf("NFCManager: setupRF after reset: %s\n", rfOk ? "OK" : "FAILED");
+            vTaskDelay(pdMS_TO_TICKS(100));
         }
-        if (!connection_->setupRF()) {
-            consecutiveFailures_++;
-            Serial.printf("NFCManager: setupRF() failed (consecutive=%lu, lastSeenValid=%d)\n",
-                          consecutiveFailures_, lastSeenValid ? 1 : 0);
-            // If RF is stuck with a tag still marked present, clear the flag so the
-            // next iteration performs a full reset() before retrying setupRF().
-            if (lastSeenValid) {
-                Serial.println("NFCManager: clearing lastSeenValid to force hardware reset");
-                lastSeenValid = false;
-            }
-            vTaskDelay(pdMS_TO_TICKS(50));
-            continue;
-        }
+        Serial.printf("NFCManager: readAndParseTag attempt %d\n", attempt + 1);
+        readOk = readAndParseTag(uid, uidLength);
+        Serial.printf("NFCManager: readAndParseTag attempt %d: %s\n", attempt + 1, readOk ? "OK" : "FAILED");
+    }
 
-        // Give tag time to power up from RF field before sending inventory.
-        // Only needed after a reset (which cuts RF); skip when tag is already present.
-        if (!lastSeenValid) {
-            vTaskDelay(pdMS_TO_TICKS(10));
-        }
+    if (readOk) return;
 
-        // setupRF succeeded, chip is responsive
-        consecutiveFailures_ = 0;
-
-        // Detect tag
-        if (connection_->detectTag(uid, &uidLength)) {
-            detectCount++;
-            // Log UID on first detection
-            if (!lastSeenValid || memcmp(uid, lastSeenUid, uidLength) != 0) {
-                Serial.printf("NFCManager: Tag detected! UID=");
-                for (uint8_t i = 0; i < uidLength; i++) {
-                    Serial.printf("%02X", uid[i]);
-                }
-                Serial.println("");
-            }
-
-            // Store UID for addressed read/write commands
-            connection_->setCurrentUid(uid, uidLength);
-
-            // Check if this is the same spool we already processed
-            // Also suppress re-detection if writes are in progress for this tag
-            bool shouldSkipReRead = isDuplicateSpool(uid, uidLength);
-
-            if (suppressReDetection_) {
-                char uidHex[17];
-                for (uint8_t i = 0; i < uidLength && i < 8; i++) {
-                    sprintf(uidHex + (i * 2), "%02X", uid[i]);
-                }
-                uidHex[uidLength * 2] = '\0';
-
-                if (strcmp(uidHex, suppressReDetectionUid_) == 0) {
-                    shouldSkipReRead = true;  // Skip re-read for tag being written to
-                }
-            }
-
-            if (!shouldSkipReRead) {
-                Serial.println("NFCManager: New spool detected, reading tag...");
-                TagScanResult scan = classifyTag(uid, uidLength);
-
-                if (scan.kind == TagKind::BambuTag) {
-                    // Bambu Lab MIFARE Classic — UID-only (data is encrypted)
-                    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-                        memcpy(currentSpool.spool_id, scan.uid_hex, sizeof(scan.uid_hex));
-                        memcpy(currentSpool.uid, uid, uidLength);
-                        currentSpool.uid_length = uidLength;
-                        currentSpool.present = true;
-                        currentSpool.blank_tag_present = false;
-                        currentSpool.kind = TagKind::BambuTag;
-                        currentSpool.tag_data_valid = false;
-                        lastTigerTagValid_ = false;
-                        memcpy(lastSeenUid, uid, uidLength);
-                        lastSeenUidLength = uidLength;
-                        lastSeenValid = true;
-                        lastSeenMs = millis();
-                        xSemaphoreGive(tagMutex);
-                    }
-                    Serial.printf("NFCManager: Bambu Lab tag — UID=%s (encrypted, no data access)\n", scan.uid_hex);
-                    sendGenericTagMessage();
-                } else if (scan.kind == TagKind::GenericUidTag) {
-                    readAndProcessISO14443Tag(uid, uidLength, scan);
-                } else {
-
-                // ISO15693 — attempt OpenPrintTag parse
-                // readAndParseTag manages its own mutex internally
-                bool readOk = false;
-                for (int attempt = 0; attempt < 3 && !readOk; attempt++) {
-                    if (attempt > 0) {
-                        Serial.printf("NFCManager: Read attempt %d — resetting RF...\n", attempt + 1);
-                        connection_->reset();
-                        bool rfOk = connection_->setupRF();
-                        Serial.printf("NFCManager: setupRF after reset: %s\n", rfOk ? "OK" : "FAILED");
-                        vTaskDelay(pdMS_TO_TICKS(100));
-                    }
-                    Serial.printf("NFCManager: readAndParseTag attempt %d\n", attempt + 1);
-                    readOk = readAndParseTag(uid, uidLength);
-                    Serial.printf("NFCManager: readAndParseTag attempt %d: %s\n", attempt + 1, readOk ? "OK" : "FAILED");
-                }
-if (!readOk) {
+    // All retries failed — treat as blank tag
     Serial.println("NFCManager: readAndParseTag() failed after retries - treating as blank tag");
-
-    bool blankStateCaptured = false;
     if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
         for (uint8_t i = 0; i < uidLength && i < 8; i++) {
             sprintf(currentSpool.spool_id + (i * 2), "%02X", uid[i]);
@@ -572,54 +516,74 @@ if (!readOk) {
         currentSpool.tag_data_valid = false;
         currentSpool.blank_tag_present = true;
         currentSpool.kind = TagKind::BlankTag;
-
         memcpy(lastSeenUid, uid, uidLength);
         lastSeenUidLength = uidLength;
         lastSeenValid = true;
         lastSeenMs = millis();
-        blankStateCaptured = true;
         xSemaphoreGive(tagMutex);
-    } else {
-        Serial.println("NFCManager: Could not acquire tagMutex");
-    }
-
-    if (blankStateCaptured) {
         sendBlankTagMessage();
     }
 }
-                } // end ISO15693 else branch
-            } else {
-                // Tag is a duplicate - skip re-reading
-                // This log would be too verbose (every 50ms), so commenting out
-                // Serial.println("NFCManager: Same tag detected, skipping read");
-            }
 
-            // Process any pending write requests while tag is present
-            processWriteQueue();
-        } else {
-            // No tag detected - clear state
-            if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-                if (lastSeenValid) {
-                    Serial.println("NFCManager: Tag removed");
+void NFCManager::handleTagAbsent() {
+    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) != pdTRUE) return;
 
-                    // Send TAG_REMOVED message before clearing state
-                    sendTagRemovedMessage();
-                }
-                currentSpool.present = false;
-                currentSpool.blank_tag_present = false;
-                lastSeenValid = false;
-                lastTigerTagValid_ = false;
-                lastOpenTag3DValid_ = false;
+    if (lastSeenValid) {
+        Serial.println("NFCManager: Tag removed");
+        sendTagRemovedMessage();
+    }
+    currentSpool.present = false;
+    currentSpool.blank_tag_present = false;
+    lastSeenValid = false;
+    lastTigerTagValid_ = false;
+    lastOpenTag3DValid_ = false;
+    suppressReDetection_ = false;
+    suppressReDetectionUid_[0] = '\0';
+    xSemaphoreGive(tagMutex);
+}
 
-                // Clear suppression if tag removed
-                suppressReDetection_ = false;
-                suppressReDetectionUid_[0] = '\0';
+// ── Main scan loop ──────────────────────────────────────────
 
-                xSemaphoreGive(tagMutex);
-            }
+void NFCManager::scanLoop() {
+    Serial.println("NFCManager: scanLoop() started, polling every 50ms");
+
+#ifndef NATIVE_TEST
+    esp_task_wdt_init(NFC_WDT_TIMEOUT_S, true);
+    esp_task_wdt_add(NULL);
+#endif
+
+    connection_->reset();
+    connection_->setupRF();
+    connection_->logDiagnostics();
+
+    while (true) {
+#ifndef NATIVE_TEST
+        esp_task_wdt_reset();
+#endif
+        uint8_t uid[8];
+        uint8_t uidLength = 0;
+
+        if (!prepareRF()) {
+            vTaskDelay(pdMS_TO_TICKS(50));
+            continue;
         }
 
-        // Small delay to prevent tight loop
+        if (connection_->detectTag(uid, &uidLength)) {
+            if (!lastSeenValid || memcmp(uid, lastSeenUid, uidLength) != 0) {
+                Serial.printf("NFCManager: Tag detected! UID=");
+                for (uint8_t i = 0; i < uidLength; i++) Serial.printf("%02X", uid[i]);
+                Serial.println("");
+            }
+            connection_->setCurrentUid(uid, uidLength);
+
+            if (!isSkippableDuplicate(uid, uidLength)) {
+                handleNewTag(uid, uidLength);
+            }
+            processWriteQueue();
+        } else {
+            handleTagAbsent();
+        }
+
         vTaskDelay(pdMS_TO_TICKS(50));
     }
 }

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -130,6 +130,12 @@ private:
     void sendTagRemovedMessage();
     void processWriteQueue();
     bool executeWrite(const NFCWriteRequest& request);
+    bool validateWriteUid(const char* expectedUid, const char* writeType);
+    bool executeTigerTagWrite(const NFCWriteRequest& request);
+    bool executeOpenTag3DWrite(const NFCWriteRequest& request);
+    bool executeOpenSpoolWrite(const NFCWriteRequest& request);
+    bool executeAtomicWrite(const NFCWriteRequest& request);
+    void forceRescan();
     void sendSpoolUpdatedMessage(uint32_t request_id, NFCWriteType type, bool success);
 
     // Deduplication

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -116,6 +116,10 @@ private:
     // Scan task
     static void scanTaskFunc(void* param);
     void scanLoop();
+    bool prepareRF();
+    bool isSkippableDuplicate(const uint8_t* uid, uint8_t uidLength);
+    void handleNewTag(uint8_t* uid, uint8_t uidLength);
+    void handleTagAbsent();
 
     // Internal operations
     bool readAndParseTag(uint8_t* uid, uint8_t uid_length);

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -119,6 +119,7 @@ private:
 
     // Internal operations
     bool readAndParseTag(uint8_t* uid, uint8_t uid_length);
+    void readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength, const TagScanResult& scan);
     bool formatNewSpool();
     TagScanResult classifyTag(const uint8_t* uid, uint8_t uid_length);
     void sendSpoolDetectedMessage(bool suppress_spoolman_sync = false);

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -120,6 +120,8 @@ private:
     // Internal operations
     bool readAndParseTag(uint8_t* uid, uint8_t uid_length);
     void readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength, const TagScanResult& scan);
+    uint16_t readNdefPayload(const struct NdefRecord& rec, const uint8_t* pageData, uint16_t bytesRead,
+                              uint8_t* outBuf, uint16_t outBufSize);
     bool formatNewSpool();
     TagScanResult classifyTag(const uint8_t* uid, uint8_t uid_length);
     void sendSpoolDetectedMessage(bool suppress_spoolman_sync = false);

--- a/src/PrinterManager.cpp
+++ b/src/PrinterManager.cpp
@@ -266,97 +266,86 @@ void PrinterManager::handleJobDisappeared() {
 // Fix #3: Retries during tracking, separate flags for mismatch vs temp
 // ---------------------------------------------------------------------------
 
+// Map OPT material enum to PrusaLink-compatible filament type string
+static const char* optMaterialToString(uint8_t mat) {
+    switch (mat) {
+        case OPT_MATERIAL_TYPE_PLA:  return "PLA";
+        case OPT_MATERIAL_TYPE_PETG: return "PETG";
+        case OPT_MATERIAL_TYPE_TPU:  return "TPU";
+        case OPT_MATERIAL_TYPE_ABS:  return "ABS";
+        case OPT_MATERIAL_TYPE_ASA:  return "ASA";
+        case OPT_MATERIAL_TYPE_PC:   return "PC";
+        case OPT_MATERIAL_TYPE_PCTG: return "PCTG";
+        case OPT_MATERIAL_TYPE_PP:   return "PP";
+        case OPT_MATERIAL_TYPE_PA6:
+        case OPT_MATERIAL_TYPE_PA11:
+        case OPT_MATERIAL_TYPE_PA12:
+        case OPT_MATERIAL_TYPE_PA66: return "PA";
+        case OPT_MATERIAL_TYPE_HIPS: return "HIPS";
+        case OPT_MATERIAL_TYPE_PVA:  return "PVA";
+        case OPT_MATERIAL_TYPE_PET:  return "PET";
+        default:                     return nullptr;
+    }
+}
+
+static void sendPrinterWarning(const char* type, const char* expected, const char* actual,
+                                float gcodeTemp = 0, int16_t tagMaxTemp = 0) {
+    AppMessage warn;
+    warn.type = AppMessageType::PRINTER_WARNING;
+    memset(&warn.payload.printerWarning, 0, sizeof(warn.payload.printerWarning));
+    strncpy(warn.payload.printerWarning.warning_type, type,
+            sizeof(warn.payload.printerWarning.warning_type) - 1);
+    if (expected) strncpy(warn.payload.printerWarning.expected, expected,
+                          sizeof(warn.payload.printerWarning.expected) - 1);
+    if (actual) strncpy(warn.payload.printerWarning.actual, actual,
+                        sizeof(warn.payload.printerWarning.actual) - 1);
+    warn.payload.printerWarning.gcode_temp = gcodeTemp;
+    warn.payload.printerWarning.tag_max_temp = tagMaxTemp;
+    ApplicationManager::getInstance().sendMessage(warn);
+}
+
 void PrinterManager::checkFilamentMismatch() {
     if (!strategy_) return;
 
-    // Get current spool from NFCManager
     CurrentSpoolState spool;
     if (!NFCManager::getInstance().getCurrentSpoolState(spool)) return;
-    if (!spool.present || !spool.tag_data_valid) {
-        // Spool not ready yet — leave validationPending_ true so we retry next poll
-        return;
-    }
+    if (!spool.present || !spool.tag_data_valid) return;
 
-    // Spool data is available — we won't need to retry
     validationPending_ = false;
 
-    // --- Filament type mismatch check ---
+    // Filament type check
     if (!mismatchWarned_) {
         const char* expected = strategy_->getExpectedFilamentType();
         if (expected[0] != '\0') {
             uint8_t tagMaterial = 0;
             opt_get_material_type(&spool.tag_data, &tagMaterial);
+            const char* tagStr = optMaterialToString(tagMaterial);
 
-            // Map openprinttag enum to PrusaLink filament_type strings
-            const char* tagMaterialStr = nullptr;
-            switch (tagMaterial) {
-                case OPT_MATERIAL_TYPE_PLA:  tagMaterialStr = "PLA"; break;
-                case OPT_MATERIAL_TYPE_PETG: tagMaterialStr = "PETG"; break;
-                case OPT_MATERIAL_TYPE_TPU:  tagMaterialStr = "TPU"; break;
-                case OPT_MATERIAL_TYPE_ABS:  tagMaterialStr = "ABS"; break;
-                case OPT_MATERIAL_TYPE_ASA:  tagMaterialStr = "ASA"; break;
-                case OPT_MATERIAL_TYPE_PC:   tagMaterialStr = "PC"; break;
-                case OPT_MATERIAL_TYPE_PCTG: tagMaterialStr = "PCTG"; break;
-                case OPT_MATERIAL_TYPE_PP:   tagMaterialStr = "PP"; break;
-                case OPT_MATERIAL_TYPE_PA6:  tagMaterialStr = "PA"; break;
-                case OPT_MATERIAL_TYPE_PA11: tagMaterialStr = "PA"; break;
-                case OPT_MATERIAL_TYPE_PA12: tagMaterialStr = "PA"; break;
-                case OPT_MATERIAL_TYPE_PA66: tagMaterialStr = "PA"; break;
-                case OPT_MATERIAL_TYPE_HIPS: tagMaterialStr = "HIPS"; break;
-                case OPT_MATERIAL_TYPE_PVA:  tagMaterialStr = "PVA"; break;
-                case OPT_MATERIAL_TYPE_PET:  tagMaterialStr = "PET"; break;
-                default: tagMaterialStr = nullptr; break;
-            }
-
-            if (tagMaterialStr != nullptr) {
-                if (strncasecmp(expected, tagMaterialStr, strlen(tagMaterialStr)) != 0) {
-                    mismatchWarned_ = true;
-                    Serial.printf("PrinterManager: FILAMENT MISMATCH — gcode expects '%s', tag has '%s'\n",
-                                  expected, tagMaterialStr);
-
-                    AppMessage warn;
-                    warn.type = AppMessageType::PRINTER_WARNING;
-                    memset(&warn.payload.printerWarning, 0, sizeof(warn.payload.printerWarning));
-                    strncpy(warn.payload.printerWarning.warning_type, "filament_mismatch",
-                            sizeof(warn.payload.printerWarning.warning_type) - 1);
-                    strncpy(warn.payload.printerWarning.expected, expected,
-                            sizeof(warn.payload.printerWarning.expected) - 1);
-                    strncpy(warn.payload.printerWarning.actual, tagMaterialStr,
-                            sizeof(warn.payload.printerWarning.actual) - 1);
-                    ApplicationManager::getInstance().sendMessage(warn);
+            if (tagStr) {
+                mismatchWarned_ = true;
+                if (strncasecmp(expected, tagStr, strlen(tagStr)) != 0) {
+                    Serial.printf("PrinterManager: FILAMENT MISMATCH — gcode expects '%s', tag has '%s'\n", expected, tagStr);
+                    sendPrinterWarning("filament_mismatch", expected, tagStr);
                 } else {
-                    mismatchWarned_ = true;  // matched — don't check again
-                    Serial.printf("PrinterManager: Filament OK — gcode '%s' matches tag '%s'\n",
-                                  expected, tagMaterialStr);
+                    Serial.printf("PrinterManager: Filament OK — gcode '%s' matches tag '%s'\n", expected, tagStr);
                 }
             }
         }
     }
 
-    // --- Temperature range check (independent from filament type) ---
+    // Temperature range check
     if (!tempWarned_) {
         float gcodeNozzle = strategy_->getExpectedNozzleTemp();
-        if (gcodeNozzle > 0.0f) {
-            int16_t tagMaxTemp = 0;
-            opt_get_max_print_temp(&spool.tag_data, &tagMaxTemp);
-            if (tagMaxTemp > 0) {
-                if (gcodeNozzle > static_cast<float>(tagMaxTemp) + 10.0f) {
-                    tempWarned_ = true;
-                    Serial.printf("PrinterManager: TEMP WARNING — gcode %.0fC exceeds tag max %dC\n",
-                                  gcodeNozzle, tagMaxTemp);
+        if (gcodeNozzle <= 0.0f) return;
 
-                    AppMessage warn;
-                    warn.type = AppMessageType::PRINTER_WARNING;
-                    memset(&warn.payload.printerWarning, 0, sizeof(warn.payload.printerWarning));
-                    strncpy(warn.payload.printerWarning.warning_type, "temp_exceeds_max",
-                            sizeof(warn.payload.printerWarning.warning_type) - 1);
-                    warn.payload.printerWarning.gcode_temp = gcodeNozzle;
-                    warn.payload.printerWarning.tag_max_temp = tagMaxTemp;
-                    ApplicationManager::getInstance().sendMessage(warn);
-                } else {
-                    tempWarned_ = true;  // within range — don't check again
-                }
-            }
+        int16_t tagMaxTemp = 0;
+        opt_get_max_print_temp(&spool.tag_data, &tagMaxTemp);
+        if (tagMaxTemp <= 0) return;
+
+        tempWarned_ = true;
+        if (gcodeNozzle > static_cast<float>(tagMaxTemp) + 10.0f) {
+            Serial.printf("PrinterManager: TEMP WARNING — gcode %.0fC exceeds tag max %dC\n", gcodeNozzle, tagMaxTemp);
+            sendPrinterWarning("temp_exceeds_max", nullptr, nullptr, gcodeNozzle, tagMaxTemp);
         }
     }
 }

--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -231,9 +231,9 @@ static int httpPatch(const char* path, const char* body, String& response) {
     return code;
 }
 
-// Stream-parse Spoolman spool list to find a spool with matching nfc_id.
-// Reads the HTTP response in chunks (~512 bytes) instead of buffering the
-// entire response in memory. Uses ~600 bytes of heap regardless of spool count.
+// Find a spool by nfc_id using ArduinoJson streaming filter.
+// Only id, archived, and extra.nfc_id are parsed — everything else is skipped,
+// keeping memory usage low (~4KB) regardless of how many spools exist.
 static int streamFindSpoolByNfcId(const char* path, const char* uuid) {
     const char* baseUrl = ConfigurationManager::getInstance().getSpoolmanURL();
     char url[256];
@@ -241,7 +241,7 @@ static int streamFindSpoolByNfcId(const char* path, const char* uuid) {
 
     WiFiClient streamClient;
     HTTPClient streamHttp;
-    streamHttp.useHTTP10(true);  // Avoid chunked encoding for streaming parse
+    streamHttp.useHTTP10(true);
     streamHttp.begin(streamClient, url);
     streamHttp.setTimeout(10000);
     int code = streamHttp.GET();
@@ -249,181 +249,45 @@ static int streamFindSpoolByNfcId(const char* path, const char* uuid) {
     if (code != 200) {
         Serial.printf("SpoolmanManager: streamFind HTTP %d for %s\n", code, path);
         streamHttp.end();
-        return -2;  // error (distinct from -1 = not found)
+        return -2;
     }
 
-    WiFiClient* stream = streamHttp.getStreamPtr();
+    // Filter: only extract id, archived, and extra.nfc_id from each spool
+    JsonDocument filter;
+    filter[0]["id"] = true;
+    filter[0]["archived"] = true;
+    filter[0]["extra"]["nfc_id"] = true;
+
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, *streamHttp.getStreamPtr(),
+                                                DeserializationOption::Filter(filter));
+    streamHttp.end();
+
+    if (err) {
+        Serial.printf("SpoolmanManager: streamFind parse error: %s\n", err.c_str());
+        return -2;
+    }
+
+    // Build quoted UID for comparison ("04A651AD8F6180")
+    char quotedUuid[130];
+    snprintf(quotedUuid, sizeof(quotedUuid), "\"%s\"", uuid);
 
     int bestMatchId = -1;
-    int currentId = -1;
-    bool nfcIdMatched = false;  // true if nfc_id matched in current spool object
-    int depth = 0;
-    bool inExtra = false;
-    int extraDepth = 0;
-
-    char buf[512];
-    char keyBuf[16] = {};
-    int keyPos = 0;
-    char valBuf[80] = {};
-    int valPos = 0;
-    bool inString = false;
-    bool escaped = false;
-    bool inKey = false;
-    bool inValue = false;
-    bool inNumValue = false;
-
-    unsigned long lastData = millis();
-    bool timedOut = false;
-
-    while (stream->available() || stream->connected()) {
-        if (millis() - lastData > 10000) {
-            Serial.println("SpoolmanManager: streamFind timeout");
-            timedOut = true;
-            break;
-        }
-
-        int avail = stream->available();
-        if (avail <= 0) { delay(1); continue; }
-        lastData = millis();
-
-        int toRead = avail > (int)sizeof(buf) ? (int)sizeof(buf) : avail;
-        int bytesRead = stream->readBytes(buf, toRead);
-
-        for (int i = 0; i < bytesRead; i++) {
-            char c = buf[i];
-
-            if (escaped) {
-                escaped = false;
-                if (inString && inKey && keyPos < (int)sizeof(keyBuf) - 1)
-                    keyBuf[keyPos++] = c;
-                if (inString && inValue && valPos < (int)sizeof(valBuf) - 1)
-                    valBuf[valPos++] = c;
-                continue;
-            }
-
-            if (c == '\\' && inString) {
-                escaped = true;
-                if (inValue && valPos < (int)sizeof(valBuf) - 1)
-                    valBuf[valPos++] = c;
-                continue;
-            }
-
-            if (c == '"') {
-                if (!inString) {
-                    inString = true;
-                    if (!inValue) {
-                        inKey = true;
-                        keyPos = 0;
-                        memset(keyBuf, 0, sizeof(keyBuf));
-                    } else {
-                        valPos = 0;
-                        memset(valBuf, 0, sizeof(valBuf));
-                    }
-                } else {
-                    inString = false;
-                    if (inKey) {
-                        inKey = false;
-                        keyBuf[keyPos] = '\0';
-                    }
-                    if (inValue) {
-                        valBuf[valPos] = '\0';
-                        if (inExtra && strcmp(keyBuf, "nfc_id") == 0) {
-                            // Strip escaped inner quotes: \"UUID\" → UUID
-                            char* nfcVal = valBuf;
-                            int nfcLen = strlen(nfcVal);
-                            if (nfcLen >= 2 && nfcVal[0] == '\\' && nfcVal[1] == '"') {
-                                nfcVal += 2; nfcLen -= 2;
-                            }
-                            if (nfcLen >= 2 && nfcVal[nfcLen - 2] == '\\' && nfcVal[nfcLen - 1] == '"') {
-                                nfcVal[nfcLen - 2] = '\0';
-                            }
-                            nfcLen = strlen(nfcVal);
-                            if (nfcLen >= 2 && nfcVal[0] == '"' && nfcVal[nfcLen - 1] == '"') {
-                                nfcVal[nfcLen - 1] = '\0';
-                                nfcVal++;
-                            }
-                            if (strcasecmp(nfcVal, uuid) == 0) {
-                                nfcIdMatched = true;
-                            }
-                        }
-                        inValue = false;
-                    }
-                }
-                continue;
-            }
-
-            if (inString) {
-                if (inKey && keyPos < (int)sizeof(keyBuf) - 1)
-                    keyBuf[keyPos++] = c;
-                if (inValue && valPos < (int)sizeof(valBuf) - 1)
-                    valBuf[valPos++] = c;
-                continue;
-            }
-
-            // Structural characters outside strings
-            if (c == '{') {
-                depth++;
-                inValue = false;  // opening brace ends the value context
-                inNumValue = false;
-                if (depth == 1) {
-                    currentId = -1;
-                    nfcIdMatched = false;
-                    inExtra = false;
-                } else if (depth >= 2 && strcmp(keyBuf, "extra") == 0) {
-                    inExtra = true;
-                    extraDepth = depth;
-                }
-            } else if (c == '}') {
-                if (inExtra && depth == extraDepth) {
-                    inExtra = false;
-                }
-                // Clear numeric state on every closing brace to prevent
-                // nested id values (filament.id, vendor.id) from leaking
-                inValue = false;
-                inNumValue = false;
-                depth--;
-                if (depth == 0) {
-                    // Deferred match — both id and nfc_id are now known
-                    if (nfcIdMatched && currentId > bestMatchId) {
-                        bestMatchId = currentId;
-                    }
-                }
-            } else if (c == ':') {
-                inValue = true;
-                valPos = 0;
-                memset(valBuf, 0, sizeof(valBuf));
-                inNumValue = false;
-            } else if (c == '[') {
-                inValue = false;
-                inNumValue = false;
-            } else if (c == ',' || c == ']') {
-                if (inNumValue && depth == 1 && strcmp(keyBuf, "id") == 0) {
-                    valBuf[valPos] = '\0';
-                    currentId = atoi(valBuf);
-                }
-                inValue = false;
-                inNumValue = false;
-            } else if (inValue && c >= '0' && c <= '9') {
-                inNumValue = true;
-                if (valPos < (int)sizeof(valBuf) - 1)
-                    valBuf[valPos++] = c;
-            } else if (inValue && (c == '-' || c == '.')) {
-                if (valPos < (int)sizeof(valBuf) - 1)
-                    valBuf[valPos++] = c;
-            }
+    for (JsonObject spool : doc.as<JsonArray>()) {
+        if (spool["archived"] | false) continue;
+        const char* nfcId = spool["extra"]["nfc_id"] | "";
+        // nfc_id is stored double-quoted in Spoolman: "\"UUID\""
+        // Compare both with and without outer quotes
+        if (strcasecmp(nfcId, uuid) == 0 || strcasecmp(nfcId, quotedUuid) == 0) {
+            int id = spool["id"] | -1;
+            if (id > bestMatchId) bestMatchId = id;
         }
     }
-
-    streamHttp.end();
 
     if (bestMatchId >= 0) {
         Serial.printf("SpoolmanManager: streamFind matched uuid=%s to spool id=%d\n", uuid, bestMatchId);
-        return bestMatchId;
     }
-
-    // Distinguish "not found" from "error" so callers don't create duplicates on transient failures
-    if (timedOut) return -2;
-    return -1;  // complete scan, no match
+    return bestMatchId >= 0 ? bestMatchId : -1;
 }
 
 // --- File-local Spoolman API helpers ---

--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -895,160 +895,51 @@ bool SpoolmanManager::getSpoolDetails(int32_t spoolmanId, SpoolDetails& outDetai
         return false;
     }
 
-    // Debug: print first 200 chars of response
     Serial.printf("SpoolmanManager: getSpoolDetails(%d) response: %.200s%s\n",
                   spoolmanId, response.c_str(), response.length() > 200 ? "..." : "");
 
-    // Parse JSON response using streaming parser
-    const_buffer_stream stm((const uint8_t*)response.c_str(), response.length());
-    json_reader reader(stm);
+    // Single spool response is ~700 bytes — parse directly with ArduinoJson
+    JsonDocument doc;
+    if (deserializeJson(doc, response)) {
+        Serial.printf("SpoolmanManager: getSpoolDetails(%d) JSON parse failed\n", spoolmanId);
+        return false;
+    }
 
-    bool inFilament = false;
-    bool inVendor = false;
-    unsigned filamentDepth = 0;
-    unsigned vendorDepth = 0;
-    bool hasId = false;
-    bool hasMaterial = false;
-    char currentField[64] = {0};  // Buffer to hold field name (reader.value() is not stable after read())
+    outDetails.spoolman_id = doc["id"] | -1;
+    outDetails.remaining_weight_g = doc["remaining_weight"] | 0.0f;
+    outDetails.initial_weight_g = doc["initial_weight"] | 0.0f;
 
-    while (reader.read()) {
-        json_node_type nodeType = reader.node_type();
+    JsonObject fil = doc["filament"];
+    if (!fil.isNull()) {
+        const char* material = fil["material"] | "";
+        if (material[0] == '\0') material = fil["name"] | "";
+        strncpy(outDetails.material_type, material, sizeof(outDetails.material_type) - 1);
 
-        // Track entry into nested objects
-        if (nodeType == json_node_type::field) {
-            strncpy(currentField, reader.value(), sizeof(currentField) - 1);  // Copy field name to stable buffer
-            //Serial.printf("  [PARSE] field='%s' inFilament=%d inVendor=%d\n", currentField, inFilament, inVendor);
+        const char* colorHex = fil["color_hex"] | "";
+        if (colorHex[0] == '#') {
+            strncpy(outDetails.color_hex, colorHex, sizeof(outDetails.color_hex) - 1);
+        } else if (colorHex[0] != '\0') {
+            snprintf(outDetails.color_hex, sizeof(outDetails.color_hex), "#%s", colorHex);
+        }
 
-            if (strcmp(currentField, "filament") == 0) {
-                if (reader.read() && reader.node_type() == json_node_type::object) {
-                    inFilament = true;
-                    filamentDepth = reader.depth();
-                }
-                continue;
-            } else if (inFilament && strcmp(currentField, "vendor") == 0) {
-                if (reader.read() && reader.node_type() == json_node_type::object) {
-                    inVendor = true;
-                    vendorDepth = reader.depth();
-                }
-                continue;
-            }
+        outDetails.extruder_temp = fil["settings_extruder_temp"] | 0;
+        outDetails.bed_temp = fil["settings_bed_temp"] | 0;
+        outDetails.density = fil["density"] | 0.0f;
+        outDetails.diameter_mm = fil["diameter"] | 0.0f;
 
-            // Read next value
-            if (!reader.read()) {
-                break;
-            }
-            // Skip nested objects/arrays we don't care about (e.g. "extra": {})
-            if (reader.node_type() == json_node_type::object ||
-                reader.node_type() == json_node_type::array) {
-                int skipDepth = reader.depth();
-                while (reader.read()) {
-                    if ((reader.node_type() == json_node_type::end_object ||
-                         reader.node_type() == json_node_type::end_array) &&
-                        reader.depth() <= skipDepth) {
-                        break;
-                    }
-                }
-                continue;
-            }
-            //Serial.printf("  [PARSE] got value for field '%s', node_type=%d, inFilament=%d, inVendor=%d\n", currentField, reader.node_type(), inFilament, inVendor);
+        if (outDetails.initial_weight_g == 0.0f) {
+            outDetails.initial_weight_g = fil["weight"] | 0.0f;
+        }
 
-            // Extract fields based on context
-            if (inVendor) {
-                if (strcmp(currentField, "name") == 0) {
-                    readStringValue(reader, outDetails.manufacturer, sizeof(outDetails.manufacturer));
-                }
-            } else if (inFilament) {
-                if (strcmp(currentField, "material") == 0) {
-                    //Serial.printf("  [PARSE] reading 'material' field\n");
-                    if (readStringValue(reader, outDetails.material_type, sizeof(outDetails.material_type))) {
-                        hasMaterial = true;
-                        //Serial.printf("  [PARSE] SUCCESS: material=%s\n", outDetails.material_type);
-                    } else {
-                        //Serial.printf("  [PARSE] FAILED: readStringValue returned false\n");
-                    }
-                } else if (strcmp(currentField, "name") == 0) {
-                    // Fallback to 'name' field if 'material' hasn't been set yet
-                    // (real Spoolman API uses 'name' for material type in some responses)
-                    if (outDetails.material_type[0] == '\0') {
-                        if (readStringValue(reader, outDetails.material_type, sizeof(outDetails.material_type))) {
-                            hasMaterial = true;
-                        }
-                    }
-                } else if (strcmp(currentField, "color_hex") == 0) {
-                    char colorBuf[8] = {0};
-                    if (readStringValue(reader, colorBuf, sizeof(colorBuf))) {
-                        // Ensure color has '#' prefix
-                        if (colorBuf[0] == '#') {
-                            strncpy(outDetails.color_hex, colorBuf, sizeof(outDetails.color_hex) - 1);
-                        } else {
-                            snprintf(outDetails.color_hex, sizeof(outDetails.color_hex), "#%s", colorBuf);
-                        }
-                    }
-                } else if (strcmp(currentField, "settings_extruder_temp") == 0) {
-                    int temp = 0;
-                    if (readIntValue(reader, temp)) {
-                        outDetails.extruder_temp = static_cast<int16_t>(temp);
-                    }
-                } else if (strcmp(currentField, "settings_bed_temp") == 0) {
-                    int temp = 0;
-                    if (readIntValue(reader, temp)) {
-                        outDetails.bed_temp = static_cast<int16_t>(temp);
-                    }
-                } else if (strcmp(currentField, "density") == 0) {
-                    if (reader.value_type() == json_value_type::real) {
-                        outDetails.density = static_cast<float>(reader.value_real());
-                    } else if (reader.value_type() == json_value_type::integer) {
-                        outDetails.density = static_cast<float>(reader.value_int());
-                    }
-                } else if (strcmp(currentField, "diameter") == 0) {
-                    if (reader.value_type() == json_value_type::real) {
-                        outDetails.diameter_mm = static_cast<float>(reader.value_real());
-                    } else if (reader.value_type() == json_value_type::integer) {
-                        outDetails.diameter_mm = static_cast<float>(reader.value_int());
-                    }
-                } else if (strcmp(currentField, "weight") == 0) {
-                    // Fallback capacity if initial_weight is not set
-                    if (outDetails.initial_weight_g == 0.0f && reader.value_type() == json_value_type::real) {
-                        outDetails.initial_weight_g = static_cast<float>(reader.value_real());
-                    }
-                }
-            } else {
-                // Top-level spool fields
-                if (strcmp(currentField, "id") == 0) {
-                    int id = -1;
-                    //Serial.printf("  [PARSE] reading 'id' field, node_type=%d\n", reader.node_type());
-                    if (readIntValue(reader, id)) {
-                        outDetails.spoolman_id = id;
-                        hasId = true;
-                        //Serial.printf("  [PARSE] SUCCESS: id=%d\n", id);
-                    } else {
-                        //Serial.printf("  [PARSE] FAILED: readIntValue returned false\n");
-                    }
-                } else if (strcmp(currentField, "remaining_weight") == 0) {
-                    if (reader.value_type() == json_value_type::real) {
-                        outDetails.remaining_weight_g = static_cast<float>(reader.value_real());
-                    } else if (reader.value_type() == json_value_type::integer) {
-                        outDetails.remaining_weight_g = static_cast<float>(reader.value_int());
-                    }
-                } else if (strcmp(currentField, "initial_weight") == 0) {
-                    if (reader.value_type() == json_value_type::real) {
-                        outDetails.initial_weight_g = static_cast<float>(reader.value_real());
-                    } else if (reader.value_type() == json_value_type::integer) {
-                        outDetails.initial_weight_g = static_cast<float>(reader.value_int());
-                    }
-                }
-            }
-        } else if (nodeType == json_node_type::end_object) {
-            // Track exit from nested objects
-            if (inVendor && reader.depth() <= vendorDepth) {
-                inVendor = false;
-            } else if (inFilament && reader.depth() <= filamentDepth) {
-                inFilament = false;
-            }
+        JsonObject vendor = fil["vendor"];
+        if (!vendor.isNull()) {
+            const char* vendorName = vendor["name"] | "";
+            strncpy(outDetails.manufacturer, vendorName, sizeof(outDetails.manufacturer) - 1);
         }
     }
 
-    // Mark as valid if we got the essential fields
+    bool hasId = outDetails.spoolman_id > 0;
+    bool hasMaterial = outDetails.material_type[0] != '\0';
     outDetails.valid = hasId && hasMaterial;
 
     if (outDetails.valid) {

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -1790,6 +1790,205 @@ void WebServerManager::handleApiSpoolmanFindFilament() {
     _server.send(200, "application/json", "{\"found\":false}");
 }
 
+// ── Enrichment save helpers ─────────────────────────────────
+
+int WebServerManager::enrichFindOrCreateVendor(WiFiClient& client, HTTPClient& http,
+                                                const char* baseUrl, const char* manufacturer, int confirmedId) {
+    if (confirmedId != -1 || manufacturer[0] == '\0') return confirmedId;
+
+    char url[256];
+    String encodedMfg = urlEncode(manufacturer);
+    snprintf(url, sizeof(url), "%s/api/v1/vendor?name=%s", baseUrl, encodedMfg.c_str());
+    http.begin(client, url);
+    http.setTimeout(5000);
+    int code = http.GET();
+    int vendorId = -1;
+    if (code == 200) {
+        String response = http.getString();
+        DynamicJsonDocument vDoc(2048);
+        if (!deserializeJson(vDoc, response)) {
+            for (JsonObject v : vDoc.as<JsonArray>()) {
+                if (strcasecmp(v["name"] | "", manufacturer) == 0) {
+                    vendorId = v["id"] | -1;
+                    break;
+                }
+            }
+        }
+    }
+    http.end();
+
+    if (vendorId >= 0) return vendorId;
+
+    StaticJsonDocument<128> vBody;
+    vBody["name"] = manufacturer;
+    String vJson;
+    serializeJson(vBody, vJson);
+    snprintf(url, sizeof(url), "%s/api/v1/vendor", baseUrl);
+    http.begin(client, url);
+    http.setTimeout(5000);
+    http.addHeader("Content-Type", "application/json");
+    code = http.POST(vJson);
+    if (code == 200 || code == 201) {
+        String response = http.getString();
+        StaticJsonDocument<256> vResp;
+        if (!deserializeJson(vResp, response)) vendorId = vResp["id"] | -1;
+    }
+    http.end();
+    return vendorId;
+}
+
+int WebServerManager::enrichFindOrCreateFilament(WiFiClient& client, HTTPClient& http,
+                                                   const char* baseUrl, const char* material, const char* colorHex,
+                                                   int vendorId, float density, float diameter,
+                                                   int bedTemp, int nozzleTemp, int confirmedId) {
+    if (confirmedId != -1 || material[0] == '\0') return confirmedId;
+
+    char url[256];
+    int filamentId = -1;
+
+    // Search existing filaments by vendor — client-side match (#92)
+    if (vendorId > 0) {
+        snprintf(url, sizeof(url), "%s/api/v1/filament?vendor_id=%d", baseUrl, vendorId);
+        http.begin(client, url);
+        http.setTimeout(5000);
+        int code = http.GET();
+        if (code == 200) {
+            String response = http.getString();
+            DynamicJsonDocument fDoc(8192);
+            if (!deserializeJson(fDoc, response)) {
+                const char* colorCmp = colorHex;
+                if (colorCmp[0] == '#') colorCmp++;
+                for (JsonObject f : fDoc.as<JsonArray>()) {
+                    if (strcasecmp(f["material"] | "", material) != 0) continue;
+                    if (colorHex[0] != '\0') {
+                        const char* fc = f["color_hex"] | "";
+                        if (fc[0] == '#') fc++;
+                        if (strcasecmp(fc, colorCmp) != 0) continue;
+                    }
+                    filamentId = f["id"] | -1;
+                    break;
+                }
+            }
+        }
+        http.end();
+    }
+
+    if (filamentId >= 0) return filamentId;
+
+    // Create new filament
+    StaticJsonDocument<512> fBody;
+    fBody["name"] = material;
+    fBody["material"] = material;
+    if (vendorId > 0) fBody["vendor_id"] = vendorId;
+    if (density > 0) fBody["density"] = density;
+    fBody["diameter"] = diameter;
+    if (colorHex[0] != '\0') {
+        const char* ch = colorHex;
+        if (ch[0] == '#') ch++;
+        fBody["color_hex"] = ch;
+    }
+    if (bedTemp > 0) fBody["settings_bed_temp"] = bedTemp;
+    if (nozzleTemp > 0) fBody["settings_extruder_temp"] = nozzleTemp;
+    String fJson;
+    serializeJson(fBody, fJson);
+    snprintf(url, sizeof(url), "%s/api/v1/filament", baseUrl);
+    http.begin(client, url);
+    http.setTimeout(5000);
+    http.addHeader("Content-Type", "application/json");
+    int code = http.POST(fJson);
+    if (code == 200 || code == 201) {
+        String response = http.getString();
+        StaticJsonDocument<256> fResp;
+        if (!deserializeJson(fResp, response)) filamentId = fResp["id"] | -1;
+    }
+    http.end();
+    return filamentId;
+}
+
+int WebServerManager::enrichFindSpoolByUid(WiFiClient& client, HTTPClient& http,
+                                            const char* baseUrl, const char* quotedUid, float& outInitialWeight) {
+    char url[256];
+    snprintf(url, sizeof(url), "%s/api/v1/spool?limit=200", baseUrl);
+    http.begin(client, url);
+    http.setTimeout(5000);
+    int code = http.GET();
+    int spoolId = -1;
+    outInitialWeight = 0.0f;
+    if (code == 200) {
+        String response = http.getString();
+        DynamicJsonDocument sDoc(16384);
+        if (!deserializeJson(sDoc, response)) {
+            JsonArray arr = sDoc.as<JsonArray>();
+            for (size_t i = 0; i < arr.size(); i++) {
+                const char* nfcId = arr[i]["extra"]["nfc_id"] | "";
+                if (strcmp(nfcId, quotedUid) != 0) continue;
+                if (arr[i]["archived"] | false) continue;
+                spoolId = arr[i]["id"] | -1;
+                outInitialWeight = arr[i]["initial_weight"] | 0.0f;
+                break;
+            }
+        }
+    }
+    http.end();
+    return spoolId;
+}
+
+bool WebServerManager::enrichUpdateSpool(WiFiClient& client, HTTPClient& http, const char* baseUrl,
+                                           int spoolId, int filamentId, float remainingG, float existingInitialWeight) {
+    char url[256];
+    StaticJsonDocument<256> patch;
+    patch["filament_id"] = filamentId;
+    if (remainingG > 0) {
+        float initialW = existingInitialWeight > 0 ? existingInitialWeight : 1000.0f;
+        float usedW = initialW - remainingG;
+        if (usedW < 0) usedW = 0;
+        patch["initial_weight"] = initialW;
+        patch["used_weight"] = usedW;
+    }
+    String pJson;
+    serializeJson(patch, pJson);
+    snprintf(url, sizeof(url), "%s/api/v1/spool/%d", baseUrl, spoolId);
+    http.begin(client, url);
+    http.setTimeout(5000);
+    http.addHeader("Content-Type", "application/json");
+    int code = http.PATCH(pJson);
+    http.end();
+    return (code >= 200 && code < 300);
+}
+
+int WebServerManager::enrichCreateSpool(WiFiClient& client, HTTPClient& http, const char* baseUrl,
+                                          int filamentId, float remainingG, const char* quotedUid) {
+    char url[256];
+    StaticJsonDocument<512> sBody;
+    sBody["filament_id"] = filamentId;
+    if (remainingG > 0) {
+        float initialW = 1000.0f;
+        float usedW = initialW - remainingG;
+        if (usedW < 0) usedW = 0;
+        sBody["initial_weight"] = initialW;
+        sBody["used_weight"] = usedW;
+    }
+    JsonObject extra = sBody.createNestedObject("extra");
+    extra["nfc_id"] = quotedUid;
+    String sJson;
+    serializeJson(sBody, sJson);
+    snprintf(url, sizeof(url), "%s/api/v1/spool", baseUrl);
+    http.begin(client, url);
+    http.setTimeout(5000);
+    http.addHeader("Content-Type", "application/json");
+    int code = http.POST(sJson);
+    int spoolId = -1;
+    if (code == 200 || code == 201) {
+        String response = http.getString();
+        StaticJsonDocument<256> sResp;
+        if (!deserializeJson(sResp, response)) spoolId = sResp["id"] | -1;
+    }
+    http.end();
+    return spoolId;
+}
+
+// ── /api/spoolman/save-enrichment ───────────────────────────
+
 void WebServerManager::handleApiSpoolmanSaveEnrichment() {
     _server.sendHeader("Access-Control-Allow-Origin", "*");
 
@@ -1798,7 +1997,6 @@ void WebServerManager::handleApiSpoolmanSaveEnrichment() {
         _server.send(400, "application/json", "{\"error\":\"bad JSON\"}");
         return;
     }
-
     if (!SpoolmanManager::getInstance().isConfigured()) {
         _server.send(503, "application/json", "{\"error\":\"Spoolman not configured\"}");
         return;
@@ -1823,7 +2021,6 @@ void WebServerManager::handleApiSpoolmanSaveEnrichment() {
     }
 
     const char* baseUrl = ConfigurationManager::getInstance().getSpoolmanURL();
-
     if (xSemaphoreTake(g_httpMutex, HTTP_MUTEX_TIMEOUT) != pdTRUE) {
         sendError(503, "Busy — try again");
         return;
@@ -1831,198 +2028,29 @@ void WebServerManager::handleApiSpoolmanSaveEnrichment() {
 
     WiFiClient client;
     HTTPClient http;
-    char url[256];
-    String response;
-    int code;
 
-    // Step 1: Find or create vendor (-1 = not searched, -2 = user declined match)
-    int vendorId = confirmedVendorId;
-    if (vendorId == -1 && manufacturer[0] != '\0') {
-        String encodedMfg = urlEncode(manufacturer);
-        snprintf(url, sizeof(url), "%s/api/v1/vendor?name=%s", baseUrl, encodedMfg.c_str());
-        http.begin(client, url);
-        http.setTimeout(5000);
-        code = http.GET();
-        if (code == 200) {
-            response = http.getString();
-            DynamicJsonDocument vDoc(2048);
-            if (!deserializeJson(vDoc, response)) {
-                for (JsonObject v : vDoc.as<JsonArray>()) {
-                    if (strcasecmp(v["name"] | "", manufacturer) == 0) {
-                        vendorId = v["id"] | -1;
-                        break;
-                    }
-                }
-            }
-        }
-        http.end();
-
-        if (vendorId < 0) {
-            StaticJsonDocument<128> vBody;
-            vBody["name"] = manufacturer;
-            String vJson;
-            serializeJson(vBody, vJson);
-            snprintf(url, sizeof(url), "%s/api/v1/vendor", baseUrl);
-            http.begin(client, url);
-            http.setTimeout(5000);
-            http.addHeader("Content-Type", "application/json");
-            code = http.POST(vJson);
-            if (code == 200 || code == 201) {
-                response = http.getString();
-                StaticJsonDocument<256> vResp;
-                if (!deserializeJson(vResp, response)) vendorId = vResp["id"] | -1;
-            }
-            http.end();
-        }
-    }
-
-    // Step 2: Find or create filament (-1 = not searched, -2 = user declined match)
-    int filamentId = confirmedFilamentId;
-    if (filamentId == -1 && material[0] != '\0') {
-        if (vendorId > 0) {
-            // Spoolman's ?material= filter is unreliable (#92) — match client-side
-            snprintf(url, sizeof(url), "%s/api/v1/filament?vendor_id=%d", baseUrl, vendorId);
-            http.begin(client, url);
-            http.setTimeout(5000);
-            code = http.GET();
-            if (code == 200) {
-                response = http.getString();
-                DynamicJsonDocument fSearchDoc(8192);
-                if (!deserializeJson(fSearchDoc, response)) {
-                    const char* colorCmp = colorHex;
-                    if (colorCmp[0] == '#') colorCmp++;
-                    for (JsonObject f : fSearchDoc.as<JsonArray>()) {
-                        if (strcasecmp(f["material"] | "", material) != 0) continue;
-                        if (colorHex[0] != '\0') {
-                            const char* fc = f["color_hex"] | "";
-                            if (fc[0] == '#') fc++;
-                            if (strcasecmp(fc, colorCmp) != 0) continue;
-                        }
-                        filamentId = f["id"] | -1;
-                        break;
-                    }
-                }
-            }
-            http.end();
-        }
-
-        // Create if not found
-        if (filamentId < 0) {
-            StaticJsonDocument<512> fBody;
-            fBody["name"] = material;
-            fBody["material"] = material;
-            if (vendorId > 0) fBody["vendor_id"] = vendorId;
-            if (density > 0) fBody["density"] = density;
-            fBody["diameter"] = diameter;
-            if (colorHex[0] != '\0') {
-                const char* ch = colorHex;
-                if (ch[0] == '#') ch++;
-                fBody["color_hex"] = ch;
-            }
-            if (bedTemp > 0) fBody["settings_bed_temp"] = bedTemp;
-            if (nozzleTemp > 0) fBody["settings_extruder_temp"] = nozzleTemp;
-            String fJson;
-            serializeJson(fBody, fJson);
-            snprintf(url, sizeof(url), "%s/api/v1/filament", baseUrl);
-            http.begin(client, url);
-            http.setTimeout(5000);
-            http.addHeader("Content-Type", "application/json");
-            code = http.POST(fJson);
-            if (code == 200 || code == 201) {
-                response = http.getString();
-                StaticJsonDocument<256> fResp;
-                if (!deserializeJson(fResp, response)) filamentId = fResp["id"] | -1;
-            }
-            http.end();
-        }
-    }
-
+    int vendorId = enrichFindOrCreateVendor(client, http, baseUrl, manufacturer, confirmedVendorId);
+    int filamentId = enrichFindOrCreateFilament(client, http, baseUrl, material, colorHex,
+                                                 vendorId, density, diameter, bedTemp, nozzleTemp, confirmedFilamentId);
     if (filamentId < 0) {
         xSemaphoreGive(g_httpMutex);
         _server.send(500, "application/json", "{\"error\":\"filament create failed\"}");
         return;
     }
 
-    // Step 3: Find existing spool by UID
-    // Spoolman's extra_field filter is unreliable — fetch all and match nfc_id client-side
-    int spoolId = -1;
-    float existingInitialWeight = 0.0f;
     char quotedUid[130];
     snprintf(quotedUid, sizeof(quotedUid), "\"%s\"", uid);
-    snprintf(url, sizeof(url), "%s/api/v1/spool?limit=200", baseUrl);
-    http.begin(client, url);
-    http.setTimeout(5000);
-    code = http.GET();
-    if (code == 200) {
-        response = http.getString();
-        DynamicJsonDocument sDoc(16384);
-        if (!deserializeJson(sDoc, response)) {
-            JsonArray arr = sDoc.as<JsonArray>();
-            for (size_t i = 0; i < arr.size(); i++) {
-                const char* nfcId = arr[i]["extra"]["nfc_id"] | "";
-                if (strcmp(nfcId, quotedUid) == 0) {
-                    bool archived = arr[i]["archived"] | false;
-                    if (archived) continue;
-                    spoolId = arr[i]["id"] | -1;
-                    existingInitialWeight = arr[i]["initial_weight"] | 0.0f;
-                    break;
-                }
-            }
-        }
-    }
-    http.end();
+    float existingInitialWeight = 0.0f;
+    int spoolId = enrichFindSpoolByUid(client, http, baseUrl, quotedUid, existingInitialWeight);
 
     if (spoolId > 0) {
-        // Update existing spool — Spoolman uses used_weight, not remaining_weight
-        StaticJsonDocument<256> patch;
-        patch["filament_id"] = filamentId;
-        if (remainingG > 0) {
-            float initialW = existingInitialWeight > 0 ? existingInitialWeight : 1000.0f;
-            float usedW = initialW - remainingG;
-            if (usedW < 0) usedW = 0;
-            patch["initial_weight"] = initialW;
-            patch["used_weight"] = usedW;
-        }
-        String pJson;
-        serializeJson(patch, pJson);
-        snprintf(url, sizeof(url), "%s/api/v1/spool/%d", baseUrl, spoolId);
-        http.begin(client, url);
-        http.setTimeout(5000);
-        http.addHeader("Content-Type", "application/json");
-        int patchCode = http.PATCH(pJson);
-        http.end();
-        if (patchCode < 200 || patchCode >= 300) {
+        if (!enrichUpdateSpool(client, http, baseUrl, spoolId, filamentId, remainingG, existingInitialWeight)) {
             xSemaphoreGive(g_httpMutex);
             _server.send(500, "application/json", "{\"error\":\"spool update failed\"}");
             return;
         }
     } else {
-        // Create new spool — Spoolman uses used_weight, not remaining_weight
-        StaticJsonDocument<512> sBody;
-        sBody["filament_id"] = filamentId;
-        if (remainingG > 0) {
-            float initialW = 1000.0f;
-            float usedW = initialW - remainingG;
-            if (usedW < 0) usedW = 0;
-            sBody["initial_weight"] = initialW;
-            sBody["used_weight"] = usedW;
-        }
-        JsonObject extra = sBody.createNestedObject("extra");
-        // Spoolman extra fields require JSON-encoded string values (double-quoted)
-        extra["nfc_id"] = quotedUid;
-        String sJson;
-        serializeJson(sBody, sJson);
-        snprintf(url, sizeof(url), "%s/api/v1/spool", baseUrl);
-        http.begin(client, url);
-        http.setTimeout(5000);
-        http.addHeader("Content-Type", "application/json");
-        code = http.POST(sJson);
-        if (code == 200 || code == 201) {
-            response = http.getString();
-            StaticJsonDocument<256> sResp;
-            if (!deserializeJson(sResp, response)) spoolId = sResp["id"] | -1;
-        }
-        http.end();
+        spoolId = enrichCreateSpool(client, http, baseUrl, filamentId, remainingG, quotedUid);
     }
 
     StaticJsonDocument<128> result;

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -1030,13 +1030,177 @@ void WebServerManager::handleApiOtaStatus() {
 // API: Status
 // ---------------------------------------------------------------------------
 
+// ── Status serializers ──────────────────────────────────────
+
+void WebServerManager::serializeTigerTagStatus(JsonDocument& doc) {
+    TigerTagData tt;
+    if (!NFCManager::getInstance().getLastTigerTagData(tt) || !tt.valid) return;
+
+    JsonObject obj = doc.createNestedObject("tigertag");
+    obj["material_id"] = tt.material_id;
+    obj["material_name"] = tt.material_name;
+    obj["brand_id"] = tt.brand_id;
+    obj["brand_name"] = tt.brand_name;
+    obj["weight_g"] = tt.weight_g;
+    obj["diameter_mm"] = tt.diameter_mm;
+    obj["aspect1_name"] = tt.aspect1_name;
+    obj["aspect2_name"] = tt.aspect2_name;
+
+    char colorHex[8];
+    snprintf(colorHex, sizeof(colorHex), "#%02X%02X%02X", tt.color_r, tt.color_g, tt.color_b);
+    obj["color_hex"] = colorHex;
+
+    if (tt.nozzle_temp_min > 0) obj["nozzle_temp_min"] = tt.nozzle_temp_min;
+    if (tt.nozzle_temp_max > 0) obj["nozzle_temp_max"] = tt.nozzle_temp_max;
+    if (tt.bed_temp_min > 0) obj["bed_temp_min"] = tt.bed_temp_min;
+    if (tt.bed_temp_max > 0) obj["bed_temp_max"] = tt.bed_temp_max;
+    if (tt.dry_temp > 0) obj["dry_temp"] = tt.dry_temp;
+    if (tt.dry_time_hours > 0) obj["dry_time_hours"] = tt.dry_time_hours;
+}
+
+void WebServerManager::serializeOpenTag3DStatus(JsonDocument& doc) {
+    opentag3d_t ot3d;
+    if (!NFCManager::getInstance().getLastOpenTag3DData(ot3d)) return;
+
+    JsonObject obj = doc.createNestedObject("opentag3d");
+    obj["base_material"] = ot3d.base_material;
+    if (ot3d.material_modifiers[0]) obj["modifiers"] = ot3d.material_modifiers;
+    obj["manufacturer"] = ot3d.manufacturer;
+    if (ot3d.color_name[0]) obj["color_name"] = ot3d.color_name;
+
+    char colorHex[8];
+    snprintf(colorHex, sizeof(colorHex), "#%02X%02X%02X",
+             ot3d.color_rgba[0][0], ot3d.color_rgba[0][1], ot3d.color_rgba[0][2]);
+    obj["color_hex"] = colorHex;
+
+    obj["target_weight_g"] = ot3d.target_weight_g;
+    obj["diameter_mm"] = opentag3d_diameter_mm(&ot3d);
+    if (ot3d.density_ugcm3 > 0) obj["density"] = opentag3d_density_gcc(&ot3d);
+
+    uint16_t printTemp = (uint16_t)opentag3d_temp_c(ot3d.print_temp_encoded);
+    uint16_t bedTemp = (uint16_t)opentag3d_temp_c(ot3d.bed_temp_encoded);
+    if (printTemp > 0) obj["print_temp"] = printTemp;
+    if (bedTemp > 0) obj["bed_temp"] = bedTemp;
+
+    if (ot3d.has_extended) {
+        if (ot3d.measured_filament_weight_g > 0) obj["measured_weight_g"] = ot3d.measured_filament_weight_g;
+        if (ot3d.empty_spool_weight_g > 0) obj["empty_spool_g"] = ot3d.empty_spool_weight_g;
+        if (ot3d.serial_number[0]) obj["serial_number"] = ot3d.serial_number;
+        uint16_t minPrint = (uint16_t)opentag3d_temp_c(ot3d.min_print_temp_encoded);
+        uint16_t maxPrint = (uint16_t)opentag3d_temp_c(ot3d.max_print_temp_encoded);
+        uint16_t minBed = (uint16_t)opentag3d_temp_c(ot3d.min_bed_temp_encoded);
+        uint16_t maxBed = (uint16_t)opentag3d_temp_c(ot3d.max_bed_temp_encoded);
+        if (minPrint > 0) obj["min_print_temp"] = minPrint;
+        if (maxPrint > 0) obj["max_print_temp"] = maxPrint;
+        if (minBed > 0) obj["min_bed_temp"] = minBed;
+        if (maxBed > 0) obj["max_bed_temp"] = maxBed;
+        uint16_t dryTemp = (uint16_t)opentag3d_temp_c(ot3d.max_dry_temp_encoded);
+        if (dryTemp > 0) obj["dry_temp"] = dryTemp;
+        if (ot3d.dry_time_hours > 0) obj["dry_time_hours"] = ot3d.dry_time_hours;
+    }
+}
+
+void WebServerManager::serializeOpenSpoolStatus(JsonDocument& doc) {
+    OpenSpoolData os;
+    if (!NFCManager::getInstance().getLastOpenSpoolData(os) || !os.valid) return;
+
+    JsonObject obj = doc.createNestedObject("openspool");
+    obj["brand"] = os.brand;
+    obj["material"] = os.material;
+    char colorHex[8];
+    snprintf(colorHex, sizeof(colorHex), "#%s", os.color_hex);
+    obj["color_hex"] = colorHex;
+    obj["version"] = os.version;
+    if (os.min_temp > 0) obj["min_temp"] = os.min_temp;
+    if (os.max_temp > 0) obj["max_temp"] = os.max_temp;
+}
+
+void WebServerManager::serializeGenericUidStatus(JsonDocument& doc) {
+    GenericTagSpoolInfo spoolInfo;
+    NFCManager::getInstance().getGenericTagSpoolInfo(spoolInfo);
+    if (!spoolInfo.valid) return;
+
+    doc["material_name"] = spoolInfo.material_type;
+    doc["manufacturer"] = spoolInfo.manufacturer;
+    doc["color"] = spoolInfo.color_hex;
+    doc["remaining_g"] = spoolInfo.remaining_weight_g;
+    doc["spoolman_id"] = spoolInfo.spoolman_id;
+    if (spoolInfo.extruder_temp > 0) doc["extruder_temp"] = spoolInfo.extruder_temp;
+    if (spoolInfo.bed_temp > 0) doc["bed_temp"] = spoolInfo.bed_temp;
+}
+
+void WebServerManager::serializeOpenPrintTagStatus(JsonDocument& doc, const CurrentSpoolState& state) {
+    if (!state.tag_data_valid) return;
+
+    uint8_t mat_type = 0;
+    opt_get_material_type(&state.tag_data, &mat_type);
+    doc["material_type"] = mat_type;
+    doc["material_name"] = materialTypeToString(mat_type);
+
+    uint8_t color[4] = {0};
+    if (opt_get_primary_color(&state.tag_data, color) == OPT_OK) {
+        char colorHex[8];
+        snprintf(colorHex, sizeof(colorHex), "#%02X%02X%02X", color[0], color[1], color[2]);
+        doc["color"] = colorHex;
+    } else {
+        doc["color"] = (const char*)nullptr;
+    }
+
+    char manufacturer[33] = {0};
+    opt_get_brand_name(&state.tag_data, manufacturer, sizeof(manufacturer));
+    doc["manufacturer"] = manufacturer;
+
+    float full_weight = 0.0f, consumed = 0.0f;
+    opt_get_actual_full_weight(&state.tag_data, &full_weight);
+    opt_get_consumed_weight(&state.tag_data, &consumed);
+    doc["remaining_g"] = full_weight - consumed;
+    doc["initial_weight_g"] = full_weight;
+
+    int32_t spoolman_id = -1;
+    opt_get_gp_spoolman_id(&state.tag_data, &spoolman_id);
+    doc["spoolman_id"] = spoolman_id;
+
+    float density = 0.0f;
+    if (opt_get_density(&state.tag_data, &density) == OPT_OK && density > 0.0f)
+        doc["density"] = density;
+    float diameter = 0.0f;
+    if (opt_get_filament_diameter(&state.tag_data, &diameter) == OPT_OK && diameter > 0.0f)
+        doc["diameter_mm"] = diameter;
+
+    char mat_name_custom[33] = {0};
+    if (opt_get_material_name(&state.tag_data, mat_name_custom, sizeof(mat_name_custom)) == OPT_OK
+            && mat_name_custom[0] != '\0')
+        doc["material_name"] = mat_name_custom;
+
+    int16_t t = 0;
+    if (opt_get_min_print_temp(&state.tag_data, &t) == OPT_OK && t != 0) doc["min_print_temp"] = t;
+    if (opt_get_max_print_temp(&state.tag_data, &t) == OPT_OK && t != 0) doc["max_print_temp"] = t;
+    if (opt_get_preheat_temp(&state.tag_data, &t) == OPT_OK && t != 0)   doc["preheat_temp"] = t;
+    if (opt_get_min_bed_temp(&state.tag_data, &t) == OPT_OK && t != 0)   doc["min_bed_temp"] = t;
+    if (opt_get_max_bed_temp(&state.tag_data, &t) == OPT_OK && t != 0)   doc["max_bed_temp"] = t;
+}
+
+void WebServerManager::serializeEnrichment(JsonDocument& doc) {
+    SmartTagEnrichment enrichment = ApplicationManager::getInstance().getSmartTagEnrichment();
+    if (!enrichment.valid || doc.containsKey("spoolman")) return;
+
+    JsonObject sp = doc.createNestedObject("spoolman");
+    sp["spool_id"] = enrichment.spoolman_id;
+    sp["remaining_g"] = enrichment.remaining_g;
+    if (enrichment.bed_temp > 0) sp["bed_temp"] = enrichment.bed_temp;
+    if (enrichment.extruder_temp > 0) sp["extruder_temp"] = enrichment.extruder_temp;
+    if (enrichment.density > 0) sp["density"] = enrichment.density;
+    if (enrichment.diameter_mm > 0) sp["diameter_mm"] = enrichment.diameter_mm;
+}
+
+// ── /api/status ─────────────────────────────────────────────
+
 void WebServerManager::handleApiStatus() {
     _server.sendHeader("Access-Control-Allow-Origin", "*");
 
     CurrentSpoolState state;
     StaticJsonDocument<1536> doc;
 
-    // Always include device ID and firmware version
     char deviceId[8];
     HomeAssistantManager::getDeviceId(deviceId, sizeof(deviceId));
     doc["device_id"] = deviceId;
@@ -1048,186 +1212,22 @@ void WebServerManager::handleApiStatus() {
         doc["tag_data_valid"] = state.tag_data_valid;
         doc["tag_kind"] = tagKindToString(state.kind);
 
-        if (state.kind == TagKind::TigerTag) {
-            // TigerTag — include parsed TigerTag data
-            TigerTagData tt;
-            if (NFCManager::getInstance().getLastTigerTagData(tt) && tt.valid) {
-                JsonObject ttObj = doc.createNestedObject("tigertag");
-                ttObj["material_id"] = tt.material_id;
-                ttObj["material_name"] = tt.material_name;
-                ttObj["brand_id"] = tt.brand_id;
-                ttObj["brand_name"] = tt.brand_name;
-                ttObj["weight_g"] = tt.weight_g;
-                ttObj["diameter_mm"] = tt.diameter_mm;
-                ttObj["aspect1_name"] = tt.aspect1_name;
-                ttObj["aspect2_name"] = tt.aspect2_name;
-
-                char colorHex[8];
-                snprintf(colorHex, sizeof(colorHex), "#%02X%02X%02X",
-                         tt.color_r, tt.color_g, tt.color_b);
-                ttObj["color_hex"] = colorHex;
-
-                if (tt.nozzle_temp_min > 0) ttObj["nozzle_temp_min"] = tt.nozzle_temp_min;
-                if (tt.nozzle_temp_max > 0) ttObj["nozzle_temp_max"] = tt.nozzle_temp_max;
-                if (tt.bed_temp_min > 0) ttObj["bed_temp_min"] = tt.bed_temp_min;
-                if (tt.bed_temp_max > 0) ttObj["bed_temp_max"] = tt.bed_temp_max;
-                if (tt.dry_temp > 0) ttObj["dry_temp"] = tt.dry_temp;
-                if (tt.dry_time_hours > 0) ttObj["dry_time_hours"] = tt.dry_time_hours;
-            }
-        } else if (state.kind == TagKind::OpenTag3D) {
-            // OpenTag3D — include parsed data
-            opentag3d_t ot3d;
-            if (NFCManager::getInstance().getLastOpenTag3DData(ot3d)) {
-                JsonObject otObj = doc.createNestedObject("opentag3d");
-                otObj["base_material"] = ot3d.base_material;
-                if (ot3d.material_modifiers[0]) otObj["modifiers"] = ot3d.material_modifiers;
-                otObj["manufacturer"] = ot3d.manufacturer;
-                if (ot3d.color_name[0]) otObj["color_name"] = ot3d.color_name;
-
-                char colorHex[8];
-                snprintf(colorHex, sizeof(colorHex), "#%02X%02X%02X",
-                         ot3d.color_rgba[0][0], ot3d.color_rgba[0][1], ot3d.color_rgba[0][2]);
-                otObj["color_hex"] = colorHex;
-
-                otObj["target_weight_g"] = ot3d.target_weight_g;
-                otObj["diameter_mm"] = opentag3d_diameter_mm(&ot3d);
-                if (ot3d.density_ugcm3 > 0) otObj["density"] = opentag3d_density_gcc(&ot3d);
-
-                uint16_t printTemp = (uint16_t)opentag3d_temp_c(ot3d.print_temp_encoded);
-                uint16_t bedTemp = (uint16_t)opentag3d_temp_c(ot3d.bed_temp_encoded);
-                if (printTemp > 0) otObj["print_temp"] = printTemp;
-                if (bedTemp > 0) otObj["bed_temp"] = bedTemp;
-
-                if (ot3d.has_extended) {
-                    if (ot3d.measured_filament_weight_g > 0) otObj["measured_weight_g"] = ot3d.measured_filament_weight_g;
-                    if (ot3d.empty_spool_weight_g > 0) otObj["empty_spool_g"] = ot3d.empty_spool_weight_g;
-                    if (ot3d.serial_number[0]) otObj["serial_number"] = ot3d.serial_number;
-                    uint16_t minPrint = (uint16_t)opentag3d_temp_c(ot3d.min_print_temp_encoded);
-                    uint16_t maxPrint = (uint16_t)opentag3d_temp_c(ot3d.max_print_temp_encoded);
-                    uint16_t minBed = (uint16_t)opentag3d_temp_c(ot3d.min_bed_temp_encoded);
-                    uint16_t maxBed = (uint16_t)opentag3d_temp_c(ot3d.max_bed_temp_encoded);
-                    if (minPrint > 0) otObj["min_print_temp"] = minPrint;
-                    if (maxPrint > 0) otObj["max_print_temp"] = maxPrint;
-                    if (minBed > 0) otObj["min_bed_temp"] = minBed;
-                    if (maxBed > 0) otObj["max_bed_temp"] = maxBed;
-                    uint16_t dryTemp = (uint16_t)opentag3d_temp_c(ot3d.max_dry_temp_encoded);
-                    if (dryTemp > 0) otObj["dry_temp"] = dryTemp;
-                    if (ot3d.dry_time_hours > 0) otObj["dry_time_hours"] = ot3d.dry_time_hours;
-                }
-            }
-        } else if (state.kind == TagKind::OpenSpoolTag) {
-            OpenSpoolData os;
-            if (NFCManager::getInstance().getLastOpenSpoolData(os) && os.valid) {
-                JsonObject osObj = doc.createNestedObject("openspool");
-                osObj["brand"] = os.brand;
-                osObj["material"] = os.material;
-                char osColorHex[8];
-                snprintf(osColorHex, sizeof(osColorHex), "#%s", os.color_hex);
-                osObj["color_hex"] = osColorHex;
-                osObj["version"] = os.version;
-                if (os.min_temp > 0) osObj["min_temp"] = os.min_temp;
-                if (os.max_temp > 0) osObj["max_temp"] = os.max_temp;
-            }
-        } else if (state.kind == TagKind::GenericUidTag) {
-            // Generic UID tag — include resolved Spoolman data if available
-            GenericTagSpoolInfo spoolInfo;
-            NFCManager::getInstance().getGenericTagSpoolInfo(spoolInfo);
-            if (spoolInfo.valid) {
-                doc["material_name"] = spoolInfo.material_type;
-                doc["manufacturer"] = spoolInfo.manufacturer;
-                doc["color"] = spoolInfo.color_hex;
-                doc["remaining_g"] = spoolInfo.remaining_weight_g;
-                doc["spoolman_id"] = spoolInfo.spoolman_id;
-                if (spoolInfo.extruder_temp > 0) doc["extruder_temp"] = spoolInfo.extruder_temp;
-                if (spoolInfo.bed_temp > 0) doc["bed_temp"] = spoolInfo.bed_temp;
-            }
-        } else if (state.tag_data_valid) {
-            // OpenPrintTag — include OPT fields
-            uint8_t mat_type = 0;
-            opt_get_material_type(&state.tag_data, &mat_type);
-            doc["material_type"] = mat_type;
-            doc["material_name"] = materialTypeToString(mat_type);
-
-            uint8_t color[4] = {0};
-            if (opt_get_primary_color(&state.tag_data, color) == OPT_OK) {
-                char colorHex[8];
-                snprintf(colorHex, sizeof(colorHex), "#%02X%02X%02X",
-                         color[0], color[1], color[2]);
-                doc["color"] = colorHex;
-            } else {
-                doc["color"] = (const char*)nullptr;
-            }
-
-            char manufacturer[33] = {0};
-            opt_get_brand_name(&state.tag_data, manufacturer, sizeof(manufacturer));
-            doc["manufacturer"] = manufacturer;
-
-            float full_weight = 0.0f, consumed = 0.0f;
-            opt_get_actual_full_weight(&state.tag_data, &full_weight);
-            opt_get_consumed_weight(&state.tag_data, &consumed);
-            doc["remaining_g"] = full_weight - consumed;
-            doc["initial_weight_g"] = full_weight;
-
-            int32_t spoolman_id = -1;
-            opt_get_gp_spoolman_id(&state.tag_data, &spoolman_id);
-            doc["spoolman_id"] = spoolman_id;
-
-            float density = 0.0f;
-            if (opt_get_density(&state.tag_data, &density) == OPT_OK && density > 0.0f)
-                doc["density"] = density;
-
-            float diameter = 0.0f;
-            if (opt_get_filament_diameter(&state.tag_data, &diameter) == OPT_OK && diameter > 0.0f)
-                doc["diameter_mm"] = diameter;
-
-            char mat_name_custom[33] = {0};
-            if (opt_get_material_name(&state.tag_data, mat_name_custom, sizeof(mat_name_custom)) == OPT_OK
-                    && mat_name_custom[0] != '\0')
-                doc["material_name"] = mat_name_custom;
-
-            int16_t t = 0;
-            if (opt_get_min_print_temp(&state.tag_data, &t) == OPT_OK && t != 0) doc["min_print_temp"] = t;
-            if (opt_get_max_print_temp(&state.tag_data, &t) == OPT_OK && t != 0) doc["max_print_temp"] = t;
-            if (opt_get_preheat_temp(&state.tag_data, &t) == OPT_OK && t != 0)   doc["preheat_temp"] = t;
-            if (opt_get_min_bed_temp(&state.tag_data, &t) == OPT_OK && t != 0)   doc["min_bed_temp"] = t;
-            if (opt_get_max_bed_temp(&state.tag_data, &t) == OPT_OK && t != 0)   doc["max_bed_temp"] = t;
+        switch (state.kind) {
+            case TagKind::TigerTag:     serializeTigerTagStatus(doc); break;
+            case TagKind::OpenTag3D:    serializeOpenTag3DStatus(doc); break;
+            case TagKind::OpenSpoolTag: serializeOpenSpoolStatus(doc); break;
+            case TagKind::GenericUidTag: serializeGenericUidStatus(doc); break;
+            case TagKind::BambuTag:     break;
+            default:                    serializeOpenPrintTagStatus(doc, state); break;
         }
 
-        // Smart tag enrichment — include Spoolman data if available
-        {
-            SmartTagEnrichment enrichment = ApplicationManager::getInstance().getSmartTagEnrichment();
-            if (enrichment.valid &&
-                (state.kind == TagKind::TigerTag ||
-                 state.kind == TagKind::OpenTag3D ||
-                 state.kind == TagKind::OpenSpoolTag ||
-                 state.kind == TagKind::OpenPrintTag)) {
-                JsonObject sp = doc.createNestedObject("spoolman");
-                sp["spool_id"] = enrichment.spoolman_id;
-                sp["remaining_g"] = enrichment.remaining_g;
-                if (enrichment.bed_temp > 0) sp["bed_temp"] = enrichment.bed_temp;
-                if (enrichment.extruder_temp > 0) sp["extruder_temp"] = enrichment.extruder_temp;
-                if (enrichment.density > 0) sp["density"] = enrichment.density;
-                if (enrichment.diameter_mm > 0) sp["diameter_mm"] = enrichment.diameter_mm;
-            }
-        }
+        serializeEnrichment(doc);
     } else {
         doc["present"] = false;
         doc["tag_data_valid"] = false;
     }
 
-    // Include enrichment even when tag is not present (persists until next scan)
-    {
-        SmartTagEnrichment enrichment = ApplicationManager::getInstance().getSmartTagEnrichment();
-        if (enrichment.valid && !doc.containsKey("spoolman")) {
-            JsonObject sp = doc.createNestedObject("spoolman");
-            sp["spool_id"] = enrichment.spoolman_id;
-            sp["remaining_g"] = enrichment.remaining_g;
-            if (enrichment.bed_temp > 0) sp["bed_temp"] = enrichment.bed_temp;
-            if (enrichment.extruder_temp > 0) sp["extruder_temp"] = enrichment.extruder_temp;
-            if (enrichment.density > 0) sp["density"] = enrichment.density;
-            if (enrichment.diameter_mm > 0) sp["diameter_mm"] = enrichment.diameter_mm;
-        }
-    }
+    serializeEnrichment(doc);
 
     String body;
     serializeJson(doc, body);

--- a/src/WebServerManager.h
+++ b/src/WebServerManager.h
@@ -3,7 +3,10 @@
 
 #ifndef NATIVE_TEST
 #include <WebServer.h>
+#include <ArduinoJson.h>
 #endif
+
+#include "NFCTypes.h"
 
 class DisplayI;
 
@@ -78,6 +81,14 @@ private:
     volatile uint8_t _otaProgress = 0;
 
     DisplayI* _display = nullptr;
+
+    // Status serializers — per-tag-type JSON builders for /api/status
+    void serializeTigerTagStatus(JsonDocument& doc);
+    void serializeOpenTag3DStatus(JsonDocument& doc);
+    void serializeOpenSpoolStatus(JsonDocument& doc);
+    void serializeGenericUidStatus(JsonDocument& doc);
+    void serializeOpenPrintTagStatus(JsonDocument& doc, const CurrentSpoolState& state);
+    void serializeEnrichment(JsonDocument& doc);
 
     void sendError(int code, const char* msg);
 #endif

--- a/src/WebServerManager.h
+++ b/src/WebServerManager.h
@@ -4,6 +4,7 @@
 #ifndef NATIVE_TEST
 #include <WebServer.h>
 #include <ArduinoJson.h>
+#include <HTTPClient.h>
 #endif
 
 #include "NFCTypes.h"
@@ -89,6 +90,19 @@ private:
     void serializeGenericUidStatus(JsonDocument& doc);
     void serializeOpenPrintTagStatus(JsonDocument& doc, const CurrentSpoolState& state);
     void serializeEnrichment(JsonDocument& doc);
+
+    // Enrichment save helpers — each step of the Spoolman save pipeline
+    int enrichFindOrCreateVendor(WiFiClient& client, HTTPClient& http, const char* baseUrl,
+                                  const char* manufacturer, int confirmedId);
+    int enrichFindOrCreateFilament(WiFiClient& client, HTTPClient& http, const char* baseUrl,
+                                    const char* material, const char* colorHex, int vendorId,
+                                    float density, float diameter, int bedTemp, int nozzleTemp, int confirmedId);
+    int enrichFindSpoolByUid(WiFiClient& client, HTTPClient& http, const char* baseUrl,
+                              const char* quotedUid, float& outInitialWeight);
+    bool enrichUpdateSpool(WiFiClient& client, HTTPClient& http, const char* baseUrl,
+                            int spoolId, int filamentId, float remainingG, float existingInitialWeight);
+    int enrichCreateSpool(WiFiClient& client, HTTPClient& http, const char* baseUrl,
+                           int filamentId, float remainingG, const char* quotedUid);
 
     void sendError(int code, const char* msg);
 #endif


### PR DESCRIPTION
## Summary
- Extract per-format write functions from `executeWrite()` (126 → ~15 branch points)
- Extract `readAndProcessISO14443Tag()` from `scanLoop()` (90 → ~45)
- Extract per-tag-type serializers from `handleApiStatus()` (74 → ~10)
- Extract enrichment save steps from `handleApiSpoolmanSaveEnrichment()` (57 → ~12)
- Extract NDEF TLV parsing into `findNdefMediaRecord()` + `readNdefPayload()` (5 levels → 2)
- Shared helpers: `buildNdefTlv()`, `validateWriteUid()`, `forceRescan()`, `serializeEnrichment()`

## Test plan
- [x] Scan TigerTag — detected correctly
- [x] Scan OpenSpool tag — detected correctly
- [x] Scan plain NTAG (NFC+) — detected correctly
- [x] Write tag from writer page — write flow works
- [x] `/api/status` returns correct data
- [x] All 3 build targets compile clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable NFC tag reads/writes with broader tag-format support and steadier behavior.
  * More consistent API status payloads and smoother spool enrichment flows.

* **Bug Fixes**
  * Fixed incomplete NDEF reads and intermittent enrichment save failures.

* **Refactor**
  * Internal reorganization of NFC, web-server, and spool handling for maintainability.

* **Chores**
  * Updated repository ignore rules for internal documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->