### PR TITLE
feat: LED breathing from Spoolman weight for non-writable tags

### DIFF
--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -856,6 +856,22 @@ void ApplicationManager::handleSpoolmanSynced(const AppMessage& msg) {
     }
 
 #ifndef NATIVE_TEST
+    // Re-evaluate LED state using Spoolman weight — catches tags without weight data
+    // (OpenSpool, GenericUID, TigerTag) where Spoolman knows the remaining weight
+    if (msg.payload.spoolmanSynced.success && kgRemaining > 0.0f &&
+        ConfigurationManager::getInstance().isLedEnabled()) {
+        const char* colorSrc = msg.payload.spoolmanSynced.color_hex;
+        if (colorSrc[0] == '#') colorSrc++;
+        unsigned int r = 0, g = 0, b = 0;
+        sscanf(colorSrc, "%02x%02x%02x", &r, &g, &b);
+        float remaining_g = kgRemaining * 1000.0f;
+        if (remaining_g > 0.0f && remaining_g <= 100.0f) {
+            ledManager.breatheFilamentColor(r, g, b);
+        } else {
+            ledManager.showFilamentColor(r, g, b);
+        }
+    }
+
     // Cache sync result in NFCManager (used by web UI to mark "synced" on reader page)
     if (msg.payload.spoolmanSynced.success && !msg.payload.spoolmanSynced.is_uid_lookup) {
         NFCManager::getInstance().updateRecentSpoolSyncStatus(

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -858,7 +858,7 @@ void ApplicationManager::handleSpoolmanSynced(const AppMessage& msg) {
 #ifndef NATIVE_TEST
     // Re-evaluate LED state using Spoolman weight — catches tags without weight data
     // (OpenSpool, GenericUID, TigerTag) where Spoolman knows the remaining weight
-    if (msg.payload.spoolmanSynced.success && kgRemaining > 0.0f &&
+    if (msg.payload.spoolmanSynced.success &&
         ConfigurationManager::getInstance().isLedEnabled() &&
         msg.payload.spoolmanSynced.color_hex[0] != '\0') {
         const char* colorSrc = msg.payload.spoolmanSynced.color_hex;

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -859,11 +859,12 @@ void ApplicationManager::handleSpoolmanSynced(const AppMessage& msg) {
     // Re-evaluate LED state using Spoolman weight — catches tags without weight data
     // (OpenSpool, GenericUID, TigerTag) where Spoolman knows the remaining weight
     if (msg.payload.spoolmanSynced.success && kgRemaining > 0.0f &&
-        ConfigurationManager::getInstance().isLedEnabled()) {
+        ConfigurationManager::getInstance().isLedEnabled() &&
+        msg.payload.spoolmanSynced.color_hex[0] != '\0') {
         const char* colorSrc = msg.payload.spoolmanSynced.color_hex;
         if (colorSrc[0] == '#') colorSrc++;
         unsigned int r = 0, g = 0, b = 0;
-        sscanf(colorSrc, "%02x%02x%02x", &r, &g, &b);
+        if (sscanf(colorSrc, "%02x%02x%02x", &r, &g, &b) != 3) { r = g = b = 0; }
         float remaining_g = kgRemaining * 1000.0f;
         if (remaining_g > 0.0f && remaining_g <= 100.0f) {
             ledManager.breatheFilamentColor(r, g, b);


### PR DESCRIPTION
## Summary

- After Spoolman sync, re-evaluate LED state using Spoolman-provided remaining weight
- Tags without weight data (OpenSpool, GenericUID, TigerTag) now trigger low-spool breathing when Spoolman reports weight below threshold (100g)
- Safe color parsing with empty/invalid hex guard

## How it works

1. `handleSpoolDetected` runs first — sets LED based on tag data (solid color for tags without weight)
2. Spoolman sync completes 1-2 seconds later with remaining weight from the database
3. `handleSpoolmanSynced` re-evaluates — if weight ≤ 100g, switches LED to breathing

## Test plan

- [x] Build succeeds
- [x] OpenSpool tag with Spoolman weight 50g → LED breathes after sync
- [x] OpenSpool tag with Spoolman weight 0g → no breathing (0g fails > 0 check)
- [x] OpenTag3D tag with weight on tag → scan-time breathing still works

Partial fix for #137 (gap #2 — Spoolman-driven breathing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LED now updates during spool synchronization when enabled and a filament color is present.
  * Hex color values with a leading “#” are accepted; colors fallback to off on parse failure.
  * LED pulses gently when remaining filament ≤100g; otherwise shows the filament color steadily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->