### PR TITLE
feat: web serial log viewer

### DIFF
--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -9,6 +9,7 @@
 #include "DeductionManager.h"
 #include "TagStateJson.h"
 #include "LEDManager.h"
+#include "LogBuffer.h"
 
 #ifndef NATIVE_TEST
   #include <Arduino.h>
@@ -381,6 +382,7 @@ void HomeAssistantManager::taskLoop() {
                     publishAvailability("online");
                     publishCurrentTagState();
                     Serial.println("HomeAssistantManager: Connected to MQTT broker");
+                    LogBuffer::getInstance().logPrintf("MQTT connected\n");
                 } else {
                     connected_ = false;
                     // Exponential backoff: 1s → 2s → 4s → ... up to MAX (avoid broker hammering)
@@ -389,6 +391,7 @@ void HomeAssistantManager::taskLoop() {
                     lastMqttState_ = mqttClient.state();
                     Serial.printf("HomeAssistantManager: MQTT connect failed, retry in %lums\n",
                                   reconnectDelay_);
+                    LogBuffer::getInstance().logPrintf("MQTT connect failed, retry in %lums\n", reconnectDelay_);
                 }
             }
         }

--- a/src/LandingHTML.h
+++ b/src/LandingHTML.h
@@ -96,6 +96,12 @@ const char LANDING_HTML[] PROGMEM = R"rawliteral(
         <div class="tool-desc">Verify scanner connectivity, MQTT, Spoolman, and NFC reader status.</div>
       </a>
 
+      <a href="/logs" class="tool-card">
+        <div class="tool-icon">&#128220;</div>
+        <div class="tool-name">Serial Log</div>
+        <div class="tool-desc">View live scanner serial output for debugging.</div>
+      </a>
+
       <a href="/config" class="tool-card">
         <div class="tool-icon">&#9881;</div>
         <div class="tool-name">Configuration</div>

--- a/src/LogBuffer.cpp
+++ b/src/LogBuffer.cpp
@@ -1,0 +1,68 @@
+#include "LogBuffer.h"
+#include <stdarg.h>
+#include <cstring>
+
+LogBuffer::LogBuffer() {
+    mutex_ = xSemaphoreCreateMutex();
+    memset(buffer_, 0, BUFFER_SIZE);
+}
+
+LogBuffer& LogBuffer::getInstance() {
+    static LogBuffer instance;
+    return instance;
+}
+
+void LogBuffer::append(const char* data, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        buffer_[head_] = data[i];
+        head_ = (head_ + 1) % BUFFER_SIZE;
+        if (count_ < BUFFER_SIZE) count_++;
+    }
+}
+
+void LogBuffer::logPrintf(const char* format, ...) {
+    char temp[256];
+    va_list args;
+    va_start(args, format);
+    int len = vsnprintf(temp, sizeof(temp), format, args);
+    va_end(args);
+
+    if (len <= 0) return;
+    if ((size_t)len >= sizeof(temp)) len = sizeof(temp) - 1;
+
+    // Write to Serial
+    Serial.print(temp);
+
+    // Write to ring buffer under mutex
+    if (xSemaphoreTake(mutex_, pdMS_TO_TICKS(50)) == pdTRUE) {
+        append(temp, len);
+        xSemaphoreGive(mutex_);
+    }
+}
+
+size_t LogBuffer::getLog(char* out, size_t outSize) {
+    if (!out || outSize == 0) return 0;
+
+    if (xSemaphoreTake(mutex_, pdMS_TO_TICKS(100)) == pdTRUE) {
+        size_t available = (count_ < outSize - 1) ? count_ : outSize - 1;
+        // Oldest data starts at (head_ - count_) wrapped
+        size_t start = (head_ + BUFFER_SIZE - count_) % BUFFER_SIZE;
+
+        for (size_t i = 0; i < available; i++) {
+            out[i] = buffer_[(start + i) % BUFFER_SIZE];
+        }
+        out[available] = '\0';
+        xSemaphoreGive(mutex_);
+        return available;
+    }
+    out[0] = '\0';
+    return 0;
+}
+
+void LogBuffer::clear() {
+    if (xSemaphoreTake(mutex_, pdMS_TO_TICKS(50)) == pdTRUE) {
+        head_ = 0;
+        count_ = 0;
+        xSemaphoreGive(mutex_);
+    }
+}

--- a/src/LogBuffer.cpp
+++ b/src/LogBuffer.cpp
@@ -1,10 +1,10 @@
 #include "LogBuffer.h"
-#include <stdarg.h>
+#include <cstdarg>
 #include <cstring>
 
-LogBuffer::LogBuffer() {
-    mutex_ = xSemaphoreCreateMutex();
+LogBuffer::LogBuffer() : mutex_(xSemaphoreCreateMutex()) {
     memset(buffer_, 0, BUFFER_SIZE);
+    if (!mutex_) Serial.println("LogBuffer: CRITICAL — mutex creation failed");
 }
 
 LogBuffer& LogBuffer::getInstance() {

--- a/src/LogBuffer.h
+++ b/src/LogBuffer.h
@@ -29,6 +29,8 @@ private:
     SemaphoreHandle_t mutex_;
 
     LogBuffer();
+    LogBuffer(const LogBuffer&) = delete;
+    LogBuffer& operator=(const LogBuffer&) = delete;
     void append(const char* data, size_t len);
 };
 

--- a/src/LogBuffer.h
+++ b/src/LogBuffer.h
@@ -1,0 +1,35 @@
+#ifndef LOG_BUFFER_H
+#define LOG_BUFFER_H
+
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+// Circular log buffer that captures Serial output for web UI viewing.
+// Thread-safe — safe to call from any FreeRTOS task.
+class LogBuffer {
+public:
+    static LogBuffer& getInstance();
+
+    // Write formatted output to both Serial and the ring buffer
+    void logPrintf(const char* format, ...) __attribute__((format(printf, 2, 3)));
+
+    // Copy current buffer contents into a pre-allocated char array.
+    // Returns number of bytes written (excluding null terminator).
+    size_t getLog(char* out, size_t outSize);
+
+    void clear();
+
+private:
+    static constexpr size_t BUFFER_SIZE = 4096;
+
+    char buffer_[BUFFER_SIZE];
+    size_t head_ = 0;
+    size_t count_ = 0;
+    SemaphoreHandle_t mutex_;
+
+    LogBuffer();
+    void append(const char* data, size_t len);
+};
+
+#endif // LOG_BUFFER_H

--- a/src/LogViewerHTML.h
+++ b/src/LogViewerHTML.h
@@ -1,0 +1,146 @@
+#ifndef LogViewerHTML_h
+#define LogViewerHTML_h
+
+#include <Arduino.h>
+
+const char LOG_VIEWER_HTML[] PROGMEM = R"=====(
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Serial Log</title>
+    <style>
+        :root {
+            --bg: #0b0b0d;
+            --panel: #141519;
+            --panel-2: #1a1c21;
+            --border: #2a2e36;
+            --text: #f4f4f5;
+            --muted: #a1a1aa;
+            --blue: #3b82f6;
+            --radius: 16px;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            background: var(--bg);
+            color: var(--text);
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+        .wrap {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px 16px;
+        }
+        nav {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px 14px;
+            margin-bottom: 24px;
+            font-size: 13px;
+            font-weight: 600;
+        }
+        nav a {
+            color: var(--muted);
+            text-decoration: none;
+        }
+        nav a:hover, nav a.active {
+            color: var(--text);
+        }
+        .nav-brand {
+            color: var(--blue);
+            font-weight: 800;
+            margin-right: 8px;
+        }
+        h2 { font-size: 1.3em; margin-bottom: 6px; }
+        .subtitle {
+            color: var(--muted);
+            font-size: 14px;
+            margin-bottom: 16px;
+        }
+        .controls {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            margin-bottom: 12px;
+            font-size: 13px;
+            color: var(--muted);
+        }
+        .controls label { cursor: pointer; }
+        .btn {
+            background: var(--blue);
+            color: #fff;
+            border: none;
+            padding: 6px 16px;
+            cursor: pointer;
+            border-radius: 8px;
+            font-size: 13px;
+            font-weight: 600;
+        }
+        .btn:hover { opacity: 0.88; }
+        pre {
+            background: var(--panel);
+            padding: 14px;
+            border-radius: var(--radius);
+            overflow: auto;
+            max-height: 70vh;
+            font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+            font-size: 12px;
+            line-height: 1.5;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            border: 1px solid var(--border);
+            color: var(--muted);
+        }
+    </style>
+</head>
+<body>
+    <div class="wrap">
+        <nav>
+            <span class="nav-brand">SpoolSense</span>
+            <a href="/">Home</a>
+            <a href="/reader">Reader</a>
+            <a href="/writer/openprinttag">OpenPrintTag</a>
+            <a href="/writer/tigertag">TigerTag</a>
+            <a href="/writer/opentag3d">OpenTag3D</a>
+            <a href="/writer/openspool">OpenSpool</a>
+            <a href="/register/uid">NFC+</a>
+            <a href="/update">Update</a>
+            <a href="/troubleshooting">Troubleshooting</a>
+            <a href="/logs" class="active">Logs</a>
+            <a href="/config">Config</a>
+        </nav>
+
+        <h2>Serial Log</h2>
+        <p class="subtitle">Live scanner output for debugging. Auto-refreshes every 2 seconds.</p>
+
+        <div class="controls">
+            <label><input type="checkbox" id="autoscroll" checked> Auto-scroll</label>
+            <button class="btn" onclick="clearLogs()">Clear</button>
+        </div>
+        <pre id="logOutput">(empty)</pre>
+    </div>
+    <script>
+        var logEl = document.getElementById('logOutput');
+        var autoEl = document.getElementById('autoscroll');
+        function fetchLogs() {
+            fetch('/api/logs')
+                .then(function(r) { return r.text(); })
+                .then(function(data) {
+                    logEl.textContent = data || '(empty)';
+                    if (autoEl.checked) logEl.scrollTop = logEl.scrollHeight;
+                })
+                .catch(function(e) { logEl.textContent = 'Error: ' + e.message; });
+        }
+        function clearLogs() {
+            fetch('/api/logs/clear', { method: 'POST' })
+                .then(function() { fetchLogs(); });
+        }
+        fetchLogs();
+        setInterval(fetchLogs, 2000);
+    </script>
+</body>
+</html>
+)=====";
+
+#endif

--- a/src/LogViewerHTML.h
+++ b/src/LogViewerHTML.h
@@ -116,6 +116,7 @@ const char LOG_VIEWER_HTML[] PROGMEM = R"=====(
 
         <div class="controls">
             <label><input type="checkbox" id="autoscroll" checked> Auto-scroll</label>
+            <button class="btn" onclick="copyLogs()">Copy</button>
             <button class="btn" onclick="clearLogs()">Clear</button>
         </div>
         <pre id="logOutput">(empty)</pre>
@@ -131,6 +132,23 @@ const char LOG_VIEWER_HTML[] PROGMEM = R"=====(
                     if (autoEl.checked) logEl.scrollTop = logEl.scrollHeight;
                 })
                 .catch(function(e) { logEl.textContent = 'Error: ' + e.message; });
+        }
+        function copyLogs() {
+            var text = logEl.textContent;
+            if (navigator.clipboard) {
+                navigator.clipboard.writeText(text).then(function() {
+                    var btn = document.querySelector('.btn');
+                    btn.textContent = 'Copied!';
+                    setTimeout(function() { btn.textContent = 'Copy'; }, 1500);
+                });
+            } else {
+                var ta = document.createElement('textarea');
+                ta.value = text;
+                document.body.appendChild(ta);
+                ta.select();
+                document.execCommand('copy');
+                document.body.removeChild(ta);
+            }
         }
         function clearLogs() {
             fetch('/api/logs/clear', { method: 'POST' })

--- a/src/LogViewerHTML.h
+++ b/src/LogViewerHTML.h
@@ -5,54 +5,13 @@
 
 const char LOG_VIEWER_HTML[] PROGMEM = R"=====(
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Serial Log</title>
+    <title>Serial Log &mdash; SpoolSense</title>
+    <link rel="stylesheet" href="/css/shared.css" />
     <style>
-        :root {
-            --bg: #0b0b0d;
-            --panel: #141519;
-            --panel-2: #1a1c21;
-            --border: #2a2e36;
-            --text: #f4f4f5;
-            --muted: #a1a1aa;
-            --blue: #3b82f6;
-            --radius: 16px;
-        }
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body {
-            background: var(--bg);
-            color: var(--text);
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
-        .wrap {
-            max-width: 800px;
-            margin: 0 auto;
-            padding: 20px 16px;
-        }
-        nav {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 8px 14px;
-            margin-bottom: 24px;
-            font-size: 13px;
-            font-weight: 600;
-        }
-        nav a {
-            color: var(--muted);
-            text-decoration: none;
-        }
-        nav a:hover, nav a.active {
-            color: var(--text);
-        }
-        .nav-brand {
-            color: var(--blue);
-            font-weight: 800;
-            margin-right: 8px;
-        }
-        h2 { font-size: 1.3em; margin-bottom: 6px; }
         .subtitle {
             color: var(--muted);
             font-size: 14px;
@@ -67,17 +26,16 @@ const char LOG_VIEWER_HTML[] PROGMEM = R"=====(
             color: var(--muted);
         }
         .controls label { cursor: pointer; }
-        .btn {
-            background: var(--blue);
-            color: #fff;
-            border: none;
-            padding: 6px 16px;
+        .log-btn {
+            font-size: 11px;
+            padding: 4px 10px;
+            background: rgba(99,102,241,.2);
+            color: #a5b4fc;
+            border: 1px solid rgba(99,102,241,.4);
+            border-radius: 6px;
             cursor: pointer;
-            border-radius: 8px;
-            font-size: 13px;
-            font-weight: 600;
         }
-        .btn:hover { opacity: 0.88; }
+        .log-btn:hover { background: rgba(99,102,241,.35); }
         pre {
             background: var(--panel);
             padding: 14px;
@@ -111,13 +69,13 @@ const char LOG_VIEWER_HTML[] PROGMEM = R"=====(
             <a href="/config">Config</a>
         </nav>
 
-        <h2>Serial Log</h2>
+        <h2 style="margin-bottom:6px">Serial Log</h2>
         <p class="subtitle">Live scanner output for debugging. Auto-refreshes every 2 seconds.</p>
 
         <div class="controls">
             <label><input type="checkbox" id="autoscroll" checked> Auto-scroll</label>
-            <button class="btn" onclick="copyLogs()">Copy</button>
-            <button class="btn" onclick="clearLogs()">Clear</button>
+            <button class="log-btn" onclick="copyLogs()">Copy</button>
+            <button class="log-btn" onclick="clearLogs()">Clear</button>
         </div>
         <pre id="logOutput">(empty)</pre>
     </div>
@@ -137,9 +95,9 @@ const char LOG_VIEWER_HTML[] PROGMEM = R"=====(
             var text = logEl.textContent;
             if (navigator.clipboard) {
                 navigator.clipboard.writeText(text).then(function() {
-                    var btn = document.querySelector('.btn');
-                    btn.textContent = 'Copied!';
-                    setTimeout(function() { btn.textContent = 'Copy'; }, 1500);
+                    var btns = document.querySelectorAll('.log-btn');
+                    btns[0].textContent = 'Copied!';
+                    setTimeout(function() { btns[0].textContent = 'Copy'; }, 1500);
                 });
             } else {
                 var ta = document.createElement('textarea');

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -6,6 +6,7 @@
   #include "ApplicationManager.h"
   #include "HardwareNFCConnection.h"
   #include "SpoolmanManager.h"
+  #include "LogBuffer.h"
   #include <Arduino.h>
 #else
   #include "platform/NativePlatform.h"
@@ -367,6 +368,8 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
             lastOpenTag3DValid_ = false;
             Serial.printf("NFCManager: TigerTag detected — %s %s %s\n",
                           tigerData.brand_name, tigerData.material_name, tigerData.aspect1_name);
+            LogBuffer::getInstance().logPrintf("TigerTag: %s %s %s\n",
+                          tigerData.brand_name, tigerData.material_name, tigerData.aspect1_name);
         } else if (isOpenTag3D) {
             currentSpool.kind = TagKind::OpenTag3D;
             currentSpool.tag_data_valid = false;
@@ -377,6 +380,9 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
             Serial.printf("NFCManager: OpenTag3D detected — %s %s %.2fmm %ug\n",
                           ot3dData.manufacturer, ot3dData.base_material,
                           opentag3d_diameter_mm(&ot3dData), ot3dData.target_weight_g);
+            LogBuffer::getInstance().logPrintf("OpenTag3D: %s %s %.2fmm %ug\n",
+                          ot3dData.manufacturer, ot3dData.base_material,
+                          opentag3d_diameter_mm(&ot3dData), ot3dData.target_weight_g);
         } else if (isOpenSpool) {
             currentSpool.kind = TagKind::OpenSpoolTag;
             currentSpool.tag_data_valid = false;
@@ -385,6 +391,8 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
             lastTigerTagValid_ = false;
             lastOpenTag3DValid_ = false;
             Serial.printf("NFCManager: OpenSpool detected — %s %s #%s\n",
+                          openSpoolData.brand, openSpoolData.material, openSpoolData.color_hex);
+            LogBuffer::getInstance().logPrintf("OpenSpool: %s %s #%s\n",
                           openSpoolData.brand, openSpoolData.material, openSpoolData.color_hex);
         } else {
             currentSpool.kind = TagKind::GenericUidTag;
@@ -490,6 +498,7 @@ void NFCManager::handleNewTag(uint8_t* uid, uint8_t uidLength) {
             xSemaphoreGive(tagMutex);
         }
         Serial.printf("NFCManager: Bambu Lab tag — UID=%s (encrypted, no data access)\n", scan.uid_hex);
+        LogBuffer::getInstance().logPrintf("Bambu Lab tag: %s (encrypted)\n", scan.uid_hex);
         sendGenericTagMessage();
         return;
     }
@@ -545,6 +554,7 @@ void NFCManager::handleTagAbsent() {
 
     if (lastSeenValid) {  // only send removal if we had a tag
         Serial.println("NFCManager: Tag removed");
+        LogBuffer::getInstance().logPrintf("Tag removed: %s\n", currentSpool.spool_id);
         sendTagRemovedMessage();
     }
     currentSpool.present = false;
@@ -585,9 +595,10 @@ void NFCManager::scanLoop() {
 
         if (connection_->detectTag(uid, &uidLength)) {
             if (!lastSeenValid || memcmp(uid, lastSeenUid, uidLength) != 0) {
-                Serial.printf("NFCManager: Tag detected! UID=");
-                for (uint8_t i = 0; i < uidLength; i++) Serial.printf("%02X", uid[i]);
-                Serial.println("");
+                char uidHex[17]; uidHex[0] = '\0';
+                for (uint8_t i = 0; i < uidLength; i++) snprintf(uidHex + i*2, 3, "%02X", uid[i]);
+                Serial.printf("NFCManager: Tag detected! UID=%s\n", uidHex);
+                LogBuffer::getInstance().logPrintf("Tag detected: UID=%s\n", uidHex);
             }
             connection_->setCurrentUid(uid, uidLength);
 
@@ -932,6 +943,10 @@ void NFCManager::sendSpoolDetectedMessage(bool suppress_spoolman_sync) {
         Serial.printf("  spoolman_id:  %d  suppress_sync=%d\n",
                       s.spoolman_id, s.suppress_spoolman_sync);
         Serial.println("-----------------------------");
+        LogBuffer::getInstance().logPrintf("OpenPrintTag: %s %s #%02X%02X%02X %.0fg\n",
+            s.manufacturer, s.material_name,
+            s.primary_color[0], s.primary_color[1], s.primary_color[2],
+            s.kg_remaining * 1000.0f);
     }
 
     ApplicationManager::getInstance().sendMessage(msg);
@@ -1033,6 +1048,8 @@ void NFCManager::sendTigerTagMessage(const TigerTagData& tt) {
     Serial.printf("  bed:          %d-%d°C\n", tt.bed_temp_min, tt.bed_temp_max);
     Serial.printf("  dry:          %d°C / %dh\n", tt.dry_temp, tt.dry_time_hours);
     Serial.println("--------------------------------------");
+    LogBuffer::getInstance().logPrintf("  %s %s #%02X%02X%02X %dg\n",
+        s.manufacturer, s.material_name, tt.color_r, tt.color_g, tt.color_b, tt.weight_g);
 
     ApplicationManager::getInstance().sendMessage(msg);
 }
@@ -1138,6 +1155,9 @@ void NFCManager::sendOpenTag3DMessage(const opentag3d_t& ot3d) {
         Serial.printf("  dry:          %d°C / %dh\n", s.dry_temp, s.dry_time_hours);
     }
     Serial.println("---------------------------------------");
+    LogBuffer::getInstance().logPrintf("  %s %s #%02X%02X%02X %.0fg\n",
+        s.manufacturer, s.material_name,
+        ot3d.color_rgba[0][0], ot3d.color_rgba[0][1], ot3d.color_rgba[0][2], s.initial_weight_g);
 
     ApplicationManager::getInstance().sendMessage(msg);
 }
@@ -1188,6 +1208,7 @@ void NFCManager::sendOpenSpoolMessage(const char* uid, const OpenSpoolData& os) 
     Serial.printf("  nozzle:       %d-%d°C\n", s.min_print_temp, s.max_print_temp);
     Serial.printf("  version:      %s\n", os.version);
     Serial.println("---------------------------------------");
+    LogBuffer::getInstance().logPrintf("  %s %s #%s\n", s.manufacturer, s.material_name, os.color_hex);
 
     ApplicationManager::getInstance().sendMessage(msg);
 }
@@ -1225,6 +1246,8 @@ TagScanResult NFCManager::classifyTag(const uint8_t* uid, uint8_t uid_length) {
             if (connection_->ntagGetVersion(version)) {
                 result.variant = mapStorageByte(version[6]);
                 Serial.printf("NFCManager: %s detected (%d pages)\n",
+                    ntagVariantName(result.variant), ntagUsablePages(result.variant));
+                LogBuffer::getInstance().logPrintf("%s (%d pages)\n",
                     ntagVariantName(result.variant), ntagUsablePages(result.variant));
             }
         }
@@ -1675,9 +1698,11 @@ bool NFCManager::executeTigerTagWrite(const NFCWriteRequest& request) {
     bool ok = connection_->writeISO14443Pages(4, 10, request.data.tigertag_data, 40);
     if (ok) {
         Serial.println("NFCManager: WRITE_TIGERTAG succeeded");
+        LogBuffer::getInstance().logPrintf("Write TigerTag: OK\n");
         forceRescan();
     } else {
         Serial.println("NFCManager: WRITE_TIGERTAG failed");
+        LogBuffer::getInstance().logPrintf("Write TigerTag: FAILED\n");
     }
     return ok;
 }
@@ -1715,9 +1740,11 @@ bool NFCManager::executeOpenTag3DWrite(const NFCWriteRequest& request) {
     bool ok = connection_->writeISO14443Pages(4, pagesNeeded, ndefBuf, ndefLen);
     if (ok) {
         Serial.printf("NFCManager: WRITE_OPENTAG3D succeeded (%u bytes, %u pages)\n", ndefLen, pagesNeeded);
+        LogBuffer::getInstance().logPrintf("Write OpenTag3D: OK (%u bytes)\n", ndefLen);
         forceRescan();
     } else {
         Serial.println("NFCManager: WRITE_OPENTAG3D failed");
+        LogBuffer::getInstance().logPrintf("Write OpenTag3D: FAILED\n");
     }
     return ok;
 }
@@ -1747,9 +1774,11 @@ bool NFCManager::executeOpenSpoolWrite(const NFCWriteRequest& request) {
     bool ok = connection_->writeISO14443Pages(4, pagesNeeded, ndefBuf, ndefLen);
     if (ok) {
         Serial.printf("NFCManager: WRITE_OPENSPOOL succeeded (%u bytes, %u pages)\n", ndefLen, pagesNeeded);
+        LogBuffer::getInstance().logPrintf("Write OpenSpool: OK (%u bytes)\n", ndefLen);
         forceRescan();
     } else {
         Serial.println("NFCManager: WRITE_OPENSPOOL failed");
+        LogBuffer::getInstance().logPrintf("Write OpenSpool: FAILED\n");
     }
     return ok;
 }

--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -12,6 +12,7 @@
 #endif
 #include <cmath>
 #include "openprinttag_lib.h"
+#include "LogBuffer.h"
 
 static constexpr size_t JSON_SMALL_CAPACITY = 256;
 static constexpr size_t JSON_MEDIUM_CAPACITY = 768;
@@ -734,6 +735,7 @@ static int createSpool(int filamentId, const SpoolmanSyncRequest& req) {
         int id = -1;
         if (parseIdFromObject(response.c_str(), id)) {
             Serial.printf("SpoolmanManager: Created spool for %s, id=%d\n", req.spool_id, id);
+            LogBuffer::getInstance().logPrintf("Spoolman: Created spool %d for %s\n", id, req.spool_id);
             return id;
         }
         Serial.printf("SpoolmanManager: Created spool but failed to parse response\n");
@@ -741,6 +743,7 @@ static int createSpool(int filamentId, const SpoolmanSyncRequest& req) {
     }
 
     Serial.printf("SpoolmanManager: Failed to create spool, code=%d\n", code);
+    LogBuffer::getInstance().logPrintf("ERROR: Failed to create spool, HTTP %d\n", code);
     Serial.printf("  Request:  %s\n", body.c_str());
     Serial.printf("  Response: %s\n", response.c_str());
     return -1;
@@ -793,6 +796,7 @@ static bool archiveSpool(int spoolId) {
     int code = httpPatch(path, body.c_str(), response);
     if (code == 200) {
         Serial.printf("SpoolmanManager: Archived spool id=%d\n", spoolId);
+        LogBuffer::getInstance().logPrintf("Spoolman: Archived spool %d\n", spoolId);
         return true;
     }
 
@@ -823,6 +827,7 @@ static bool shouldArchiveAndReplace(int existingSpoolId, int newFilamentId,
     if (oldFilamentId >= 0 && newFilamentId >= 0 && oldFilamentId != newFilamentId) {
         Serial.printf("SpoolmanManager: Filament changed (%d -> %d), will archive spool %d\n",
                       oldFilamentId, newFilamentId, existingSpoolId);
+        LogBuffer::getInstance().logPrintf("Spoolman: Filament changed, archiving spool %d\n", existingSpoolId);
         return true;
     }
 
@@ -861,10 +866,12 @@ static bool updateSpool(int spoolId, int filamentId, float remainingWeight) {
     int code = httpPatch(path, body.c_str(), response);
     if (code == 200) {
         Serial.printf("SpoolmanManager: Updated spool id=%d, remaining=%.1fg\n", spoolId, remainingWeight);
+        LogBuffer::getInstance().logPrintf("Spoolman: Spool %d, %.1fg remaining\n", spoolId, remainingWeight);
         return true;
     }
 
     Serial.printf("SpoolmanManager: Failed to update spool, code=%d\n", code);
+    LogBuffer::getInstance().logPrintf("ERROR: Failed to update spool, HTTP %d\n", code);
     return false;
 }
 
@@ -1336,6 +1343,7 @@ bool SpoolmanManager::syncSpool(const SpoolmanSyncRequest& req, int& resolvedSpo
     int vendorId = findOrCreateVendor(req.manufacturer);
     if (vendorId < 0) {
         Serial.println("SpoolmanManager: Failed to find/create vendor");
+        LogBuffer::getInstance().logPrintf("ERROR: Failed to find/create vendor\n");
         xSemaphoreGive(httpMutex_);
         return false;
     }
@@ -1343,6 +1351,7 @@ bool SpoolmanManager::syncSpool(const SpoolmanSyncRequest& req, int& resolvedSpo
     int filamentId = findOrCreateFilament(vendorId, req);
     if (filamentId < 0) {
         Serial.println("SpoolmanManager: Failed to find/create filament");
+        LogBuffer::getInstance().logPrintf("ERROR: Failed to find/create filament\n");
         xSemaphoreGive(httpMutex_);
         return false;
     }

--- a/src/TroubleshootingHTML.h
+++ b/src/TroubleshootingHTML.h
@@ -126,6 +126,10 @@ const char TROUBLESHOOTING_HTML[] PROGMEM = R"rawliteral(
     </div>
 
     <button class="run-btn" id="runBtn" onclick="runChecks()">Run Checks</button>
+
+    <p style="margin-top:20px;font-size:13px;color:var(--muted)">
+      Need more detail? <a href="/logs" style="color:var(--blue);font-weight:600">View Serial Log</a> for live scanner output.
+    </p>
   </div>
 
   <script>

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -25,6 +25,8 @@
 #include "OpenSpoolLogo.h"
 #include "OpenSpoolWriterHTML.h"
 #include "UpdateHTML.h"
+#include "LogViewerHTML.h"
+#include "LogBuffer.h"
 #include "ConfigurationManager.h"
 #include "NFCManager.h"
 #include "NFCTypes.h"
@@ -137,6 +139,11 @@ bool WebServerManager::begin(bool apMode, uint16_t port) {
     _server.on("/api/spoolman/find-vendor",     HTTP_GET,  [this]() { handleApiSpoolmanFindVendor(); });
     _server.on("/api/spoolman/find-filament",   HTTP_GET,  [this]() { handleApiSpoolmanFindFilament(); });
     _server.on("/api/spoolman/save-enrichment", HTTP_POST, [this]() { handleApiSpoolmanSaveEnrichment(); });
+
+    // Log viewer
+    _server.on("/logs",           HTTP_GET,  [this]() { handleLogViewer(); });
+    _server.on("/api/logs",       HTTP_GET,  [this]() { handleApiLogs(); });
+    _server.on("/api/logs/clear", HTTP_POST, [this]() { handleApiLogsClear(); });
 
     // Captive portal detection endpoints (AP mode)
     if (apMode) {
@@ -270,6 +277,29 @@ void WebServerManager::handleTroubleshootingPage() {
 void WebServerManager::handleUIDRegistrationPage() {
     _server.sendHeader("Access-Control-Allow-Origin", "*");
     _server.send_P(200, "text/html", UID_REGISTRATION_HTML);
+}
+
+void WebServerManager::handleLogViewer() {
+    _server.sendHeader("Access-Control-Allow-Origin", "*");
+    _server.send_P(200, "text/html", LOG_VIEWER_HTML);
+}
+
+void WebServerManager::handleApiLogs() {
+    _server.sendHeader("Access-Control-Allow-Origin", "*");
+    char* buf = (char*)malloc(4097);
+    if (!buf) {
+        _server.send(500, "text/plain", "out of memory");
+        return;
+    }
+    LogBuffer::getInstance().getLog(buf, 4097);
+    _server.send(200, "text/plain", buf);
+    free(buf);
+}
+
+void WebServerManager::handleApiLogsClear() {
+    _server.sendHeader("Access-Control-Allow-Origin", "*");
+    LogBuffer::getInstance().clear();
+    _server.send(200, "application/json", "{\"success\":true}");
 }
 
 void WebServerManager::handleApiRegisterUid() {

--- a/src/WebServerManager.h
+++ b/src/WebServerManager.h
@@ -73,6 +73,11 @@ private:
     void handleApiSpoolmanFindFilament();
     void handleApiSpoolmanSaveEnrichment();
 
+    // Log viewer
+    void handleLogViewer();
+    void handleApiLogs();
+    void handleApiLogsClear();
+
     // OTA download state
     static void otaDownloadTask(void* param);
     enum class OtaState : uint8_t { IDLE, DOWNLOADING, FLASHING, SUCCESS, FAILED };


### PR DESCRIPTION
## Summary

- New `LogBuffer` class — 4KB ring buffer singleton with `logPrintf()` that writes to both Serial and the buffer, thread-safe via FreeRTOS mutex
- New `/logs` page — dark-themed auto-scrolling log viewer matching the SpoolSense UI, polls `/api/logs` every 2 seconds
- `GET /api/logs` returns buffer contents as plain text, `POST /api/logs/clear` clears it
- Landing page "Serial Log" card and troubleshooting page "View Serial Log" link

### Instrumented events

| Source | Events |
|--------|--------|
| NFCManager | Tag detected (UID), NTAG variant, tag payload summaries (all 4 formats + Bambu), tag removed, all write outcomes |
| SpoolmanManager | Spool sync/create/archive, filament changes, HTTP errors |
| HomeAssistantManager | MQTT connected/failed |

## Test plan

- [x] Build succeeds (esp32s3devkitc)
- [x] Log viewer page loads at /logs with correct theme
- [x] Scanning tags shows detection + payload + Spoolman events
- [x] All tag formats appear (OpenPrintTag, TigerTag, OpenTag3D, OpenSpool)
- [x] Clear button works
- [x] Auto-scroll works
- [x] Troubleshooting page has "View Serial Log" link
- [x] Landing page has Serial Log card

Closes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a live **Serial Log Viewer** accessible from the web interface, displaying real-time device logs without requiring a serial terminal connection.
  * Log viewer includes copy, clear, and auto-scroll controls for enhanced diagnostics.
  * Added navigation links to the log viewer on the home page and troubleshooting page.
  * Enhanced logging throughout device operations for improved visibility into scanner activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->