### PR TITLE
feat: Bambu AMS deduction via scanner MQTT

### DIFF
--- a/homeassistant/blueprints/spoolsense_bambu_deduction.yaml
+++ b/homeassistant/blueprints/spoolsense_bambu_deduction.yaml
@@ -1,9 +1,10 @@
 blueprint:
-  name: "SpoolSense → Spoolman Deduction"
+  name: "SpoolSense → Bambu Deduction"
   description: >
-    Automatically deduct filament weight from Spoolman after a Bambu Lab print
-    completes or is canceled. Requires the SpoolSense → Bambu AMS blueprint
-    (which stores spool UIDs per tray) and the spoolman-homeassistant integration.
+    Automatically deduct filament weight after a Bambu Lab print completes or is
+    canceled. Sends deductions to the SpoolSense scanner via MQTT, which updates
+    Spoolman and writes to NFC tags. No spoolman-homeassistant integration needed.
+    Requires the SpoolSense → Bambu AMS blueprint (which stores spool UIDs per tray).
   domain: automation
   input:
     bambu_device:
@@ -31,6 +32,13 @@ blueprint:
           multiple: true
           filter:
             - domain: sensor
+    scanner_device_id:
+      name: SpoolSense Scanner Device ID
+      description: >
+        The scanner's device ID (e.g., 4d9620). Found on the scanner's landing page
+        or in the MQTT topic prefix.
+      selector:
+        text: {}
 
 mode: single
 max_exceeded: silent
@@ -52,7 +60,7 @@ actions:
   - variables:
       weight_sensor: !input print_weight_sensor
       tray_entities: !input ams_tray_entities
-      # Per-tray weights are attributes on the print_weight sensor (e.g., "AMS 1 Tray 1": 12.5)
+      scanner_id: !input scanner_device_id
 
   - repeat:
       for_each: "{{ tray_entities }}"
@@ -69,9 +77,7 @@ actions:
               {% endif %}
             tray_weight_used: "{{ state_attr(weight_sensor, tray_name_key | trim) | float(0) }}"
             helper_uid: "input_text.spoolsense_{{ tray_entity | replace('sensor.', '') }}_uid"
-            helper_spoolman_id: "input_text.spoolsense_{{ tray_entity | replace('sensor.', '') }}_spoolman_id"
             stored_uid: "{{ states(helper_uid) | default('') }}"
-            stored_spoolman_id: "{{ states(helper_spoolman_id) | default('-1') }}"
 
         - condition: template
           value_template: "{{ tray_weight_used | float(0) > 0 }}"
@@ -79,24 +85,7 @@ actions:
         - condition: template
           value_template: "{{ stored_uid != '' and stored_uid != 'unknown' }}"
 
-        - variables:
-            spoolman_id: >
-              {% if stored_spoolman_id | int(-1) > 0 %}
-                {{ stored_spoolman_id }}
-              {% else %}
-                {% set ns = namespace(found='') %}
-                {% for entity in integration_entities('spoolman') %}
-                  {% if state_attr(entity, 'extra_nfc_id') == stored_uid and ns.found == '' %}
-                    {% set ns.found = state_attr(entity, 'id') | string %}
-                  {% endif %}
-                {% endfor %}
-                {{ ns.found }}
-              {% endif %}
-
-        - condition: template
-          value_template: "{{ spoolman_id | trim | int(-1) > 0 }}"
-
-        - action: spoolman.use_spool_filament
+        - action: mqtt.publish
           data:
-            id: "{{ spoolman_id | trim }}"
-            use_weight: "{{ tray_weight_used | float }}"
+            topic: "spoolsense/{{ scanner_id }}/cmd/deduct/{{ stored_uid }}"
+            payload: '{"deduct_g": {{ tray_weight_used | float }}}'

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -537,8 +537,11 @@ void ApplicationManager::handleSpoolUpdated(const AppMessage& msg) {
     if (display_) {
         if (msg.payload.spoolUpdated.success) {
             char line1[17];
-            snprintf(line1, sizeof(line1), "Updated: %.0fg",
-                     kgRemaining * 1000.0f);
+            if (kgRemaining > 0.0f) {
+                snprintf(line1, sizeof(line1), "Updated: %.0fg", kgRemaining * 1000.0f);
+            } else {
+                strncpy(line1, "Tag Updated!", sizeof(line1) - 1);
+            }
             if (spoolmanConfigured) {
                 // Show "syncing" — SPOOLMAN_SYNCED event will show final display + schedule Type/Remain
                 display_->showText(line1, "Syncing Spoolman");

--- a/src/DeductionManager.cpp
+++ b/src/DeductionManager.cpp
@@ -8,6 +8,8 @@
   #include <Preferences.h>
   #include <Arduino.h>
   #include "NFCManager.h"
+  #include "SpoolmanManager.h"
+  #include "LogBuffer.h"
   #include "opentag3d_lib.h"
 #endif
 
@@ -163,9 +165,18 @@ float DeductionManager::applyIfPending(const char* uid, TagKind kind) {
             deducted = applyOpenTag3D(uid, pending);
             break;
         default:
-            // Tag can't accept weight writes — clear stale deduction so it doesn't accumulate forever
-            Serial.printf("DeductionManager: Tag type %d does not support weight writes — clearing\n", (int)kind);
-            clearPending(uid);
+            // Tag can't accept weight writes — try Spoolman direct if configured
+            if (SpoolmanManager::getInstance().isConfigured()) {
+                float spDeducted = SpoolmanManager::getInstance().deductFromSpoolman(uid, pending);
+                if (spDeducted > 0.0f) {
+                    clearPending(uid);
+                    deducted = spDeducted;
+                }
+                // If deductFromSpoolman returned 0, keep in NVS for retry on next scan
+            } else {
+                Serial.printf("DeductionManager: Tag type %d has no weight writes and Spoolman not configured — clearing\n", (int)kind);
+                clearPending(uid);
+            }
             break;
     }
 

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -10,6 +10,7 @@
 #include "TagStateJson.h"
 #include "LEDManager.h"
 #include "LogBuffer.h"
+#include "SpoolmanManager.h"
 
 #ifndef NATIVE_TEST
   #include <Arduino.h>
@@ -847,12 +848,17 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
 
         DeductionManager::getInstance().storePending(uidFromTopic, deductG);
 
-        // If tag is currently on scanner, apply immediately instead of waiting for next scan
-        // Use case-insensitive compare — MQTT topic UID may differ in case from scanner's uppercase
+        // If tag is currently on scanner, apply immediately (write to tag or Spoolman)
         CurrentSpoolState deductSpool;
         if (NFCManager::getInstance().getCurrentSpoolState(deductSpool) &&
             deductSpool.present && strcasecmp(deductSpool.spool_id, uidFromTopic) == 0) {
             DeductionManager::getInstance().applyIfPending(deductSpool.spool_id, deductSpool.kind);
+        } else if (SpoolmanManager::getInstance().isConfigured()) {
+            // Tag not on scanner — try Spoolman direct (Bambu AMS use case)
+            float spDeducted = SpoolmanManager::getInstance().deductFromSpoolman(uidFromTopic, deductG);
+            if (spDeducted > 0.0f) {
+                DeductionManager::getInstance().clearPending(uidFromTopic);
+            }
         }
 
         publishCommandResponse(command, true, nullptr);

--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -1244,6 +1244,63 @@ bool SpoolmanManager::lookupSpoolByUid(const char* uid, SpoolDetails& outDetails
     return ok;
 }
 
+float SpoolmanManager::deductFromSpoolman(const char* uid, float grams) {
+    if (!isConfigured()) return 0.0f;
+    if (xSemaphoreTake(httpMutex_, HTTP_MUTEX_TIMEOUT) != pdTRUE) {
+        Serial.println("SpoolmanManager: deductFromSpoolman — mutex timeout");
+        return 0.0f;
+    }
+
+    int spoolId = findSpoolByUuidGlobal(uid);
+    if (spoolId < 0) {
+        Serial.printf("SpoolmanManager: deductFromSpoolman — spool not found for %s\n", uid);
+        xSemaphoreGive(httpMutex_);
+        return 0.0f;
+    }
+
+    // Get current remaining weight
+    char path[64];
+    snprintf(path, sizeof(path), "/api/v1/spool/%d", spoolId);
+    String response;
+    int code = httpGet(path, response);
+    if (code != 200) {
+        Serial.printf("SpoolmanManager: deductFromSpoolman — GET spool %d failed (HTTP %d)\n", spoolId, code);
+        xSemaphoreGive(httpMutex_);
+        return 0.0f;
+    }
+
+    StaticJsonDocument<JSON_SMALL_CAPACITY> doc;
+    if (deserializeJson(doc, response)) {
+        xSemaphoreGive(httpMutex_);
+        return 0.0f;
+    }
+
+    float currentRemaining = doc["remaining_weight"] | 0.0f;
+    float deduction = (grams > currentRemaining) ? currentRemaining : grams;
+    float newRemaining = currentRemaining - deduction;
+    if (newRemaining < 0.0f) newRemaining = 0.0f;
+
+    // PATCH with new remaining weight
+    StaticJsonDocument<JSON_SMALL_CAPACITY> patchDoc;
+    patchDoc["remaining_weight"] = newRemaining;
+    String body;
+    serializeJson(patchDoc, body);
+
+    code = httpPatch(path, body.c_str(), response);
+    xSemaphoreGive(httpMutex_);
+
+    if (code == 200) {
+        Serial.printf("SpoolmanManager: Deducted %.1fg from spool %d (%.1fg -> %.1fg)\n",
+                      deduction, spoolId, currentRemaining, newRemaining);
+        LogBuffer::getInstance().logPrintf("Spoolman: Deducted %.1fg from spool %d\n", deduction, spoolId);
+        return deduction;
+    }
+
+    Serial.printf("SpoolmanManager: deductFromSpoolman — PATCH failed (HTTP %d)\n", code);
+    LogBuffer::getInstance().logPrintf("ERROR: Spoolman deduction failed, HTTP %d\n", code);
+    return 0.0f;
+}
+
 bool SpoolmanManager::syncSpool(const SpoolmanSyncRequest& req, int& resolvedSpoolmanId) {
     if (xSemaphoreTake(httpMutex_, HTTP_MUTEX_TIMEOUT) != pdTRUE) {
         Serial.println("SpoolmanManager: Could not acquire HTTP mutex");

--- a/src/SpoolmanManager.h
+++ b/src/SpoolmanManager.h
@@ -54,6 +54,10 @@ public:
     bool getSpoolDetails(int32_t spoolmanId, SpoolDetails& outDetails);
     void invalidateCachedSpoolmanId(const char* spoolId);
 
+    // Deduct weight directly in Spoolman for non-writable tags.
+    // Returns grams deducted, or 0 on failure (caller should retry later).
+    float deductFromSpoolman(const char* uid, float grams);
+
 private:
     struct SpoolIdCacheEntry {
         char spool_id[17];


### PR DESCRIPTION
## Summary

Routes Bambu AMS filament deductions through the scanner instead of requiring the spoolman-homeassistant HA integration.

### Blueprint update
- Replaces `spoolman.use_spool_filament` with `mqtt.publish` to `spoolsense/{id}/cmd/deduct/{uid}`
- New `scanner_device_id` input
- No spoolman-homeassistant integration dependency

### Firmware: Spoolman-direct deduction
- New `SpoolmanManager::deductFromSpoolman(uid, grams)` — looks up spool by nfc_id, GETs remaining weight, PATCHes deduction
- `DeductionManager` default case routes non-writable tags (OpenSpool, GenericUID, TigerTag) through Spoolman direct instead of clearing
- `cmd/deduct` handler tries Spoolman direct immediately when tag is not on scanner (Bambu AMS use case)
- NVS retry: if Spoolman unreachable, deduction stays in NVS for next scan

### Display fix
- Shows "Tag Updated!" instead of "Updated: 0g" when remaining weight is unavailable in the write event

## Test plan

- [x] Build succeeds
- [x] Spoolman-direct: MQTT deduction for OpenSpool tag (no tag on scanner) — 50g → 39.5g
- [x] Tag write: MQTT deduction for OpenTag3D tag (on scanner) — 752g → 747g → 742g
- [x] Web log shows deduction events
- [x] Display shows "Tag Updated!" not "Updated: 0g"
- [x] Spoolman weight preserved (0g bug fix in base)

Closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "SpoolSense → Bambu Deduction" blueprint replacing the previous Spoolman version.
  * Added new scanner device ID configuration input.
  * Implemented MQTT-based filament deduction commands for improved compatibility.

* **Bug Fixes**
  * Enhanced display messaging for successful spool updates.
  * Improved handling of pending deductions when tags are temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->