### PR TITLE
feat: cmd/low_spool MQTT handler

### DIFF
--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -828,6 +828,25 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
         return;
     }
 
+    // low_spool: middleware/HA sends true/false to trigger LED breathing mid-print
+    if (strcmp(command, "low_spool") == 0) {
+        extern LEDManager ledManager;
+        bool enable = (strcmp(payload, "true") == 0);
+        // Use current LED target color (persists after tag removal)
+        uint8_t r = 0, g = 0, b = 0;
+        ledManager.getTargetColor(r, g, b);
+        if (r == 0 && g == 0 && b == 0) { r = g = b = 0x33; }  // fallback dim white
+        if (enable) {
+            ledManager.breatheFilamentColor(r, g, b);
+            LogBuffer::getInstance().logPrintf("Low spool: breathing enabled\n");
+        } else {
+            ledManager.showFilamentColor(r, g, b);
+            LogBuffer::getInstance().logPrintf("Low spool: breathing disabled\n");
+        }
+        publishCommandResponse(command, true, nullptr);
+        return;
+    }
+
     // deduct: store filament usage deduction — tag may not be on scanner
     if (strcmp(command, "deduct") == 0) {
         if (strlen(uidFromTopic) == 0) {

--- a/src/LEDManager.cpp
+++ b/src/LEDManager.cpp
@@ -160,6 +160,10 @@ void LEDManager::setFilamentColorFromHex(const char* hex) {
     showFilamentColor((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF);
 }
 
+void LEDManager::getTargetColor(uint8_t& r, uint8_t& g, uint8_t& b) const {
+    r = _target.r; g = _target.g; b = _target.b;
+}
+
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------

--- a/src/LEDManager.h
+++ b/src/LEDManager.h
@@ -37,6 +37,7 @@ public:
     void flashWarning();        // 3× yellow 150ms on/off
 
     void setFilamentColorFromHex(const char* hex);
+    void getTargetColor(uint8_t& r, uint8_t& g, uint8_t& b) const;
 
 private:
     bool _initialized = false;

--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -870,8 +870,13 @@ static bool updateSpool(int spoolId, int filamentId, float remainingWeight) {
     String response;
     int code = httpPatch(path, body.c_str(), response);
     if (code == 200) {
-        Serial.printf("SpoolmanManager: Updated spool id=%d, remaining=%.1fg\n", spoolId, remainingWeight);
-        LogBuffer::getInstance().logPrintf("Spoolman: Spool %d, %.1fg remaining\n", spoolId, remainingWeight);
+        if (remainingWeight > 0.0f) {
+            Serial.printf("SpoolmanManager: Updated spool id=%d, remaining=%.1fg\n", spoolId, remainingWeight);
+            LogBuffer::getInstance().logPrintf("Spoolman: Spool %d, %.1fg remaining\n", spoolId, remainingWeight);
+        } else {
+            Serial.printf("SpoolmanManager: Updated spool id=%d (weight unchanged)\n", spoolId);
+            LogBuffer::getInstance().logPrintf("Spoolman: Spool %d synced\n", spoolId);
+        }
         return true;
     }
 


### PR DESCRIPTION
## Summary

- New `cmd/low_spool` MQTT command — middleware/HA sends `true`/`false` to start/stop LED breathing mid-print
- Uses LED's current target color (persists after tag removal) so breathing matches the last scanned spool
- `LEDManager::getTargetColor()` getter for reading current LED target RGB
- Fix misleading log: "Spool X synced" instead of "Spool X, 0.0g remaining" when weight not sent

## Test plan

- [x] Build succeeds
- [x] Scan red tag, remove, send `cmd/low_spool true` → breathes red
- [x] Send `cmd/low_spool false` → solid red
- [x] Web log shows "Low spool: breathing enabled/disabled"

Completes #137 (gap #3 — cmd/low_spool handler)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new MQTT command support for controlling LED indicator behavior based on spool status, enabling LED breathing effects or static display modes

* **Improvements**
  * Enhanced logging messages for spool weight synchronization to provide clearer feedback during updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->