### PR TITLE
feat: configurable low-spool threshold

### DIFF
--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -351,7 +351,7 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
             uint8_t r = msg.payload.spoolDetected.primary_color[0];
             uint8_t g = msg.payload.spoolDetected.primary_color[1];
             uint8_t b = msg.payload.spoolDetected.primary_color[2];
-            if (remaining_g > 0.0f && remaining_g <= 100.0f) {
+            if (remaining_g > 0.0f && remaining_g <= (float)ConfigurationManager::getInstance().getLowSpoolThreshold()) {
                 ledManager.breatheFilamentColor(r, g, b);
             } else {
                 ledManager.showFilamentColor(r, g, b);
@@ -866,7 +866,7 @@ void ApplicationManager::handleSpoolmanSynced(const AppMessage& msg) {
         unsigned int r = 0, g = 0, b = 0;
         if (sscanf(colorSrc, "%02x%02x%02x", &r, &g, &b) != 3) { r = g = b = 0; }
         float remaining_g = kgRemaining * 1000.0f;
-        if (remaining_g > 0.0f && remaining_g <= 100.0f) {
+        if (remaining_g > 0.0f && remaining_g <= (float)ConfigurationManager::getInstance().getLowSpoolThreshold()) {
             ledManager.breatheFilamentColor(r, g, b);
         } else {
             ledManager.showFilamentColor(r, g, b);

--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -77,6 +77,11 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
                      pattern="[a-z0-9](?:[a-z0-9\-]{0,30}[a-z0-9])?" title="Lowercase letters, numbers, hyphens (1-32 chars, no leading/trailing hyphens)" />
               <div style="font-size:11px;color:#71717A;margin-top:4px">mDNS hostname (e.g. spoolsense-lane1). Access at http://&lt;hostname&gt;.local</div>
             </div>
+            <div class="field">
+              <label for="low_spool_g">Low Spool Threshold (g)</label>
+              <input id="low_spool_g" type="number" min="0" max="5000" value="100" />
+              <div style="font-size:11px;color:#71717A;margin-top:4px">LED breathes when remaining weight is at or below this value</div>
+            </div>
             <h3 style="font-size:13px;color:#A1A1AA;margin:16px 0 8px;font-weight:600">WiFi</h3>
             <div class="grid-2">
               <div class="field">
@@ -247,6 +252,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
     // Load current config
     api('/api/config').then(function(cfg) {
       maybeSetValue('hostname', cfg.hostname);
+      if (cfg.low_spool_threshold_g !== undefined) document.getElementById('low_spool_g').value = cfg.low_spool_threshold_g;
       maybeSetValue('wifi_ssid', cfg.wifi_ssid);
       maybeSetValue('mqtt_host', cfg.mqtt_host);
       maybeSetValue('mqtt_port', cfg.mqtt_port);
@@ -306,6 +312,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
 
       var body = {
         hostname: normalizedHostname,
+        low_spool_threshold_g: parseInt(document.getElementById('low_spool_g').value) || 100,
         wifi_ssid: document.getElementById('wifi_ssid').value.trim(),
         wifi_pass: document.getElementById('wifi_pass').value,
         mqtt_host: document.getElementById('mqtt_host').value.trim(),

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -33,6 +33,7 @@ static const char* NVS_KEY_PRUSALINK_URL  = "prusalink_url";
 static const char* NVS_KEY_PRUSALINK_KEY  = "prusalink_key";
 static const char* NVS_KEY_NFC_READER    = "nfc_reader";
 static const char* NVS_KEY_HOSTNAME      = "hostname";
+static const char* NVS_KEY_LOW_SPOOL     = "low_spool_g";
 
 // Sanitize hostname: enforce mDNS naming constraints (lowercase alphanum + hyphens,
 // no leading/trailing hyphens) and reject empty strings to avoid boot-time errors.
@@ -243,6 +244,10 @@ bool ConfigurationManager::loadFromNVS() {
         sanitizeHostname(_hostname, sizeof(_hostname));
         anyOverride = true;
     }
+    if (prefs.isKey(NVS_KEY_LOW_SPOOL)) {
+        _lowSpoolThreshold = prefs.getUShort(NVS_KEY_LOW_SPOOL, 100);
+        anyOverride = true;
+    }
 
     prefs.end();
     return anyOverride;
@@ -341,6 +346,10 @@ const char* ConfigurationManager::getHostname() const {
     return _hostname;
 }
 
+uint16_t ConfigurationManager::getLowSpoolThreshold() const {
+    return _lowSpoolThreshold;
+}
+
 void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     memset(&out, 0, sizeof(out));
     strncpy(out.wifi_ssid, _ssid, sizeof(out.wifi_ssid) - 1);
@@ -363,6 +372,7 @@ void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     strncpy(out.moonraker_url, _moonrakerUrl, sizeof(out.moonraker_url) - 1);
     strncpy(out.nfc_reader, _nfcReader, sizeof(out.nfc_reader) - 1);
     strncpy(out.hostname, _hostname, sizeof(out.hostname) - 1);
+    out.low_spool_threshold_g = _lowSpoolThreshold;
 }
 
 #ifndef NATIVE_TEST
@@ -405,6 +415,7 @@ bool ConfigurationManager::saveToNVS(const ConfigUpdate& update) {
     strncpy(sanitizedHostname, update.hostname, sizeof(sanitizedHostname) - 1);
     sanitizeHostname(sanitizedHostname, sizeof(sanitizedHostname));  // enforce mDNS constraints before NVS write
     prefs.putString(NVS_KEY_HOSTNAME, sanitizedHostname);
+    prefs.putUShort(NVS_KEY_LOW_SPOOL, update.low_spool_threshold_g);
 
     // Invalidate Spoolman enrichment cache on config change to force re-fetch
     // (config change could invalidate cached spool lookups)

--- a/src/ConfigurationManager.h
+++ b/src/ConfigurationManager.h
@@ -38,6 +38,7 @@ struct ConfigUpdate {
     char nfc_reader[8];  // "pn5180" or "pn532"
     // mDNS / WiFi hostname
     char hostname[33];   // max 32 chars + null
+    uint16_t low_spool_threshold_g;  // grams below which LED breathes (default 100)
 };
 
 class ConfigurationManager {
@@ -81,6 +82,9 @@ public:
     bool isKeypadEnabled() const;
     bool isTftEnabled() const;
     const char* getTftDriver() const;
+
+    // Low-spool threshold (grams) — LED breathes when remaining weight is at or below this
+    uint16_t getLowSpoolThreshold() const;
 
     // Web config support
     void getCurrentConfig(ConfigUpdate& out) const;
@@ -130,6 +134,7 @@ private:
     bool _keypadEnabled = false;
     bool _tftEnabled = false;
     char _tftDriver[8] = "st7789";
+    uint16_t _lowSpoolThreshold = 100;  // grams
 
     bool _initialized = false;
 };

--- a/src/TFTManager.cpp
+++ b/src/TFTManager.cpp
@@ -1,4 +1,5 @@
 #include "TFTManager.h"
+#include "ConfigurationManager.h"
 #include <Arduino.h>
 
 // TFT display controller for 240x240 ST7789 or GC9A01 (round). Manages sprite rendering to PSRAM
@@ -254,7 +255,7 @@ void TFTManager::processQueue() {
             case TFTState::SpoolScanned:
                 // Breathing animation for low-weight spools (< 100g): visual cue for respool
                 _isBreathing = (msg.spool.remainingWeight > 0 &&
-                                msg.spool.remainingWeight <= 100.0f);
+                                msg.spool.remainingWeight <= (float)ConfigurationManager::getInstance().getLowSpoolThreshold());
                 if (_isBreathing) {
                     _breathColor = hexToRgb(msg.spool.colorHex);
                     _breathBrightness = 255;

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -721,6 +721,7 @@ void WebServerManager::handleApiGetConfig() {
     doc["prusalink_key_set"] = (cfg.prusalink_api_key[0] != '\0');
     doc["nfc_reader"] = cfg.nfc_reader;
     doc["hostname"] = cfg.hostname;
+    doc["low_spool_threshold_g"] = cfg.low_spool_threshold_g;
     doc["tft_enabled"] = cfg.tft_enabled;
     doc["tft_driver"] = cfg.tft_driver;
     doc["ap_mode"] = _apMode;
@@ -777,6 +778,7 @@ void WebServerManager::handleApiPostConfig() {
     strncpy(update.hostname, doc["hostname"] | "spoolsense", sizeof(update.hostname) - 1);
     update.hostname[sizeof(update.hostname) - 1] = '\0';
     sanitizeHostname(update.hostname, sizeof(update.hostname));
+    update.low_spool_threshold_g = doc["low_spool_threshold_g"] | (uint16_t)100;
 
     if (update.wifi_ssid[0] == '\0') {
         sendError(400, "WiFi SSID is required");


### PR DESCRIPTION
## Summary

- Low-spool breathing threshold now configurable via web config at spoolsense.local/config
- "Low Spool Threshold (g)" field — default 100g, stored in NVS, persists across reboots
- Replaces hardcoded 100g in ApplicationManager (LED) and TFTManager (display breathing)
- SpoolmanManager archive threshold (100g) intentionally left hardcoded — different purpose

## Files changed

| File | Change |
|------|--------|
| ConfigurationManager.h | Added `low_spool_threshold_g` to ConfigUpdate, `_lowSpoolThreshold` member, `getLowSpoolThreshold()` getter |
| ConfigurationManager.cpp | NVS load/save, getter, getCurrentConfig |
| ApplicationManager.cpp | Both LED breathing checks use configurable threshold |
| TFTManager.cpp | TFT breathing check uses configurable threshold |
| WebServerManager.cpp | GET/POST config handlers include threshold field |
| ConfigHTML.h | New input field + JS load/save |

## Test plan

- [x] Build succeeds
- [x] Config page shows threshold field with default 100
- [x] Changed to 50g, saved, rebooted — persisted
- [x] OpenSpool tag with Spoolman weight 50g → LED breathes at threshold 50
- [x] Spoolman weight not zeroed on scan (hotfix verified)

Partial fix for #137 (gap #1 — configurable threshold)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a customizable low spool threshold setting (in grams) accessible through the web configuration interface
  * LED indicators and display notifications now use this configurable threshold to determine when to show low filament warnings, with a default value of 100 grams

<!-- end of auto-generated comment: release notes by coderabbit.ai -->