### PR TITLE
feat: keep tag session alive between consecutive reads

### DIFF
--- a/src/HardwareNFCConnection.cpp
+++ b/src/HardwareNFCConnection.cpp
@@ -299,8 +299,15 @@ bool HardwareNFCConnection::detectTag(uint8_t* uid, uint8_t* uidLength) {
     return false;
 }
 
+void HardwareNFCConnection::endTagSession() {
+    if (tagSessionActive_ && iso14443a_) {
+        iso14443a_->mifareHalt();
+        tagSessionActive_ = false;
+    }
+}
+
 uint16_t HardwareNFCConnection::readISO14443Pages(uint8_t startPage, uint8_t pageCount,
-                                                    uint8_t* buffer, uint16_t bufferSize) {
+                                                    uint8_t* buffer, uint16_t bufferSize, bool keepSession) {
     if (!iso14443a_ || pageCount == 0 || buffer == nullptr) return 0;
 
     uint16_t totalBytes = pageCount * 4;
@@ -348,8 +355,10 @@ uint16_t HardwareNFCConnection::readISO14443Pages(uint8_t startPage, uint8_t pag
     }
 
     unsigned long rT3 = millis();
-    iso14443a_->mifareHalt();
-    tagSessionActive_ = false;  // tag halted after read — next read must re-activate
+    if (!keepSession) {
+        iso14443a_->mifareHalt();
+        tagSessionActive_ = false;
+    }
     Serial.printf("TIMING readPages: setupRF=%lums activate=%lums read=%lums total=%lums (%d bytes)\n",
                   rT1-rT0, rT2-rT1, rT3-rT2, rT3-rT0, bytesRead);
     return bytesRead;

--- a/src/HardwareNFCConnection.h
+++ b/src/HardwareNFCConnection.h
@@ -20,7 +20,8 @@ public:
     bool detectTag(uint8_t* uid, uint8_t* uidLength) override;
     void setCurrentUid(const uint8_t* uid, uint8_t length) override;
     opt_nfc_hal_t* getHal() override;
-    uint16_t readISO14443Pages(uint8_t startPage, uint8_t pageCount, uint8_t* buffer, uint16_t bufferSize) override;
+    uint16_t readISO14443Pages(uint8_t startPage, uint8_t pageCount, uint8_t* buffer, uint16_t bufferSize, bool keepSession = false) override;
+    void endTagSession() override;
     bool writeISO14443Pages(uint8_t startPage, uint8_t pageCount, const uint8_t* data, uint16_t dataLen) override;
     uint8_t getLastSAK() const override { return lastSAK_; }
     uint16_t getLastATQA() const override { return lastATQA_; }

--- a/src/HardwareNFCConnectionPN532.cpp
+++ b/src/HardwareNFCConnectionPN532.cpp
@@ -137,7 +137,7 @@ bool HardwareNFCConnectionPN532::reactivateTag() {
 }
 
 uint16_t HardwareNFCConnectionPN532::readISO14443Pages(
-    uint8_t startPage, uint8_t pageCount, uint8_t* buffer, uint16_t bufferSize) {
+    uint8_t startPage, uint8_t pageCount, uint8_t* buffer, uint16_t bufferSize, bool /*keepSession*/) {
     if (!pn532_ || !ready_) return 0;
 
     uint16_t totalBytes = (uint16_t)pageCount * 4;

--- a/src/HardwareNFCConnectionPN532.h
+++ b/src/HardwareNFCConnectionPN532.h
@@ -21,7 +21,7 @@ public:
     bool ntagGetVersion(uint8_t* versionOut) override;
     void setCurrentUid(const uint8_t* uid, uint8_t length) override;
     opt_nfc_hal_t* getHal() override;
-    uint16_t readISO14443Pages(uint8_t startPage, uint8_t pageCount, uint8_t* buffer, uint16_t bufferSize) override;
+    uint16_t readISO14443Pages(uint8_t startPage, uint8_t pageCount, uint8_t* buffer, uint16_t bufferSize, bool keepSession = false) override;
     bool writeISO14443Pages(uint8_t startPage, uint8_t pageCount, const uint8_t* data, uint16_t dataLen) override;
     void getReaderInfo(char* buf, size_t len) const override;
     void logDiagnostics() override;

--- a/src/HardwareNFCConnectionPN532.h
+++ b/src/HardwareNFCConnectionPN532.h
@@ -21,7 +21,10 @@ public:
     bool ntagGetVersion(uint8_t* versionOut) override;
     void setCurrentUid(const uint8_t* uid, uint8_t length) override;
     opt_nfc_hal_t* getHal() override;
+    // keepSession is ignored: PN532 manages tag activation per-page via reactivateTag()
     uint16_t readISO14443Pages(uint8_t startPage, uint8_t pageCount, uint8_t* buffer, uint16_t bufferSize, bool keepSession = false) override;
+    // No-op: PN532 has no explicit session state to end
+    void endTagSession() override {}
     bool writeISO14443Pages(uint8_t startPage, uint8_t pageCount, const uint8_t* data, uint16_t dataLen) override;
     void getReaderInfo(char* buf, size_t len) const override;
     void logDiagnostics() override;

--- a/src/NFCConnectionI.h
+++ b/src/NFCConnectionI.h
@@ -37,8 +37,12 @@ public:
     virtual opt_nfc_hal_t* getHal() = 0;
 
     // Read ISO14443A tag pages (NTAG213/215/216). Reactivates tag if needed.
+    // When keepSession=true, tag stays active after read for a follow-up read.
     // Returns number of bytes read, or 0 on failure.
-    virtual uint16_t readISO14443Pages(uint8_t startPage, uint8_t pageCount, uint8_t* buffer, uint16_t bufferSize) = 0;
+    virtual uint16_t readISO14443Pages(uint8_t startPage, uint8_t pageCount, uint8_t* buffer, uint16_t bufferSize, bool keepSession = false) = 0;
+
+    // End an active tag session (halt tag). No-op if no session is active.
+    virtual void endTagSession() {}
 
     // Write ISO14443A tag pages (NTAG213/215/216). Writes 4 bytes per page.
     // Returns true if all pages written successfully.

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -295,7 +295,7 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
     memset(&ot3dData, 0, sizeof(ot3dData));
 
     uint8_t pageData[40] = {0};
-    uint16_t bytesRead = connection_->readISO14443Pages(4, 10, pageData, sizeof(pageData));
+    uint16_t bytesRead = connection_->readISO14443Pages(4, 10, pageData, sizeof(pageData), true);
 
     // Try TigerTag first (binary magic at offset 0)
     if (bytesRead >= 14 && tigerTagCheckMagic(pageData, bytesRead)) {
@@ -342,6 +342,9 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
             }
         }
     }
+
+    // All reads done — halt tag if session is still active
+    connection_->endTagSession();
 
     // Update shared state under mutex
     if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {


### PR DESCRIPTION
## Summary

- Add `keepSession` parameter to `readISO14443Pages()` so the first page read preserves the active tag session for a follow-up extended NDEF read
- Add `endTagSession()` to cleanly halt the tag after all reads are complete
- First read in `readAndProcessISO14443Tag()` now passes `keepSession=true`; `endTagSession()` called after classification

Eliminates the costly `setupRF()` + `activateTypeA()` re-activation cycle between the initial 40-byte read and the extended NDEF read. This was the root cause of OpenTag3D quick-tap failures — the tag couldn't survive the RF field toggle during re-activation.

## Benchmarks

| Metric | Before | After |
|--------|--------|-------|
| Extended read time | 1080ms | 420ms |
| Extended read setupRF | 510ms | 0ms |
| Extended read activate | 150ms | 0ms |
| Quick-tap OpenTag3D | ❌ fails | ✅ reliable |

Tested across 4 tag types (OpenTag3D, TigerTag, OpenSpool, GenericUID) — all working correctly.

## Test plan

- [x] Build succeeds (esp32s3devkitc)
- [x] Quick-tap OpenTag3D — full decode, no re-activation
- [x] OpenSpool extended read — session alive, 0ms setupRF
- [x] TigerTag single read — no regression
- [x] GenericUID fallback — no regression

Closes #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added control over NFC tag session lifecycle during page reads, with an option to keep a session open across sequential reads.
  * Explicit session termination added to end active tag sessions reliably.
  * NFC processing now explicitly ends sessions after decoding, improving resource handling, efficiency, and read reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->