### PR TITLE
feat: Bambu AMS tray dashboard on TFT display (#148)

### DIFF
--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -160,8 +160,8 @@ void ApplicationManager::processMessages() {
 
     // Bambu dashboard revert: after scan interruption, return to dashboard
     if (dashboardRevertAt_ != 0) {
-        uint32_t now = millis();
-        if (now >= dashboardRevertAt_) {
+        uint32_t elapsedMs = static_cast<uint32_t>(millis() - dashboardRevertAt_);
+        if (elapsedMs >= DASHBOARD_REVERT_DELAY_MS) {
             dashboardRevertAt_ = 0;
 #ifndef NATIVE_TEST
             bool dashEnabled = ConfigurationManager::getInstance().isBambuDashboardEnabled();
@@ -452,7 +452,7 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
 
 #ifndef NATIVE_TEST
         if (ConfigurationManager::getInstance().isBambuDashboardEnabled() && trayDashboardState_.has_data) {
-            dashboardRevertAt_ = millis() + DASHBOARD_REVERT_DELAY_MS;
+            dashboardRevertAt_ = millis();
         }
 #endif
     } else if (display_) {
@@ -694,7 +694,7 @@ void ApplicationManager::handleBlankTagDetected(const AppMessage& msg) {
 
 #ifndef NATIVE_TEST
         if (ConfigurationManager::getInstance().isBambuDashboardEnabled() && trayDashboardState_.has_data) {
-            dashboardRevertAt_ = millis() + DASHBOARD_REVERT_DELAY_MS;
+            dashboardRevertAt_ = millis();
         }
 #endif
     }
@@ -740,7 +740,7 @@ void ApplicationManager::handleGenericTagDetected(const AppMessage& msg) {
 
 #ifndef NATIVE_TEST
         if (ConfigurationManager::getInstance().isBambuDashboardEnabled() && trayDashboardState_.has_data) {
-            dashboardRevertAt_ = millis() + DASHBOARD_REVERT_DELAY_MS;
+            dashboardRevertAt_ = millis();
         }
 #endif
     }
@@ -1280,11 +1280,13 @@ const TrayDashboardState& ApplicationManager::getTrayDashboardState() const {
 }
 
 void ApplicationManager::handleTrayUpdate() {
+#ifndef NATIVE_TEST
     // Persist to NVS
     Preferences prefs;
     prefs.begin("spoolsense", false);
     prefs.putBytes("tray_dash", &trayDashboardState_, sizeof(TrayDashboardState));
     prefs.end();
+#endif
 
     Serial.printf("ApplicationManager: Tray dashboard updated, %d trays\n",
                   trayDashboardState_.tray_count);

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -18,6 +18,7 @@
   #include <Arduino.h>
   #include <WiFi.h>
   #include <HTTPClient.h>
+  #include <Preferences.h>
   extern LEDManager ledManager;
 #else
   #include "platform/NativePlatform.h"
@@ -60,6 +61,30 @@ bool ApplicationManager::begin(DisplayI* display) {
     }
 
     Serial.println("ApplicationManager: Message queue created");
+
+#ifndef NATIVE_TEST
+    // Load cached tray dashboard from NVS
+    bool dashEnabled = ConfigurationManager::getInstance().isBambuDashboardEnabled();
+    if (dashEnabled) {
+        Preferences prefs;
+        prefs.begin("spoolsense", true);
+        size_t len = prefs.getBytesLength("tray_dash");
+        if (len == sizeof(TrayDashboardState)) {
+            prefs.getBytes("tray_dash", &trayDashboardState_, sizeof(TrayDashboardState));
+            if (trayDashboardState_.has_data && display_) {
+                display_->showTrayDashboard(trayDashboardState_);
+                Serial.printf("ApplicationManager: Loaded cached tray dashboard, %d trays\n",
+                              trayDashboardState_.tray_count);
+            } else if (display_) {
+                display_->showText("SpoolSense", "AMS Ready");
+            }
+        } else if (display_) {
+            display_->showText("SpoolSense", "AMS Ready");
+        }
+        prefs.end();
+    }
+#endif
+
     return true;
 }
 
@@ -130,6 +155,22 @@ void ApplicationManager::processMessages() {
 
             Serial.printf("ApplicationManager: Displayed delayed Type/Remain - Type: %s, Remain: %.0fg\n",
                          delayedDisplayMaterialName, delayedDisplayKgRemaining * 1000.0f);
+        }
+    }
+
+    // Bambu dashboard revert: after scan interruption, return to dashboard
+    if (dashboardRevertAt_ != 0) {
+        uint32_t now = millis();
+        if (now >= dashboardRevertAt_) {
+            dashboardRevertAt_ = 0;
+#ifndef NATIVE_TEST
+            bool dashEnabled = ConfigurationManager::getInstance().isBambuDashboardEnabled();
+#else
+            bool dashEnabled = false;
+#endif
+            if (dashEnabled && trayDashboardState_.has_data && display_) {
+                display_->showTrayDashboard(trayDashboardState_);
+            }
         }
     }
 
@@ -253,6 +294,10 @@ void ApplicationManager::handleMessage(const AppMessage& msg) {
 
         case AppMessageType::KEYPAD_CANCEL:
             handleKeypadCancel();
+            break;
+
+        case AppMessageType::TRAY_UPDATE:
+            handleTrayUpdate();
             break;
     }
 }
@@ -404,6 +449,12 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
         else if (strcmp(s.tag_format, "OpenSpool") == 0) spool.tagType = 6;
         else spool.tagType = 0;
         display_->showSpool(spool);
+
+#ifndef NATIVE_TEST
+        if (ConfigurationManager::getInstance().isBambuDashboardEnabled() && trayDashboardState_.has_data) {
+            dashboardRevertAt_ = millis() + DASHBOARD_REVERT_DELAY_MS;
+        }
+#endif
     } else if (display_) {
         Serial.printf("ApplicationManager: Skipping LCD update for already displayed spool %s\n", msg.payload.spoolDetected.spool_id);
     }
@@ -640,6 +691,12 @@ void ApplicationManager::handleBlankTagDetected(const AppMessage& msg) {
         lastDisplayedSpoolId[0] = '\0';  // Clear smart tag display — allow re-display if tag swapped
 
         display_->showText4("**** Spool ****", "*** Scanned ***", "Unknown Tag", "Use app to setup");
+
+#ifndef NATIVE_TEST
+        if (ConfigurationManager::getInstance().isBambuDashboardEnabled() && trayDashboardState_.has_data) {
+            dashboardRevertAt_ = millis() + DASHBOARD_REVERT_DELAY_MS;
+        }
+#endif
     }
 
     // HA MQTT: publish blank tag detected
@@ -680,6 +737,12 @@ void ApplicationManager::handleGenericTagDetected(const AppMessage& msg) {
         lastDisplayedSpoolId[0] = '\0';  // Clear smart tag display — allow re-display if tag swapped
 
         display_->showText4("**** Spool ****", "*** Scanned ***", "Generic Tag", "Checking Spoolman");
+
+#ifndef NATIVE_TEST
+        if (ConfigurationManager::getInstance().isBambuDashboardEnabled() && trayDashboardState_.has_data) {
+            dashboardRevertAt_ = millis() + DASHBOARD_REVERT_DELAY_MS;
+        }
+#endif
     }
 
     // HA MQTT: publish generic tag (UID only, awaiting Spoolman lookup)
@@ -1203,6 +1266,36 @@ void ApplicationManager::handleKeypadCancel() {
 
     if (display_) {
         display_->showText("Tool entry", "Cleared");
+    }
+}
+
+// ── Tray Dashboard ──────────────────────────────────────────────────────────
+
+void ApplicationManager::updateTrayDashboard(const TrayDashboardState& state) {
+    trayDashboardState_ = state;
+}
+
+const TrayDashboardState& ApplicationManager::getTrayDashboardState() const {
+    return trayDashboardState_;
+}
+
+void ApplicationManager::handleTrayUpdate() {
+    // Persist to NVS
+    Preferences prefs;
+    prefs.begin("spoolsense", false);
+    prefs.putBytes("tray_dash", &trayDashboardState_, sizeof(TrayDashboardState));
+    prefs.end();
+
+    Serial.printf("ApplicationManager: Tray dashboard updated, %d trays\n",
+                  trayDashboardState_.tray_count);
+
+#ifndef NATIVE_TEST
+    bool dashEnabled = ConfigurationManager::getInstance().isBambuDashboardEnabled();
+#else
+    bool dashEnabled = false;
+#endif
+    if (dashEnabled && display_) {
+        display_->showTrayDashboard(trayDashboardState_);
     }
 }
 

--- a/src/ApplicationManager.h
+++ b/src/ApplicationManager.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include "IPrinterStrategy.h"  // for MAX_TOOLS constant
+#include "TrayDashboardTypes.h"
 
 #ifdef NATIVE_TEST
   #include "platform/NativePlatform.h"
@@ -30,6 +31,7 @@ enum class AppMessageType {
     KEYPAD_DIGIT,
     KEYPAD_CONFIRM,
     KEYPAD_CANCEL,
+    TRAY_UPDATE,
 };
 
 enum class AutomationMode : uint8_t {
@@ -180,6 +182,8 @@ public:
     AutomationMode getAutomationMode() const { return automationMode; }
     void setAutomationMode(AutomationMode mode) { automationMode = mode; }
     SmartTagEnrichment getSmartTagEnrichment() const { return smartTagEnrichment_; }
+    void updateTrayDashboard(const TrayDashboardState& state);
+    const TrayDashboardState& getTrayDashboardState() const;
 #ifdef NATIVE_TEST
     void resetForTest() {
         if (messageQueue) { vQueueDelete(messageQueue); messageQueue = nullptr; }
@@ -247,6 +251,11 @@ private:
     // Enrichment data from Spoolman UID lookup for the current smart tag
     SmartTagEnrichment smartTagEnrichment_;
 
+    // Bambu AMS tray dashboard state
+    TrayDashboardState trayDashboardState_ = {};
+    uint32_t dashboardRevertAt_ = 0;
+    static constexpr uint32_t DASHBOARD_REVERT_DELAY_MS = 5000;
+
     // Handlers
     void handlePrintStarted(const AppMessage& msg);
     void handlePrintEnded(const AppMessage& msg);
@@ -262,6 +271,7 @@ private:
     void handleKeypadDigit(const AppMessage& msg);
     void handleKeypadConfirm();
     void handleKeypadCancel();
+    void handleTrayUpdate();
     bool sendAssignSpool(const char* toolNumber);
     void finishPrint(float gramsUsed, bool canceled);
     void enqueueSpoolmanSync(const SpoolDetectedPayload& spool);

--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -219,6 +219,16 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
                   <option value="gc9a01">GC9A01 (round)</option>
                 </select>
               </div>
+            </div>
+            <h3>Bambu</h3>
+            <div class="field-group">
+              <span class="toggle-label">AMS Tray Dashboard (TFT only)</span>
+              <label class="toggle-switch">
+                <input type="checkbox" id="bambu_dashboard" />
+                <span class="toggle-track"></span>
+              </label>
+            </div>
+            <div style="display:grid;gap:10px">
               <div class="toggle-row">
                 <span class="toggle-label">NFC Reader</span>
                 <select id="nfc_reader" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text);font-size:0.95em">
@@ -274,6 +284,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
         document.getElementById('tft_driver_row').style.display = this.checked ? '' : 'none';
       });
       if (cfg.nfc_reader) document.getElementById('nfc_reader').value = cfg.nfc_reader;
+      document.getElementById('bambu_dashboard').checked = !!cfg.bambu_dashboard;
       maybeSetValue('moonraker_url', cfg.moonraker_url);
       // Password placeholders
       if (cfg.wifi_pass_set) document.getElementById('wifi_pass').placeholder = '(set) Leave blank to keep';
@@ -331,7 +342,8 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
         moonraker_url: document.getElementById('moonraker_url').value.trim(),
         prusalink_on: document.getElementById('prusalink_on').checked ? 1 : 0,
         prusalink_url: document.getElementById('prusalink_url').value.trim(),
-        prusalink_api_key: document.getElementById('prusalink_api_key').value
+        prusalink_api_key: document.getElementById('prusalink_api_key').value,
+        bambu_dashboard: document.getElementById('bambu_dashboard').checked ? 1 : 0
       };
 
       fetch('/api/config', {

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -34,6 +34,7 @@ static const char* NVS_KEY_PRUSALINK_KEY  = "prusalink_key";
 static const char* NVS_KEY_NFC_READER    = "nfc_reader";
 static const char* NVS_KEY_HOSTNAME      = "hostname";
 static const char* NVS_KEY_LOW_SPOOL     = "low_spool_g";
+static const char* NVS_KEY_BAMBU_DASH    = "bambu_dash";
 
 // Sanitize hostname: enforce mDNS naming constraints (lowercase alphanum + hyphens,
 // no leading/trailing hyphens) and reject empty strings to avoid boot-time errors.
@@ -248,6 +249,10 @@ bool ConfigurationManager::loadFromNVS() {
         _lowSpoolThreshold = prefs.getUShort(NVS_KEY_LOW_SPOOL, 100);
         anyOverride = true;
     }
+    if (prefs.isKey(NVS_KEY_BAMBU_DASH)) {
+        _bambuDashboard = prefs.getBool(NVS_KEY_BAMBU_DASH, false);
+        anyOverride = true;
+    }
 
     prefs.end();
     return anyOverride;
@@ -350,6 +355,10 @@ uint16_t ConfigurationManager::getLowSpoolThreshold() const {
     return _lowSpoolThreshold;
 }
 
+bool ConfigurationManager::isBambuDashboardEnabled() const {
+    return _bambuDashboard;
+}
+
 void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     memset(&out, 0, sizeof(out));
     strncpy(out.wifi_ssid, _ssid, sizeof(out.wifi_ssid) - 1);
@@ -373,6 +382,7 @@ void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     strncpy(out.nfc_reader, _nfcReader, sizeof(out.nfc_reader) - 1);
     strncpy(out.hostname, _hostname, sizeof(out.hostname) - 1);
     out.low_spool_threshold_g = _lowSpoolThreshold;
+    out.bambu_dashboard = _bambuDashboard ? 1 : 0;
 }
 
 #ifndef NATIVE_TEST
@@ -416,6 +426,7 @@ bool ConfigurationManager::saveToNVS(const ConfigUpdate& update) {
     sanitizeHostname(sanitizedHostname, sizeof(sanitizedHostname));  // enforce mDNS constraints before NVS write
     prefs.putString(NVS_KEY_HOSTNAME, sanitizedHostname);
     prefs.putUShort(NVS_KEY_LOW_SPOOL, update.low_spool_threshold_g);
+    prefs.putBool(NVS_KEY_BAMBU_DASH, update.bambu_dashboard != 0);
 
     // Invalidate Spoolman enrichment cache on config change to force re-fetch
     // (config change could invalidate cached spool lookups)

--- a/src/ConfigurationManager.h
+++ b/src/ConfigurationManager.h
@@ -39,6 +39,7 @@ struct ConfigUpdate {
     // mDNS / WiFi hostname
     char hostname[33];   // max 32 chars + null
     uint16_t low_spool_threshold_g;  // grams below which LED breathes (default 100)
+    uint8_t bambu_dashboard;
 };
 
 class ConfigurationManager {
@@ -85,6 +86,8 @@ public:
 
     // Low-spool threshold (grams) — LED breathes when remaining weight is at or below this
     uint16_t getLowSpoolThreshold() const;
+
+    bool isBambuDashboardEnabled() const;
 
     // Web config support
     void getCurrentConfig(ConfigUpdate& out) const;
@@ -135,6 +138,7 @@ private:
     bool _tftEnabled = false;
     char _tftDriver[8] = "st7789";
     uint16_t _lowSpoolThreshold = 100;  // grams
+    bool _bambuDashboard = false;
 
     bool _initialized = false;
 };

--- a/src/DeviceConfig.cpp
+++ b/src/DeviceConfig.cpp
@@ -12,6 +12,9 @@
 #ifndef ENABLE_KEYPAD
 #define ENABLE_KEYPAD 0
 #endif
+#ifndef ENABLE_BAMBU_DASHBOARD
+#define ENABLE_BAMBU_DASHBOARD 0
+#endif
 
 static const DeviceConfig kDeviceConfig = {
     .device_name = DEVICE_NAME,
@@ -46,6 +49,7 @@ static const DeviceConfig kDeviceConfig = {
         .lcd_enabled = ENABLE_LCD,
         .status_led_enabled = ENABLE_STATUS_LED,
         .keypad_enabled = ENABLE_KEYPAD,
+        .bambu_dashboard = ENABLE_BAMBU_DASHBOARD,
     },
 
     .automation_mode = AUTOMATION_MODE,

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -29,6 +29,7 @@ struct PeripheralConfig {
     bool lcd_enabled;
     bool status_led_enabled;
     bool keypad_enabled;
+    bool bambu_dashboard;
 };
 
 struct DeviceConfig {

--- a/src/DisplayI.h
+++ b/src/DisplayI.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include "TrayDashboardTypes.h"
 
 // Spool data passed to the display — enough for both LCD text and TFT graphics.
 struct DisplaySpoolData {
@@ -31,6 +32,9 @@ public:
 
     // Write result — LCD shows text, TFT shows checkmark/X graphic
     virtual void showWriteResult(bool success, const char* format) = 0;
+
+    // Bambu AMS tray dashboard
+    virtual void showTrayDashboard(const TrayDashboardState& state) {}
 
     // Screen timeout
     virtual void setScreenTimeoutMs(uint32_t timeoutMs) = 0;

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -914,6 +914,7 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
 
             const char* mat = obj["material"] | "";
             strncpy(tray.material, mat, sizeof(tray.material) - 1);
+            tray.material[sizeof(tray.material) - 1] = '\0';
 
             const char* colorHex = obj["color"] | "333333";
             if (strlen(colorHex) == 6) {

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -353,7 +353,7 @@ void HomeAssistantManager::taskLoop() {
     // One-time MQTT client config (buffer size, callback for incoming commands)
     mqttClient.setClient(wifiClient);
     mqttClient.setServer(config.getHAMqttHost(), config.getHAMqttPort());
-    mqttClient.setBufferSize(1024);
+    mqttClient.setBufferSize(2048);
     mqttClient.setCallback(mqttCallback);
 
     Serial.printf("HomeAssistantManager: Connecting to MQTT broker %s:%d\n",
@@ -780,7 +780,7 @@ void HomeAssistantManager::publishCurrentTagState() {
 // Static context — routes to instance's handleCommand for processing
 void HomeAssistantManager::mqttCallback(char* topic, uint8_t* payload, unsigned int length) {
     // Null-terminate payload buffer (MQTT payload is not null-terminated)
-    char buf[384];
+    char buf[1536];
     size_t copyLen = (length < sizeof(buf) - 1) ? length : sizeof(buf) - 1;
     memcpy(buf, payload, copyLen);
     buf[copyLen] = '\0';
@@ -887,7 +887,7 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
 
     // tray_update: HA sends full AMS tray state for dashboard display
     if (strcmp(command, "tray_update") == 0) {
-        StaticJsonDocument<768> trayDoc;
+        StaticJsonDocument<2048> trayDoc;
         if (deserializeJson(trayDoc, payload)) {
             publishCommandResponse(command, false, "invalid_json");
             return;

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -11,6 +11,7 @@
 #include "LEDManager.h"
 #include "LogBuffer.h"
 #include "SpoolmanManager.h"
+#include "TrayDashboardTypes.h"
 
 #ifndef NATIVE_TEST
   #include <Arduino.h>
@@ -879,6 +880,57 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
                 DeductionManager::getInstance().clearPending(uidFromTopic);
             }
         }
+
+        publishCommandResponse(command, true, nullptr);
+        return;
+    }
+
+    // tray_update: HA sends full AMS tray state for dashboard display
+    if (strcmp(command, "tray_update") == 0) {
+        StaticJsonDocument<768> trayDoc;
+        if (deserializeJson(trayDoc, payload)) {
+            publishCommandResponse(command, false, "invalid_json");
+            return;
+        }
+
+        JsonArray arr = trayDoc.as<JsonArray>();
+        if (arr.isNull()) {
+            publishCommandResponse(command, false, "expected_array");
+            return;
+        }
+
+        TrayDashboardState state = {};
+        state.has_data = true;
+        uint8_t count = 0;
+
+        for (JsonObject obj : arr) {
+            if (count >= MAX_TRAYS) break;
+
+            TrayData& tray = state.trays[count];
+            tray.tray_index = obj["tray_index"] | 0;
+            tray.ams_id = obj["ams_id"] | 0;
+            tray.weight_g = obj["weight_g"] | 0;
+            tray.populated = true;
+
+            const char* mat = obj["material"] | "";
+            strncpy(tray.material, mat, sizeof(tray.material) - 1);
+
+            const char* colorHex = obj["color"] | "333333";
+            if (strlen(colorHex) == 6) {
+                uint32_t c = strtoul(colorHex, nullptr, 16);
+                tray.color[0] = (c >> 16) & 0xFF;
+                tray.color[1] = (c >> 8) & 0xFF;
+                tray.color[2] = c & 0xFF;
+            }
+
+            count++;
+        }
+        state.tray_count = count;
+
+        ApplicationManager::getInstance().updateTrayDashboard(state);
+        AppMessage msg = {};
+        msg.type = AppMessageType::TRAY_UPDATE;
+        ApplicationManager::getInstance().sendMessage(msg);
 
         publishCommandResponse(command, true, nullptr);
         return;

--- a/src/TFTDashboard.cpp
+++ b/src/TFTDashboard.cpp
@@ -30,7 +30,7 @@ void TFTDashboard::renderCell(LGFX_Sprite* sprite, int x, int y, int w, int h,
     sprite->setTextColor(textColor);
     sprite->setTextDatum(MC_DATUM);
 
-    char label[4];
+    char label[6];
     snprintf(label, sizeof(label), "T%d", tray.tray_index + 1);
 
     char weight[8];

--- a/src/TFTDashboard.cpp
+++ b/src/TFTDashboard.cpp
@@ -1,0 +1,102 @@
+#include "TFTDashboard.h"
+
+static const uint32_t COLOR_EMPTY_BG = 0x1A1A1A;
+static const uint32_t COLOR_EMPTY_TEXT = 0x555555;
+static const uint32_t COLOR_WHITE = 0xFFFFFF;
+static const uint32_t COLOR_BLACK = 0x000000;
+static const int CELL_GAP = 2;
+
+uint32_t TFTDashboard::contrastTextColor(uint8_t r, uint8_t g, uint8_t b) {
+    float luminance = 0.299f * r + 0.587f * g + 0.114f * b;
+    return luminance > 128.0f ? COLOR_BLACK : COLOR_WHITE;
+}
+
+void TFTDashboard::renderEmptyCell(LGFX_Sprite* sprite, int x, int y, int w, int h, bool small) {
+    sprite->fillRect(x, y, w, h, COLOR_EMPTY_BG);
+    sprite->setTextColor(COLOR_EMPTY_TEXT);
+    sprite->setTextDatum(MC_DATUM);
+    sprite->setTextSize(small ? 1 : 2);
+    sprite->drawString("-", x + w / 2, y + h / 2);
+}
+
+void TFTDashboard::renderCell(LGFX_Sprite* sprite, int x, int y, int w, int h,
+                               const TrayData& tray, bool small) {
+    uint32_t bgColor = (static_cast<uint32_t>(tray.color[0]) << 16) |
+                       (static_cast<uint32_t>(tray.color[1]) << 8) |
+                        static_cast<uint32_t>(tray.color[2]);
+    sprite->fillRect(x, y, w, h, bgColor);
+
+    uint32_t textColor = contrastTextColor(tray.color[0], tray.color[1], tray.color[2]);
+    sprite->setTextColor(textColor);
+    sprite->setTextDatum(MC_DATUM);
+
+    char label[4];
+    snprintf(label, sizeof(label), "T%d", tray.tray_index + 1);
+
+    char weight[8];
+    if (tray.weight_g > 0) {
+        snprintf(weight, sizeof(weight), "%dg", tray.weight_g);
+    } else {
+        snprintf(weight, sizeof(weight), "?g");
+    }
+
+    if (small) {
+        // 4x4 grid: compact layout
+        sprite->setTextSize(1);
+        int cy = y + h / 2;
+        sprite->drawString(label, x + w / 2, cy - 14);
+        sprite->drawString(tray.material, x + w / 2, cy);
+        sprite->drawString(weight, x + w / 2, cy + 14);
+    } else {
+        // 2x2 grid: spacious layout
+        int cy = y + h / 2;
+        sprite->setTextSize(1);
+        sprite->drawString(label, x + w / 2, cy - 28);
+        sprite->setTextSize(2);
+        sprite->drawString(tray.material, x + w / 2, cy);
+        sprite->setTextSize(1);
+        sprite->drawString(weight, x + w / 2, cy + 28);
+    }
+}
+
+void TFTDashboard::render(LGFX_Sprite* sprite, const TrayDashboardState& state) {
+    sprite->fillScreen(0x000000);
+
+    if (state.tray_count == 0) {
+        sprite->setTextColor(COLOR_EMPTY_TEXT);
+        sprite->setTextDatum(MC_DATUM);
+        sprite->setTextSize(2);
+        sprite->drawString("No Trays", 120, 120);
+        sprite->pushSprite(0, 0);
+        return;
+    }
+
+    // Determine grid dimensions
+    uint8_t cols, rows;
+    bool small;
+    if (state.tray_count <= 4) {
+        cols = 2; rows = 2; small = false;
+    } else if (state.tray_count <= 8) {
+        cols = 2; rows = 4; small = true;
+    } else {
+        cols = 4; rows = 4; small = true;
+    }
+
+    int cellW = (240 - (cols + 1) * CELL_GAP) / cols;
+    int cellH = (240 - (rows + 1) * CELL_GAP) / rows;
+
+    for (uint8_t i = 0; i < rows * cols; i++) {
+        uint8_t col = i % cols;
+        uint8_t row = i / cols;
+        int x = CELL_GAP + col * (cellW + CELL_GAP);
+        int y = CELL_GAP + row * (cellH + CELL_GAP);
+
+        if (i < state.tray_count && state.trays[i].populated) {
+            renderCell(sprite, x, y, cellW, cellH, state.trays[i], small);
+        } else {
+            renderEmptyCell(sprite, x, y, cellW, cellH, small);
+        }
+    }
+
+    sprite->pushSprite(0, 0);
+}

--- a/src/TFTDashboard.h
+++ b/src/TFTDashboard.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <LovyanGFX.hpp>
+#include "TrayDashboardTypes.h"
+
+class TFTDashboard {
+public:
+    void render(LGFX_Sprite* sprite, const TrayDashboardState& state);
+
+private:
+    void renderCell(LGFX_Sprite* sprite, int x, int y, int w, int h,
+                    const TrayData& tray, bool small);
+    void renderEmptyCell(LGFX_Sprite* sprite, int x, int y, int w, int h, bool small);
+    uint32_t contrastTextColor(uint8_t r, uint8_t g, uint8_t b);
+};

--- a/src/TFTManager.cpp
+++ b/src/TFTManager.cpp
@@ -275,6 +275,9 @@ void TFTManager::processQueue() {
             case TFTState::Error:
                 renderStatus("Error", msg.statusText);
                 break;
+            case TFTState::TrayDashboard:
+                _dashboard.render(&_sprite, msg.dashboardState);
+                break;
         }
     }
 
@@ -654,6 +657,16 @@ void TFTManager::showText4(const char* line1, const char* line2,
 
 void TFTManager::showKeypad(const char* digits) {
     showKeypadEntry(digits && digits[0] ? digits : "_");
+}
+
+void TFTManager::showTrayDashboard(const TrayDashboardState& state) {
+    if (!_messageQueue) return;
+    TFTMessage msg = {};
+    msg.state = TFTState::TrayDashboard;
+    msg.dashboardState = state;
+    if (xQueueSend(_messageQueue, &msg, 0) != pdTRUE) {
+        Serial.println("TFTManager: Queue full, dropping tray dashboard");
+    }
 }
 
 void TFTManager::showSpool(const DisplaySpoolData& spool) {

--- a/src/TFTManager.h
+++ b/src/TFTManager.h
@@ -5,6 +5,8 @@
 #include "BoardPins.h"
 #include "TFTConfig.h"
 #include "DisplayI.h"
+#include "TrayDashboardTypes.h"
+#include "TFTDashboard.h"
 
 // Tag type constants — one icon per type
 #define TAG_TYPE_UNKNOWN      0
@@ -26,7 +28,8 @@ enum class TFTState {
     Writing,
     WriteResult,
     KeypadEntry,
-    Error
+    Error,
+    TrayDashboard
 };
 
 // ---------------------------------------------------------------------------
@@ -38,6 +41,7 @@ struct TFTMessage {
     char statusText[48];   // used for Boot/Ready/Error/Writing/KeypadEntry
     char statusText2[48];  // second line for generic status display
     bool writeSuccess;     // used for WriteResult
+    TrayDashboardState dashboardState; // valid when state == TrayDashboard
 };
 
 // ---------------------------------------------------------------------------
@@ -74,6 +78,7 @@ public:
                    const char* line3, const char* line4) override;
     void showSpool(const DisplaySpoolData& spool) override;
     void showKeypad(const char* digits) override;
+    void showTrayDashboard(const TrayDashboardState& state) override;
 
 private:
     static void taskFunc(void* param);
@@ -98,6 +103,7 @@ private:
     LGFX _tft;
     LGFX_Sprite _sprite;
     TFTDriver _driver;
+    TFTDashboard _dashboard;
 
     QueueHandle_t _messageQueue;
     TaskHandle_t _taskHandle;

--- a/src/TrayDashboardTypes.h
+++ b/src/TrayDashboardTypes.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <stdint.h>
+
+static const uint8_t MAX_TRAYS = 16;
+
+struct TrayData {
+    uint8_t tray_index;    // 0-15 AMS, 16-23 AMS-HT, 254/255 external
+    uint8_t ams_id;        // for optional visual grouping later
+    char material[8];      // "PLA", "PETG", "ASA", etc.
+    uint8_t color[3];      // RGB
+    uint16_t weight_g;     // remaining weight in grams
+    bool populated;        // true if tray has a spool
+};
+
+struct TrayDashboardState {
+    TrayData trays[MAX_TRAYS];
+    uint8_t tray_count;    // number of populated trays
+    bool has_data;         // false until first cmd/tray_update received
+};

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -722,6 +722,7 @@ void WebServerManager::handleApiGetConfig() {
     doc["nfc_reader"] = cfg.nfc_reader;
     doc["hostname"] = cfg.hostname;
     doc["low_spool_threshold_g"] = cfg.low_spool_threshold_g;
+    doc["bambu_dashboard"] = cfg.bambu_dashboard;
     doc["tft_enabled"] = cfg.tft_enabled;
     doc["tft_driver"] = cfg.tft_driver;
     doc["ap_mode"] = _apMode;
@@ -779,6 +780,7 @@ void WebServerManager::handleApiPostConfig() {
     update.hostname[sizeof(update.hostname) - 1] = '\0';
     sanitizeHostname(update.hostname, sizeof(update.hostname));
     update.low_spool_threshold_g = doc["low_spool_threshold_g"] | (uint16_t)100;
+    update.bambu_dashboard = doc["bambu_dashboard"] | 0;
 
     if (update.wifi_ssid[0] == '\0') {
         sendError(400, "WiFi SSID is required");


### PR DESCRIPTION
## Summary

- Adds a persistent TFT dashboard showing Bambu AMS tray status (color, material, weight) in a colored grid
- HA blueprint sends `cmd/tray_update` MQTT command with flat JSON array of tray states
- Auto-detects grid layout from tray count: 2x2 (1-4 trays), 2x4 (5-8), 4x4 (9-16)
- NVS caches last tray state for instant display on reboot
- 5-second revert timer returns to dashboard after tag scans
- New "Bambu Dashboard" toggle on config page (disabled by default)

## Design

- Scanner is a **dumb display** — topology-blind, HA owns all Bambu mapping logic
- `DisplayI::showTrayDashboard()` with default empty body (LCD gets no-op automatically)
- `TFTDashboard` helper class isolates grid rendering from TFTManager
- `TRAY_UPDATE` signal message through existing AppMessage queue
- Contrast text via luminance formula: white on dark backgrounds, black on light

## New Files

| File | Purpose |
|------|---------|
| `src/TrayDashboardTypes.h` | TrayData/TrayDashboardState structs |
| `src/TFTDashboard.h/.cpp` | Grid renderer (LovyanGFX sprites) |

## Test plan

- [ ] Enable Bambu Dashboard in config page, verify toggle persists after reboot
- [ ] Send `cmd/tray_update` via MQTT with 4 trays — verify 2x2 grid renders with correct colors
- [ ] Send update with 16 trays — verify 4x4 grid renders
- [ ] Scan a tag while dashboard active — verify spool details show, then dashboard returns after 5s
- [ ] Reboot scanner — verify cached dashboard appears immediately
- [ ] Verify compile: esp32dev, esp32s3zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bambu AMS Tray Dashboard: displays tray material, weight, color, and tray count
  * Remote tray updates via MQTT
  * New display rendering for tray grid (adaptive layouts)

* **Behavior**
  * Dashboard state persists across restarts
  * Dashboard auto-reverts to prior state after ~5s on tag events

* **Configuration**
  * Added option to enable/disable the dashboard in device config/UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->