### PR TITLE
feat: store and apply filament usage deductions (#123)

### DIFF
--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -5,6 +5,7 @@
 #include "ApplicationManager.h"
 #include "UserConfig.h"
 #include "ConversionUtils.h"
+#include "DeductionManager.h"
 #ifndef NATIVE_TEST
   #include "NFCTypes.h"
   #include "NFCManager.h"
@@ -405,6 +406,22 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
     } else if (display_) {
         Serial.printf("ApplicationManager: Skipping LCD update for already displayed spool %s\n", msg.payload.spoolDetected.spool_id);
     }
+
+    // Apply any pending filament deductions from middleware (stored in NVS).
+    // Must run before MQTT publish so middleware sees post-deduction weight.
+#ifndef NATIVE_TEST
+    {
+        CurrentSpoolState deductState;
+        if (NFCManager::getInstance().getCurrentSpoolState(deductState) && deductState.present) {
+            float deducted = DeductionManager::getInstance().applyIfPending(
+                deductState.spool_id, deductState.kind);
+            if (deducted > 0.0f) {
+                Serial.printf("ApplicationManager: Applied %.1fg pending deduction to %s\n",
+                              deducted, deductState.spool_id);
+            }
+        }
+    }
+#endif
 
     // Publish tag state to HA (always, regardless of mode)
     {

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -408,7 +408,7 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
     }
 
     // Apply any pending filament deductions from middleware (stored in NVS).
-    // Must run before MQTT publish so middleware sees post-deduction weight.
+    // Enqueues a tag write — updated weight publishes after write completes and re-scan triggers.
 #ifndef NATIVE_TEST
     {
         CurrentSpoolState deductState;

--- a/src/DeductionManager.cpp
+++ b/src/DeductionManager.cpp
@@ -1,0 +1,164 @@
+// DeductionManager.cpp — Pending filament deduction storage (NVS) and tag write-back.
+// Middleware sends usage deductions via MQTT after prints. Scanner stores them in NVS
+// and applies to writable tags (OpenPrintTag, OpenTag3D) on the next scan.
+
+#include "DeductionManager.h"
+
+#ifndef NATIVE_TEST
+  #include <Preferences.h>
+  #include <Arduino.h>
+  #include "NFCManager.h"
+  #include "opentag3d_lib.h"
+#endif
+
+DeductionManager& DeductionManager::getInstance() {
+    static DeductionManager instance;
+    return instance;
+}
+
+void DeductionManager::makeNvsKey(const char* uid, char* out, size_t outSize) {
+    // NVS key limit: 15 usable chars (16 including null terminator)
+    size_t maxLen = (outSize - 1 < 15) ? outSize - 1 : 15;
+    strncpy(out, uid, maxLen);
+    out[maxLen] = '\0';
+}
+
+void DeductionManager::storePending(const char* uid, float grams) {
+#ifndef NATIVE_TEST
+    char key[16];
+    makeNvsKey(uid, key, sizeof(key));
+
+    Preferences prefs;
+    prefs.begin("deductions", false);  // RW mode
+    float current = prefs.getFloat(key, 0.0f);
+    float total = current + grams;
+    prefs.putFloat(key, total);
+    prefs.end();
+
+    Serial.printf("DeductionManager: Stored %.1fg pending for %s (total: %.1fg)\n", grams, uid, total);
+#endif
+}
+
+float DeductionManager::getPending(const char* uid) {
+#ifndef NATIVE_TEST
+    char key[16];
+    makeNvsKey(uid, key, sizeof(key));
+
+    Preferences prefs;
+    prefs.begin("deductions", true);  // RO mode
+    float value = prefs.getFloat(key, 0.0f);
+    prefs.end();
+    return value;
+#else
+    return 0.0f;
+#endif
+}
+
+void DeductionManager::clearPending(const char* uid) {
+#ifndef NATIVE_TEST
+    char key[16];
+    makeNvsKey(uid, key, sizeof(key));
+
+    Preferences prefs;
+    prefs.begin("deductions", false);
+    prefs.remove(key);
+    prefs.end();
+
+    Serial.printf("DeductionManager: Cleared pending deduction for %s\n", uid);
+#endif
+}
+
+// ── Apply logic ─────────────────────────────────────────────
+
+static float applyOpenPrintTag(const char* uid, float pending) {
+#ifndef NATIVE_TEST
+    CurrentSpoolState state;
+    if (!NFCManager::getInstance().getCurrentSpoolState(state)) return 0.0f;
+    if (!state.tag_data_valid) return 0.0f;
+
+    float fullWeight = 0.0f, consumed = 0.0f;
+    opt_get_actual_full_weight(&state.tag_data, &fullWeight);
+    opt_get_consumed_weight(&state.tag_data, &consumed);
+    float remaining = fullWeight - consumed;
+    if (remaining < 0) remaining = 0;
+
+    // Clamp: don't deduct more than what's on the tag
+    float deduction = (pending > remaining) ? remaining : pending;
+
+    NFCWriteRequest req;
+    memset(&req, 0, sizeof(req));
+    req.request_id = NFCManager::getInstance().generateRequestId();
+    req.type = NFCWriteType::REMOVE_WEIGHT;
+    req.data.grams_to_remove = deduction;
+    strncpy(req.expected_spool_id, uid, sizeof(req.expected_spool_id) - 1);
+
+    NFCManager::getInstance().enqueueWrite(req);
+
+    Serial.printf("DeductionManager: Applied %.1fg deduction to OpenPrintTag %s (%.1fg remaining)\n",
+                  deduction, uid, remaining - deduction);
+    return deduction;
+#else
+    return 0.0f;
+#endif
+}
+
+static float applyOpenTag3D(const char* uid, float pending) {
+#ifndef NATIVE_TEST
+    opentag3d_t ot3d;
+    if (!NFCManager::getInstance().getLastOpenTag3DData(ot3d)) {
+        Serial.printf("DeductionManager: No cached OpenTag3D data for %s\n", uid);
+        return 0.0f;
+    }
+
+    // Use measured weight if available, otherwise target weight
+    float remaining = (ot3d.measured_filament_weight_g > 0)
+                      ? ot3d.measured_filament_weight_g
+                      : (float)ot3d.target_weight_g;
+
+    float deduction = (pending > remaining) ? remaining : pending;
+
+    // Subtract from the weight field the tag uses
+    if (ot3d.measured_filament_weight_g > 0) {
+        ot3d.measured_filament_weight_g -= (uint16_t)deduction;
+    } else {
+        int newWeight = (int)ot3d.target_weight_g - (int)deduction;
+        ot3d.target_weight_g = (newWeight > 0) ? (uint16_t)newWeight : 0;
+    }
+
+    NFCWriteRequest req;
+    memset(&req, 0, sizeof(req));
+    req.request_id = NFCManager::getInstance().generateRequestId();
+    req.type = NFCWriteType::WRITE_OPENTAG3D;
+    strncpy(req.expected_spool_id, uid, sizeof(req.expected_spool_id) - 1);
+
+    NFCManager::getInstance().enqueueRawWrite(req, (const uint8_t*)&ot3d, sizeof(ot3d));
+
+    Serial.printf("DeductionManager: Applied %.1fg deduction to OpenTag3D %s (%.1fg remaining)\n",
+                  deduction, uid, remaining - deduction);
+    return deduction;
+#else
+    return 0.0f;
+#endif
+}
+
+float DeductionManager::applyIfPending(const char* uid, TagKind kind) {
+    float pending = getPending(uid);
+    if (pending <= 0.0f) return 0.0f;
+
+    float deducted = 0.0f;
+    switch (kind) {
+        case TagKind::OpenPrintTag:
+            deducted = applyOpenPrintTag(uid, pending);
+            break;
+        case TagKind::OpenTag3D:
+            deducted = applyOpenTag3D(uid, pending);
+            break;
+        default:
+            // Tag can't accept weight writes — clear stale deduction
+            Serial.printf("DeductionManager: Tag type %d does not support weight writes — clearing\n", (int)kind);
+            break;
+    }
+
+    clearPending(uid);
+    return deducted;
+}

--- a/src/DeductionManager.cpp
+++ b/src/DeductionManager.cpp
@@ -92,8 +92,12 @@ static float applyOpenPrintTag(const char* uid, float pending) {
     req.data.grams_to_remove = deduction;
     strncpy(req.expected_spool_id, uid, sizeof(req.expected_spool_id) - 1);
 
-    NFCManager::getInstance().enqueueWrite(req);
+    if (!NFCManager::getInstance().enqueueWrite(req)) {
+        Serial.printf("DeductionManager: Write queue full — deduction kept in NVS for retry\n");
+        return 0.0f;  // don't clear NVS, retry on next scan
+    }
 
+    DeductionManager::getInstance().clearPending(uid);
     Serial.printf("DeductionManager: Applied %.1fg deduction to OpenPrintTag %s (%.1fg remaining)\n",
                   deduction, uid, remaining - deduction);
     return deduction;
@@ -117,12 +121,13 @@ static float applyOpenTag3D(const char* uid, float pending) {
 
     float deduction = (pending > remaining) ? remaining : pending;
 
-    // Subtract from the weight field the tag uses
+    // Subtract from the weight field the tag uses (round to avoid truncation loss)
     if (ot3d.measured_filament_weight_g > 0) {
-        ot3d.measured_filament_weight_g -= (uint16_t)deduction;
+        int newMeasured = (int)lroundf(ot3d.measured_filament_weight_g - deduction);
+        ot3d.measured_filament_weight_g = (newMeasured > 0) ? (uint16_t)newMeasured : 0;
     } else {
-        int newWeight = (int)ot3d.target_weight_g - (int)deduction;
-        ot3d.target_weight_g = (newWeight > 0) ? (uint16_t)newWeight : 0;
+        int newTarget = (int)lroundf(ot3d.target_weight_g - deduction);
+        ot3d.target_weight_g = (newTarget > 0) ? (uint16_t)newTarget : 0;
     }
 
     NFCWriteRequest req;
@@ -131,8 +136,12 @@ static float applyOpenTag3D(const char* uid, float pending) {
     req.type = NFCWriteType::WRITE_OPENTAG3D;
     strncpy(req.expected_spool_id, uid, sizeof(req.expected_spool_id) - 1);
 
-    NFCManager::getInstance().enqueueRawWrite(req, (const uint8_t*)&ot3d, sizeof(ot3d));
+    if (!NFCManager::getInstance().enqueueRawWrite(req, (const uint8_t*)&ot3d, sizeof(ot3d))) {
+        Serial.printf("DeductionManager: Write queue full — deduction kept in NVS for retry\n");
+        return 0.0f;
+    }
 
+    DeductionManager::getInstance().clearPending(uid);
     Serial.printf("DeductionManager: Applied %.1fg deduction to OpenTag3D %s (%.1fg remaining)\n",
                   deduction, uid, remaining - deduction);
     return deduction;
@@ -154,11 +163,14 @@ float DeductionManager::applyIfPending(const char* uid, TagKind kind) {
             deducted = applyOpenTag3D(uid, pending);
             break;
         default:
-            // Tag can't accept weight writes — clear stale deduction
+            // Tag can't accept weight writes — clear stale deduction so it doesn't accumulate forever
             Serial.printf("DeductionManager: Tag type %d does not support weight writes — clearing\n", (int)kind);
+            clearPending(uid);
             break;
     }
 
-    clearPending(uid);
+    // Clear only happens inside apply functions after successful enqueue,
+    // or above for non-writable tags. Don't clear here — if enqueue failed,
+    // deduction stays in NVS for next scan attempt.
     return deducted;
 }

--- a/src/DeductionManager.h
+++ b/src/DeductionManager.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "NFCTypes.h"
+
+// DeductionManager — stores pending filament usage deductions in NVS and applies
+// them to writable NFC tags on scan. Middleware sends deductions via MQTT after
+// prints; scanner stores them persistently and writes to tag when next scanned.
+
+class DeductionManager {
+public:
+    static DeductionManager& getInstance();
+
+    // Accumulate a deduction for a UID. Adds to any existing pending amount.
+    void storePending(const char* uid, float grams);
+
+    // Apply pending deduction to tag if one exists. Enqueues the appropriate
+    // write type and clears NVS on success. Returns grams deducted (0 if none).
+    float applyIfPending(const char* uid, TagKind kind);
+
+    // Read pending amount without clearing (diagnostics)
+    float getPending(const char* uid);
+
+    // Clear pending deduction after successful tag write
+    void clearPending(const char* uid);
+
+private:
+    DeductionManager() = default;
+    DeductionManager(const DeductionManager&) = delete;
+    DeductionManager& operator=(const DeductionManager&) = delete;
+
+    // Truncate UID to 15 chars for NVS key limit (16 including null terminator).
+    // 7-byte UIDs (14 hex chars) fit fully. 8-byte UIDs (16 hex chars) lose last char.
+    void makeNvsKey(const char* uid, char* out, size_t outSize);
+};

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -12,6 +12,7 @@
 #ifndef NATIVE_TEST
   #include <Arduino.h>
   #include <WiFi.h>
+  #include <ArduinoJson.h>
   #include <json.hpp>
 
   #include <esp_heap_caps.h>
@@ -856,31 +857,12 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
             publishCommandResponse(command, false, "missing_uid_in_topic");
             return;
         }
-        float deductG = 0.0f;
-        const_buffer_stream stm((const uint8_t*)payload, strlen(payload));
-        json_reader reader(stm);
-        if (!reader.read() || reader.node_type() != json_node_type::object) {
+        StaticJsonDocument<64> deductDoc;
+        if (deserializeJson(deductDoc, payload)) {
             publishCommandResponse(command, false, "invalid_json");
             return;
         }
-        const unsigned rootDepth = reader.depth();
-        while (reader.read()) {
-            if (reader.node_type() == json_node_type::end_object && reader.depth() == rootDepth) {
-                break;
-            }
-            if (reader.node_type() != json_node_type::field || reader.depth() != rootDepth) {
-                continue;
-            }
-            const char* field = reader.value();
-            if (!reader.read() || reader.node_type() != json_node_type::value) {
-                publishCommandResponse(command, false, "invalid_json");
-                return;
-            }
-            if (strcmp(field, "deduct_g") == 0 &&
-                (reader.value_type() == json_value_type::real || reader.value_type() == json_value_type::integer)) {
-                deductG = static_cast<float>(reader.value_real());
-            }
-        }
+        float deductG = deductDoc["deduct_g"] | 0.0f;
         if (deductG <= 0.0f) {
             publishCommandResponse(command, false, "invalid_deduct_g");
             return;

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -871,10 +871,11 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
         DeductionManager::getInstance().storePending(uidFromTopic, deductG);
 
         // If tag is currently on scanner, apply immediately instead of waiting for next scan
+        // Use case-insensitive compare — MQTT topic UID may differ in case from scanner's uppercase
         CurrentSpoolState deductSpool;
         if (NFCManager::getInstance().getCurrentSpoolState(deductSpool) &&
-            deductSpool.present && strcmp(deductSpool.spool_id, uidFromTopic) == 0) {
-            DeductionManager::getInstance().applyIfPending(uidFromTopic, deductSpool.kind);
+            deductSpool.present && strcasecmp(deductSpool.spool_id, uidFromTopic) == 0) {
+            DeductionManager::getInstance().applyIfPending(deductSpool.spool_id, deductSpool.kind);
         }
 
         publishCommandResponse(command, true, nullptr);

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -6,6 +6,7 @@
 #include "ApplicationManager.h"
 #include "ConfigurationManager.h"
 #include "ConversionUtils.h"
+#include "DeductionManager.h"
 #include "LEDManager.h"
 
 #ifndef NATIVE_TEST
@@ -846,6 +847,55 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
                 ledManager.showFilamentColor(r, g, b);
             }
         }
+        return;
+    }
+
+    // deduct: store filament usage deduction — tag may not be on scanner
+    if (strcmp(command, "deduct") == 0) {
+        if (strlen(uidFromTopic) == 0) {
+            publishCommandResponse(command, false, "missing_uid_in_topic");
+            return;
+        }
+        float deductG = 0.0f;
+        const_buffer_stream stm((const uint8_t*)payload, strlen(payload));
+        json_reader reader(stm);
+        if (!reader.read() || reader.node_type() != json_node_type::object) {
+            publishCommandResponse(command, false, "invalid_json");
+            return;
+        }
+        const unsigned rootDepth = reader.depth();
+        while (reader.read()) {
+            if (reader.node_type() == json_node_type::end_object && reader.depth() == rootDepth) {
+                break;
+            }
+            if (reader.node_type() != json_node_type::field || reader.depth() != rootDepth) {
+                continue;
+            }
+            const char* field = reader.value();
+            if (!reader.read() || reader.node_type() != json_node_type::value) {
+                publishCommandResponse(command, false, "invalid_json");
+                return;
+            }
+            if (strcmp(field, "deduct_g") == 0 &&
+                (reader.value_type() == json_value_type::real || reader.value_type() == json_value_type::integer)) {
+                deductG = static_cast<float>(reader.value_real());
+            }
+        }
+        if (deductG <= 0.0f) {
+            publishCommandResponse(command, false, "invalid_deduct_g");
+            return;
+        }
+
+        DeductionManager::getInstance().storePending(uidFromTopic, deductG);
+
+        // If tag is currently on scanner, apply immediately instead of waiting for next scan
+        CurrentSpoolState deductSpool;
+        if (NFCManager::getInstance().getCurrentSpoolState(deductSpool) &&
+            deductSpool.present && strcmp(deductSpool.spool_id, uidFromTopic) == 0) {
+            DeductionManager::getInstance().applyIfPending(uidFromTopic, deductSpool.kind);
+        }
+
+        publishCommandResponse(command, true, nullptr);
         return;
     }
 


### PR DESCRIPTION
## Summary
- New `DeductionManager` stores pending filament deductions in NVS
- MQTT `cmd/deduct/<uid>` handler accumulates deductions
- Deductions apply automatically on next tag scan (before MQTT publish)
- Supports OpenPrintTag (aux region write) and OpenTag3D (NDEF rebuild)
- Persists across reboots, clamps to zero on apply
- Non-writable tags (TigerTag, OpenSpool, UID-only) clear stale deductions gracefully

## Test plan
- [x] MQTT deduct stores pending amount in NVS
- [x] Scan applies deduction and writes to physical tag
- [x] Tag weight updated (777g → 752g after 25.5g deduction)
- [x] NVS cleared after successful apply
- [x] Spoolman synced with post-deduction weight
- [x] Second scan confirms no pending deduction
- [x] All 3 build targets compile clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Home Assistant "deduct" MQTT command to record filament deductions with input validation and success/error responses.
  * Pending deductions persist across restarts and are applied automatically when the corresponding NFC tag is scanned or immediately if the tag is present.
  * Supports multiple NFC tag types; deductions are clamped to remaining filament and only cleared once the write succeeds (will retry if the write queue is full).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->