### PR TITLE
fix: default initial_weight to 1000g when creating spools

### DIFF
--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -713,7 +713,8 @@ static int createSpool(int filamentId, const SpoolmanSyncRequest& req) {
     doc["filament_id"] = filamentId;
     // Spoolman 0.23.x rejects weight fields with value 0 — omit when not set
     if (req.remaining_weight_g > 0) doc["remaining_weight"] = req.remaining_weight_g;
-    if (req.initial_weight_g > 0) doc["initial_weight"] = req.initial_weight_g;
+    float initialWeight = req.initial_weight_g > 0 ? req.initial_weight_g : 1000.0f;
+    doc["initial_weight"] = initialWeight;
 
     // Spoolman expects extra field values to be valid JSON — wrap the string in quotes
     char nfcIdJson[34];

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -425,7 +425,7 @@ void WebServerManager::handleApiRegisterUid() {
         // No existing spool — create new
         StaticJsonDocument<512> spoolBody;
         spoolBody["filament_id"] = filamentId;
-        if (initialWeight > 0) spoolBody["initial_weight"] = initialWeight;
+        spoolBody["initial_weight"] = initialWeight > 0 ? initialWeight : 1000.0f;
         if (remainingWeight > 0) spoolBody["remaining_weight"] = remainingWeight;
 
         JsonObject extra = spoolBody.createNestedObject("extra");
@@ -1981,11 +1981,11 @@ int WebServerManager::enrichCreateSpool(WiFiClient& client, HTTPClient& http, co
     char url[256];
     StaticJsonDocument<512> sBody;
     sBody["filament_id"] = filamentId;
+    float initialW = 1000.0f;
+    sBody["initial_weight"] = initialW;
     if (remainingG > 0) {
-        float initialW = 1000.0f;
         float usedW = initialW - remainingG;
         if (usedW < 0) usedW = 0;
-        sBody["initial_weight"] = initialW;
         sBody["used_weight"] = usedW;
     }
     JsonObject extra = sBody.createNestedObject("extra");


### PR DESCRIPTION
## Summary

- All three spool creation paths now default `initial_weight` to 1000g when not provided
- Prevents Spoolman from calculating `remaining_weight` as 0 for spools without initial weight set
- User-provided initial weight (from tag data or web UI) is still used when available

## Paths fixed

| Path | File | Before | After |
|------|------|--------|-------|
| SpoolmanManager::createSpool | SpoolmanManager.cpp | Omitted when 0 | Defaults to 1000g |
| handleApiRegisterUid | WebServerManager.cpp | Omitted when 0 | Defaults to 1000g |
| enrichCreateSpool | WebServerManager.cpp | Only set when remaining > 0 | Always set to 1000g |

## Test plan

- [ ] Create spool via tag scan without initial weight → Spoolman shows 1000g initial
- [ ] Create spool via web UI with explicit weight → uses provided weight
- [ ] Enrichment remaining_g no longer shows 0 for spools without initial weight

Closes #128