### PR TITLE
feat: Bambu AMS dashboard blueprint + tray_assign command (#148)

### DIFF
--- a/docs/bambu-dashboard-flow.html
+++ b/docs/bambu-dashboard-flow.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Bambu AMS Dashboard — Data Flow</title>
+    <style>
+        body {
+            background: #1a1a2e;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            display: flex;
+            justify-content: center;
+            padding: 30px;
+            color: #e0e0e0;
+        }
+        .diagram { width: 720px; }
+        h1 { text-align: center; color: #fff; font-size: 18px; margin-bottom: 30px; }
+        .row { display: flex; align-items: center; justify-content: center; margin-bottom: 6px; }
+        .box {
+            border-radius: 10px; padding: 14px 20px; text-align: center;
+            font-size: 13px; min-width: 200px; position: relative;
+        }
+        .box .label { font-weight: 700; font-size: 14px; margin-bottom: 4px; }
+        .box .detail { font-size: 11px; opacity: 0.85; }
+        .scanner { background: #2d6a4f; border: 2px solid #52b788; }
+        .nfc { background: #3a5a40; border: 2px solid #95d5b2; }
+        .printer { background: #5a189a; border: 2px solid #9d4edd; }
+        .ha { background: #1565c0; border: 2px solid #42a5f5; }
+        .blueprint { background: #0d47a1; border: 2px solid #1e88e5; }
+        .spoolman { background: #00695c; border: 2px solid #26a69a; }
+        .tft { background: #bf360c; border: 2px solid #ff7043; }
+        .arrow {
+            display: flex; flex-direction: column; align-items: center;
+            margin: 4px 0; color: #aaa; font-size: 11px;
+        }
+        .arrow .line { width: 2px; height: 18px; background: #555; }
+        .arrow .head {
+            width: 0; height: 0;
+            border-left: 6px solid transparent; border-right: 6px solid transparent;
+            border-top: 8px solid #555;
+        }
+        .arrow .msg {
+            background: #2a2a3e; padding: 3px 10px; border-radius: 6px;
+            border: 1px solid #444; margin: 2px 0;
+            font-family: 'Courier New', monospace; font-size: 11px; color: #ffd54f;
+        }
+        .split { display: flex; gap: 20px; justify-content: center; align-items: flex-start; }
+        .split-col { display: flex; flex-direction: column; align-items: center; }
+        .phase {
+            text-align: center; font-size: 11px; color: #888;
+            text-transform: uppercase; letter-spacing: 2px;
+            margin: 24px 0 12px; border-top: 1px dashed #333;
+            padding-top: 14px; width: 100%;
+        }
+        .note {
+            background: #2a2a3e; border: 1px dashed #555; border-radius: 8px;
+            padding: 10px 16px; font-size: 11px; color: #aaa;
+            text-align: center; margin: 6px 0; max-width: 400px;
+        }
+    </style>
+</head>
+<body>
+<div class="diagram">
+    <h1>Bambu AMS Dashboard — Full Data Flow</h1>
+
+    <!-- Phase 1: Spool Scan & Loading -->
+    <div class="phase">Phase 1 — Spool Scan & Loading</div>
+
+    <div class="row">
+        <div class="box nfc">
+            <div class="label">NFC Tag on Spool</div>
+            <div class="detail">UID, material, color, temps, weight</div>
+        </div>
+    </div>
+    <div class="arrow">
+        <div class="line"></div>
+        <div class="msg">scan</div>
+        <div class="head"></div>
+    </div>
+    <div class="row">
+        <div class="box scanner">
+            <div class="label">SpoolSense Scanner</div>
+            <div class="detail">Reads NFC tag → publishes to MQTT</div>
+        </div>
+    </div>
+
+    <div class="split">
+        <div class="split-col">
+            <div class="arrow">
+                <div class="line"></div>
+                <div class="msg">MQTT: spoolsense/{id}/tag/state</div>
+                <div class="detail" style="color:#aaa;font-size:10px">uid, material, color, remaining_g,<br>spoolman_id, temps</div>
+                <div class="head"></div>
+            </div>
+            <div class="row">
+                <div class="box ha">
+                    <div class="label">Home Assistant</div>
+                    <div class="detail">sensor.spoolsense_{id}_spool → "present"</div>
+                </div>
+            </div>
+        </div>
+        <div class="split-col">
+            <div class="arrow">
+                <div class="line"></div>
+                <div class="msg">HTTP: Spoolman UID lookup (async)</div>
+                <div class="head"></div>
+            </div>
+            <div class="row">
+                <div class="box spoolman" style="min-width:160px">
+                    <div class="label">Spoolman</div>
+                    <div class="detail">Returns weight, spoolman_id</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="arrow">
+        <div class="line"></div>
+        <div class="msg">trigger: sensor state → "present"</div>
+        <div class="head"></div>
+    </div>
+    <div class="row">
+        <div class="box blueprint">
+            <div class="label">Blueprint: SpoolSense → Bambu AMS</div>
+            <div class="detail">spoolsense_bambu_ams.yaml</div>
+        </div>
+    </div>
+
+    <div class="note">Waits for user to physically load spool into AMS tray<br>(wait_for_trigger: tray empty → not empty)</div>
+
+    <div class="split">
+        <div class="split-col">
+            <div class="arrow">
+                <div class="line"></div>
+                <div class="msg">bambu_lab.set_filament</div>
+                <div class="detail" style="color:#aaa;font-size:10px">tray_type, tray_color,<br>tray_info_idx, temps</div>
+                <div class="head"></div>
+            </div>
+            <div class="row">
+                <div class="box printer">
+                    <div class="label">Bambu Printer</div>
+                    <div class="detail">Updates AMS tray info</div>
+                </div>
+            </div>
+        </div>
+        <div class="split-col">
+            <div class="arrow">
+                <div class="line"></div>
+                <div class="msg">MQTT: cmd/tray_assign</div>
+                <div class="detail" style="color:#aaa;font-size:10px">{tray_index, uid, spoolman_id}</div>
+                <div class="head"></div>
+            </div>
+            <div class="row">
+                <div class="box scanner" style="min-width:180px">
+                    <div class="label">Scanner stores UID→Tray</div>
+                    <div class="detail">NVS: maps UID to tray index<br>Enqueues Spoolman weight lookup</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Phase 2: Dashboard Update -->
+    <div class="phase">Phase 2 — Dashboard Update</div>
+
+    <div class="row">
+        <div class="box printer">
+            <div class="label">Bambu Printer</div>
+            <div class="detail">Reports tray state via Bambu MQTT</div>
+        </div>
+    </div>
+    <div class="arrow">
+        <div class="line"></div>
+        <div class="msg">HA Bambu Lab Integration</div>
+        <div class="head"></div>
+    </div>
+    <div class="row">
+        <div class="box ha">
+            <div class="label">sensor.{printer}_ams_tray_{1-N}</div>
+            <div class="detail">type, color, empty, name</div>
+        </div>
+    </div>
+    <div class="arrow">
+        <div class="line"></div>
+        <div class="msg">trigger: any tray state change</div>
+        <div class="head"></div>
+    </div>
+    <div class="row">
+        <div class="box blueprint">
+            <div class="label">Blueprint: Bambu AMS Dashboard</div>
+            <div class="detail">spoolsense_bambu_dashboard.yaml</div>
+        </div>
+    </div>
+    <div class="arrow">
+        <div class="detail" style="color:#aaa;font-size:11px">Reads tray attributes (type, color, empty)<br>Builds JSON array, skips empty trays</div>
+        <div class="line"></div>
+        <div class="msg">MQTT: spoolsense/{id}/cmd/tray_update</div>
+        <div class="msg" style="font-size:10px;color:#ccc">[{tray_index, ams_id, material, color}, ...]</div>
+        <div class="head"></div>
+    </div>
+    <div class="row">
+        <div class="box scanner">
+            <div class="label">SpoolSense Scanner</div>
+            <div class="detail">Parses tray data → persists to NVS → renders dashboard</div>
+        </div>
+    </div>
+
+    <!-- Phase 3: Weight Enrichment -->
+    <div class="phase">Phase 3 — Weight Enrichment</div>
+
+    <div class="split">
+        <div class="split-col">
+            <div class="row">
+                <div class="box scanner" style="min-width:220px">
+                    <div class="label">Spoolman Weight Lookup</div>
+                    <div class="detail">Triggered by cmd/tray_assign<br>For trays with stored UIDs</div>
+                </div>
+            </div>
+            <div class="arrow">
+                <div class="line"></div>
+                <div class="msg">HTTP: streaming UID lookup</div>
+                <div class="head"></div>
+            </div>
+            <div class="row">
+                <div class="box spoolman">
+                    <div class="label">Spoolman</div>
+                    <div class="detail">Returns remaining weight for UID</div>
+                </div>
+            </div>
+            <div class="arrow">
+                <div class="line"></div>
+                <div class="msg">SPOOLMAN_SYNCED → update weight_g → re-render</div>
+                <div class="head"></div>
+            </div>
+        </div>
+        <div class="split-col" style="margin-top:10px">
+            <div class="row">
+                <div class="box scanner" style="min-width:200px">
+                    <div class="label">Deduction (follow-up)</div>
+                    <div class="detail">cmd/deduct_tray arrives →<br>scanner resolves tray → UID →<br>subtract weight → re-render</div>
+                </div>
+            </div>
+            <div class="note" style="max-width:200px;margin-top:10px">
+                Automatic weight updates<br>after every print —<br>pending print test verification
+            </div>
+        </div>
+    </div>
+
+    <div class="arrow">
+        <div class="line"></div>
+        <div class="head"></div>
+    </div>
+    <div class="row">
+        <div class="box tft">
+            <div class="label">TFT Dashboard</div>
+            <div class="detail">2x2 / 2x4 / 4x4 grid — color, material, weight per tray</div>
+        </div>
+    </div>
+
+</div>
+</body>
+</html>

--- a/docs/bambu-dashboard-flow.html
+++ b/docs/bambu-dashboard-flow.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Bambu AMS Dashboard — Data Flow</title>
     <style>

--- a/homeassistant/blueprints/spoolsense_bambu_ams.yaml
+++ b/homeassistant/blueprints/spoolsense_bambu_ams.yaml
@@ -34,6 +34,13 @@ blueprint:
           min: 30
           max: 600
           unit_of_measurement: seconds
+    scanner_device_id:
+      name: SpoolSense Scanner Device ID
+      description: >
+        The scanner's device ID (e.g., 4d9620). Found on the scanner's landing page.
+        Used to send tray assignment to the correct scanner.
+      selector:
+        text: {}
 
 mode: restart
 max_exceeded: silent
@@ -87,6 +94,8 @@ actions:
       spool_color_rgba: "{{ spool_color_raw.replace('#', '') ~ 'FF' }}"
       spool_nozzle_min: "{{ trigger.to_state.attributes.min_print_temp | default(0) | int }}"
       spool_nozzle_max: "{{ trigger.to_state.attributes.max_print_temp | default(0) | int }}"
+      scanner_id: !input scanner_device_id
+      tray_entities: !input ams_tray_entities
 
   - wait_for_trigger:
       - trigger: state
@@ -113,14 +122,10 @@ actions:
       nozzle_temp_min: "{{ spool_nozzle_min }}"
       nozzle_temp_max: "{{ spool_nozzle_max }}"
 
-  - action: input_text.set_value
-    target:
-      entity_id: "input_text.spoolsense_{{ loaded_tray | replace('sensor.', '') }}_uid"
+  - action: mqtt.publish
     data:
-      value: "{{ trigger.to_state.attributes.uid }}"
-
-  - action: input_text.set_value
-    target:
-      entity_id: "input_text.spoolsense_{{ loaded_tray | replace('sensor.', '') }}_spoolman_id"
-    data:
-      value: "{{ trigger.to_state.attributes.spoolman_id | default(-1) }}"
+      topic: "spoolsense/{{ scanner_id }}/cmd/tray_assign"
+      payload: >
+        {"tray_index": {{ tray_entities.index(loaded_tray) }},
+         "uid": "{{ trigger.to_state.attributes.uid | default('') }}",
+         "spoolman_id": {{ trigger.to_state.attributes.spoolman_id | default(-1) }}}

--- a/homeassistant/blueprints/spoolsense_bambu_ams.yaml
+++ b/homeassistant/blueprints/spoolsense_bambu_ams.yaml
@@ -16,7 +16,8 @@ blueprint:
     ams_tray_entities:
       name: AMS Tray Sensors
       description: >
-        Select all AMS tray sensor entities to monitor. When filament is loaded
+        Select all AMS tray sensor entities to monitor. Order matters — the first
+        entity is tray index 0, second is index 1, etc. When filament is loaded
         into any of these trays after a scan, the spool data is pushed to that tray.
       selector:
         entity:

--- a/homeassistant/blueprints/spoolsense_bambu_dashboard.yaml
+++ b/homeassistant/blueprints/spoolsense_bambu_dashboard.yaml
@@ -1,0 +1,61 @@
+blueprint:
+  name: "SpoolSense → Bambu AMS Dashboard"
+  description: >
+    Keeps the SpoolSense TFT tray dashboard in sync with your Bambu AMS.
+    When any AMS tray changes (spool loaded, removed, or filament info updated),
+    the blueprint publishes the current tray state to the scanner via MQTT.
+    Requires the Bambu AMS Dashboard toggle enabled on the scanner config page.
+  domain: automation
+  input:
+    spoolsense_device_id:
+      name: SpoolSense Scanner Device ID
+      description: >
+        The scanner's device ID (e.g., 4d9620). Found on the scanner's landing page
+        or in the MQTT topic prefix.
+      selector:
+        text: {}
+    ams_tray_entities:
+      name: AMS Tray Sensors
+      description: >
+        Select all AMS tray sensor entities to monitor. Order matters — the first
+        entity is tray index 0, second is index 1, etc. For a single AMS, select
+        all 4 trays in order. For multiple AMS units, select all trays across units.
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - domain: sensor
+
+mode: queued
+max_exceeded: silent
+max: 3
+
+triggers:
+  - trigger: state
+    entity_id: !input ams_tray_entities
+
+actions:
+  - variables:
+      scanner_id: !input spoolsense_device_id
+      tray_entities: !input ams_tray_entities
+
+  - variables:
+      tray_json: >
+        {% set ns = namespace(trays=[]) %}
+        {% for entity in tray_entities %}
+          {% set a = state_attr(entity, 'type') | default('') %}
+          {% set empty = state_attr(entity, 'empty') | default(true) %}
+          {% if not empty and a != '' and a != 'Empty' %}
+            {% set color_raw = state_attr(entity, 'color') | default('#000000FF') %}
+            {% set color = color_raw | replace('#', '') %}
+            {% set color = color[:6] if color | length >= 8 else color[:6] %}
+            {% set tray = '{"tray_index":' ~ loop.index0 ~ ',"ams_id":' ~ (loop.index0 // 4) ~ ',"material":"' ~ a ~ '","color":"' ~ color ~ '"}' %}
+            {% set ns.trays = ns.trays + [tray] %}
+          {% endif %}
+        {% endfor %}
+        [{{ ns.trays | join(',') }}]
+
+  - action: mqtt.publish
+    data:
+      topic: "spoolsense/{{ scanner_id }}/cmd/tray_update"
+      payload: "{{ tray_json }}"

--- a/homeassistant/blueprints/spoolsense_bambu_dashboard.yaml
+++ b/homeassistant/blueprints/spoolsense_bambu_dashboard.yaml
@@ -47,9 +47,8 @@ actions:
           {% set empty = state_attr(entity, 'empty') | default(true) %}
           {% if not empty and a != '' and a != 'Empty' %}
             {% set color_raw = state_attr(entity, 'color') | default('#000000FF') %}
-            {% set color = color_raw | replace('#', '') %}
-            {% set color = color[:6] if color | length >= 8 else color[:6] %}
-            {% set tray = '{"tray_index":' ~ loop.index0 ~ ',"ams_id":' ~ (loop.index0 // 4) ~ ',"material":"' ~ a ~ '","color":"' ~ color ~ '"}' %}
+            {% set color = (color_raw | replace('#', ''))[:6] %}
+            {% set tray = {"tray_index": loop.index0, "ams_id": (loop.index0 // 4), "material": a, "color": color} | tojson %}
             {% set ns.trays = ns.trays + [tray] %}
           {% endif %}
         {% endfor %}

--- a/homeassistant/blueprints/spoolsense_bambu_deduction.yaml
+++ b/homeassistant/blueprints/spoolsense_bambu_deduction.yaml
@@ -2,9 +2,10 @@ blueprint:
   name: "SpoolSense → Bambu Deduction"
   description: >
     Automatically deduct filament weight after a Bambu Lab print completes or is
-    canceled. Sends deductions to the SpoolSense scanner via MQTT, which updates
-    Spoolman and writes to NFC tags. No spoolman-homeassistant integration needed.
-    Requires the SpoolSense → Bambu AMS blueprint (which stores spool UIDs per tray).
+    canceled. Sends per-tray deductions to the SpoolSense scanner via MQTT, which
+    resolves the tray to a spool UID and updates Spoolman. No input_text helpers
+    or Spoolman HA integration needed — the scanner handles everything.
+    Requires the SpoolSense → Bambu AMS blueprint (which assigns UIDs to trays).
   domain: automation
   input:
     bambu_device:
@@ -17,7 +18,7 @@ blueprint:
       name: Print Weight Sensor
       description: >
         The Bambu print weight sensor (e.g., sensor.p1s_print_weight).
-        Its attributes contain per-tray weight breakdown after a print.
+        After a print, its attributes contain per-tray weight breakdown.
       selector:
         entity:
           filter:
@@ -25,8 +26,9 @@ blueprint:
     ams_tray_entities:
       name: AMS Tray Sensors
       description: >
-        Select the same AMS tray sensors as in the SpoolSense → Bambu AMS blueprint.
-        Must have matching input_text helpers created (see documentation).
+        Select the same AMS tray sensors as in the SpoolSense → Bambu AMS blueprint,
+        in the same order. The position in this list determines the tray index sent
+        to the scanner.
       selector:
         entity:
           multiple: true
@@ -67,25 +69,16 @@ actions:
       sequence:
         - variables:
             tray_entity: "{{ repeat.item }}"
-            tray_name_key: >
-              {% set parts = tray_entity.replace('sensor.', '').split('_ams_') %}
-              {% if parts | length == 2 %}
-                {% set ams_tray = parts[1].replace('tray_', '').split('_') %}
-                {% if ams_tray | length >= 1 %}
-                  AMS {{ ams_tray[0] | default(1) }} Tray {{ ams_tray[-1] | default(1) }}
-                {% endif %}
-              {% endif %}
-            tray_weight_used: "{{ state_attr(weight_sensor, tray_name_key | trim) | float(0) }}"
-            helper_uid: "input_text.spoolsense_{{ tray_entity | replace('sensor.', '') }}_uid"
-            stored_uid: "{{ states(helper_uid) | default('') }}"
+            tray_index: "{{ loop.index0 }}"
+            ams_num: "{{ (tray_index | int // 4) + 1 }}"
+            tray_in_ams: "{{ (tray_index | int % 4) + 1 }}"
+            tray_attr_key: "AMS {{ ams_num }} Tray {{ tray_in_ams }}"
+            tray_weight_used: "{{ state_attr(weight_sensor, tray_attr_key) | float(0) }}"
 
         - condition: template
           value_template: "{{ tray_weight_used | float(0) > 0 }}"
 
-        - condition: template
-          value_template: "{{ stored_uid != '' and stored_uid != 'unknown' }}"
-
         - action: mqtt.publish
           data:
-            topic: "spoolsense/{{ scanner_id }}/cmd/deduct/{{ stored_uid }}"
-            payload: '{"deduct_g": {{ tray_weight_used | float }}}'
+            topic: "spoolsense/{{ scanner_id }}/cmd/deduct_tray"
+            payload: '{"tray_index": {{ tray_index }}, "deduct_g": {{ tray_weight_used | float }}}'

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -63,7 +63,7 @@ bool ApplicationManager::begin(DisplayI* display) {
     Serial.println("ApplicationManager: Message queue created");
 
 #ifndef NATIVE_TEST
-    // Load cached tray dashboard from NVS
+    // Load cached tray dashboard from NVS (display handled by main.cpp after full boot)
     bool dashEnabled = ConfigurationManager::getInstance().isBambuDashboardEnabled();
     if (dashEnabled) {
         Preferences prefs;
@@ -71,15 +71,8 @@ bool ApplicationManager::begin(DisplayI* display) {
         size_t len = prefs.getBytesLength("tray_dash");
         if (len == sizeof(TrayDashboardState)) {
             prefs.getBytes("tray_dash", &trayDashboardState_, sizeof(TrayDashboardState));
-            if (trayDashboardState_.has_data && display_) {
-                display_->showTrayDashboard(trayDashboardState_);
-                Serial.printf("ApplicationManager: Loaded cached tray dashboard, %d trays\n",
-                              trayDashboardState_.tray_count);
-            } else if (display_) {
-                display_->showText("SpoolSense", "AMS Ready");
-            }
-        } else if (display_) {
-            display_->showText("SpoolSense", "AMS Ready");
+            Serial.printf("ApplicationManager: Loaded cached tray dashboard, %d trays\n",
+                          trayDashboardState_.tray_count);
         }
         prefs.end();
     }

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -299,6 +299,10 @@ void ApplicationManager::handleMessage(const AppMessage& msg) {
         case AppMessageType::TRAY_UPDATE:
             handleTrayUpdate();
             break;
+
+        case AppMessageType::TRAY_ASSIGN:
+            handleTrayAssign();
+            break;
     }
 }
 
@@ -1299,6 +1303,42 @@ void ApplicationManager::handleTrayUpdate() {
     if (dashEnabled && display_) {
         display_->showTrayDashboard(trayDashboardState_);
     }
+}
+
+void ApplicationManager::handleTrayAssign() {
+    uint8_t idx = pendingAssignTrayIndex_;
+    if (idx >= MAX_TRAYS) {
+        Serial.printf("ApplicationManager: tray_assign rejected — index %d out of range\n", idx);
+        return;
+    }
+
+    for (uint8_t i = 0; i < trayDashboardState_.tray_count; i++) {
+        if (trayDashboardState_.trays[i].tray_index == idx) {
+            strncpy(trayDashboardState_.trays[i].uid, pendingAssignUid_, sizeof(trayDashboardState_.trays[i].uid) - 1);
+            trayDashboardState_.trays[i].uid[sizeof(trayDashboardState_.trays[i].uid) - 1] = '\0';
+            trayDashboardState_.trays[i].spoolman_id = pendingAssignSpoolmanId_;
+
+            Serial.printf("ApplicationManager: Tray %d assigned UID=%s spoolman_id=%d\n",
+                          idx, pendingAssignUid_, pendingAssignSpoolmanId_);
+
+#ifndef NATIVE_TEST
+            Preferences prefs;
+            prefs.begin("spoolsense", false);
+            prefs.putBytes("tray_dash", &trayDashboardState_, sizeof(TrayDashboardState));
+            prefs.end();
+
+            if (strlen(pendingAssignUid_) > 0 && SpoolmanManager::getInstance().isConfigured()) {
+                SpoolmanSyncRequest req = {};
+                strncpy(req.spool_id, pendingAssignUid_, sizeof(req.spool_id) - 1);
+                req.lookup_only = true;
+                SpoolmanManager::getInstance().enqueueSync(req);
+            }
+#endif
+            return;
+        }
+    }
+
+    Serial.printf("ApplicationManager: tray_assign — index %d not in current dashboard, caching\n", idx);
 }
 
 bool ApplicationManager::sendAssignSpool(const char* toolNumber) {

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -969,6 +969,33 @@ void ApplicationManager::handleSpoolmanSynced(const AppMessage& msg) {
             }
         }
     }
+
+    // Update dashboard tray weight if this UID matches a tray
+    if (msg.payload.spoolmanSynced.success && msg.payload.spoolmanSynced.is_uid_lookup) {
+        for (uint8_t i = 0; i < trayDashboardState_.tray_count; i++) {
+            if (strlen(trayDashboardState_.trays[i].uid) > 0 &&
+                strcasecmp(trayDashboardState_.trays[i].uid, msg.payload.spoolmanSynced.spool_id) == 0) {
+                uint16_t weightG = static_cast<uint16_t>(msg.payload.spoolmanSynced.kg_remaining * 1000.0f);
+                if (weightG != trayDashboardState_.trays[i].weight_g) {
+                    trayDashboardState_.trays[i].weight_g = weightG;
+                    Serial.printf("ApplicationManager: Dashboard tray %d weight updated to %dg\n",
+                                  trayDashboardState_.trays[i].tray_index, weightG);
+#ifndef NATIVE_TEST
+                    Preferences prefs;
+                    prefs.begin("spoolsense", false);
+                    prefs.putBytes("tray_dash", &trayDashboardState_, sizeof(TrayDashboardState));
+                    prefs.end();
+
+                    bool dashEnabled = ConfigurationManager::getInstance().isBambuDashboardEnabled();
+                    if (dashEnabled && display_) {
+                        display_->showTrayDashboard(trayDashboardState_);
+                    }
+#endif
+                }
+                break;
+            }
+        }
+    }
 #endif
 }
 

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -1358,7 +1358,7 @@ void ApplicationManager::handleTrayAssign() {
         }
     }
 
-    Serial.printf("ApplicationManager: tray_assign — index %d not in current dashboard, caching\n", idx);
+    Serial.printf("ApplicationManager: tray_assign — index %d not in current dashboard, assignment ignored\n", idx);
 }
 
 bool ApplicationManager::sendAssignSpool(const char* toolNumber) {

--- a/src/ApplicationManager.h
+++ b/src/ApplicationManager.h
@@ -32,6 +32,7 @@ enum class AppMessageType {
     KEYPAD_CONFIRM,
     KEYPAD_CANCEL,
     TRAY_UPDATE,
+    TRAY_ASSIGN,
 };
 
 enum class AutomationMode : uint8_t {
@@ -184,6 +185,11 @@ public:
     SmartTagEnrichment getSmartTagEnrichment() const { return smartTagEnrichment_; }
     void updateTrayDashboard(const TrayDashboardState& state);
     const TrayDashboardState& getTrayDashboardState() const;
+
+    // Tray assign staging (written by HomeAssistantManager, consumed by handleTrayAssign)
+    uint8_t pendingAssignTrayIndex_ = 0;
+    char pendingAssignUid_[17] = {0};
+    int32_t pendingAssignSpoolmanId_ = -1;
 #ifdef NATIVE_TEST
     void resetForTest() {
         if (messageQueue) { vQueueDelete(messageQueue); messageQueue = nullptr; }
@@ -272,6 +278,7 @@ private:
     void handleKeypadConfirm();
     void handleKeypadCancel();
     void handleTrayUpdate();
+    void handleTrayAssign();
     bool sendAssignSpool(const char* toolNumber);
     void finishPrint(float gramsUsed, bool canceled);
     void enqueueSpoolmanSync(const SpoolDetectedPayload& spool);

--- a/src/ApplicationManager.h
+++ b/src/ApplicationManager.h
@@ -186,6 +186,9 @@ public:
     void updateTrayDashboard(const TrayDashboardState& state);
     const TrayDashboardState& getTrayDashboardState() const;
 
+    // Tray dashboard state (written by HomeAssistantManager commands, read by display)
+    TrayDashboardState trayDashboardState_ = {};
+
     // Tray assign staging (written by HomeAssistantManager, consumed by handleTrayAssign)
     uint8_t pendingAssignTrayIndex_ = 0;
     char pendingAssignUid_[17] = {0};
@@ -257,8 +260,6 @@ private:
     // Enrichment data from Spoolman UID lookup for the current smart tag
     SmartTagEnrichment smartTagEnrichment_;
 
-    // Bambu AMS tray dashboard state
-    TrayDashboardState trayDashboardState_ = {};
     uint32_t dashboardRevertAt_ = 0;
     static constexpr uint32_t DASHBOARD_REVERT_DELAY_MS = 5000;
 

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -937,6 +937,32 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
         return;
     }
 
+    // tray_assign: loading blueprint assigns a scanned UID to a specific AMS tray
+    if (strcmp(command, "tray_assign") == 0) {
+        StaticJsonDocument<128> assignDoc;
+        if (deserializeJson(assignDoc, payload)) {
+            publishCommandResponse(command, false, "invalid_json");
+            return;
+        }
+
+        uint8_t trayIndex = assignDoc["tray_index"] | 0;
+        const char* uid = assignDoc["uid"] | "";
+        int32_t spoolmanId = assignDoc["spoolman_id"] | -1;
+
+        ApplicationManager& app = ApplicationManager::getInstance();
+        app.pendingAssignTrayIndex_ = trayIndex;
+        strncpy(app.pendingAssignUid_, uid, sizeof(app.pendingAssignUid_) - 1);
+        app.pendingAssignUid_[sizeof(app.pendingAssignUid_) - 1] = '\0';
+        app.pendingAssignSpoolmanId_ = spoolmanId;
+
+        AppMessage msg = {};
+        msg.type = AppMessageType::TRAY_ASSIGN;
+        app.sendMessage(msg);
+
+        publishCommandResponse(command, true, nullptr);
+        return;
+    }
+
     // Parse command payload (JSON with optional uid, filament_type, color, etc.)
     ParsedHACommandPayload cmdPayload;
     if (!parseHACommandPayload(payload, cmdPayload)) {

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -963,6 +963,70 @@ void HomeAssistantManager::handleCommand(const char* topic, const char* payload)
         return;
     }
 
+    // deduct_tray: deduction blueprint sends tray_index + grams after print finishes
+    if (strcmp(command, "deduct_tray") == 0) {
+        StaticJsonDocument<128> deductDoc;
+        if (deserializeJson(deductDoc, payload)) {
+            publishCommandResponse(command, false, "invalid_json");
+            return;
+        }
+
+        uint8_t trayIndex = deductDoc["tray_index"] | 0;
+        float deductG = deductDoc["deduct_g"] | 0.0f;
+        if (deductG <= 0.0f) {
+            publishCommandResponse(command, false, "invalid_deduct_g");
+            return;
+        }
+
+        // Resolve tray_index → UID from dashboard state
+        const TrayDashboardState& dash = ApplicationManager::getInstance().getTrayDashboardState();
+        const char* resolvedUid = nullptr;
+        for (uint8_t i = 0; i < dash.tray_count; i++) {
+            if (dash.trays[i].tray_index == trayIndex && strlen(dash.trays[i].uid) > 0) {
+                resolvedUid = dash.trays[i].uid;
+                break;
+            }
+        }
+
+        if (resolvedUid == nullptr) {
+            Serial.printf("HomeAssistantManager: deduct_tray — no UID for tray %d\n", trayIndex);
+            publishCommandResponse(command, false, "no_uid_for_tray");
+            return;
+        }
+
+        Serial.printf("HomeAssistantManager: deduct_tray — tray %d → UID %s, %.1fg\n",
+                      trayIndex, resolvedUid, deductG);
+
+        DeductionManager::getInstance().storePending(resolvedUid, deductG);
+
+        // Try Spoolman direct deduction (spool not on scanner)
+        if (SpoolmanManager::getInstance().isConfigured()) {
+            float spDeducted = SpoolmanManager::getInstance().deductFromSpoolman(resolvedUid, deductG);
+            if (spDeducted > 0.0f) {
+                DeductionManager::getInstance().clearPending(resolvedUid);
+            }
+        }
+
+        // Update dashboard tray weight
+        ApplicationManager& app = ApplicationManager::getInstance();
+        for (uint8_t i = 0; i < app.getTrayDashboardState().tray_count; i++) {
+            if (app.trayDashboardState_.trays[i].tray_index == trayIndex) {
+                uint16_t currentWeight = app.trayDashboardState_.trays[i].weight_g;
+                uint16_t deductWeight = static_cast<uint16_t>(deductG);
+                app.trayDashboardState_.trays[i].weight_g =
+                    (currentWeight > deductWeight) ? (currentWeight - deductWeight) : 0;
+                // Trigger dashboard re-render
+                AppMessage dashMsg = {};
+                dashMsg.type = AppMessageType::TRAY_UPDATE;
+                app.sendMessage(dashMsg);
+                break;
+            }
+        }
+
+        publishCommandResponse(command, true, nullptr);
+        return;
+    }
+
     // Parse command payload (JSON with optional uid, filament_type, color, etc.)
     ParsedHACommandPayload cmdPayload;
     if (!parseHACommandPayload(payload, cmdPayload)) {

--- a/src/TrayDashboardTypes.h
+++ b/src/TrayDashboardTypes.h
@@ -10,6 +10,8 @@ struct TrayData {
     uint8_t color[3];      // RGB
     uint16_t weight_g;     // remaining weight in grams
     bool populated;        // true if tray has a spool
+    char uid[17];          // SpoolSense NFC tag UID hex (up to 16 chars + null)
+    int32_t spoolman_id;   // Spoolman spool ID (-1 if unknown)
 };
 
 struct TrayDashboardState {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -367,7 +367,17 @@ void setup() {
   }
 
   if (config.isTftEnabled()) {
-    if (tftManagerPtr && !config.isBambuDashboardEnabled()) tftManagerPtr->showReady();
+    if (tftManagerPtr && !config.isBambuDashboardEnabled()) {
+      tftManagerPtr->showReady();
+    } else if (tftManagerPtr && config.isBambuDashboardEnabled()) {
+      // Show cached dashboard or AMS Ready after full boot (TFT task is running)
+      const TrayDashboardState& cached = ApplicationManager::getInstance().getTrayDashboardState();
+      if (cached.has_data) {
+        tftManagerPtr->showTrayDashboard(cached);
+      } else {
+        tftManagerPtr->showText("SpoolSense", "AMS Ready");
+      }
+    }
   } else if (config.isLcdEnabled()) {
     ApplicationManager::getInstance().showStatusScreen();
   }


### PR DESCRIPTION
## Summary

- Adds HA blueprint `spoolsense_bambu_dashboard.yaml` — watches Bambu AMS tray entities, publishes `cmd/tray_update` to scanner via MQTT
- Updates loading blueprint `spoolsense_bambu_ams.yaml` — replaces broken `input_text` helper writes with `cmd/tray_assign` MQTT publish (no HA helpers needed)
- Adds `cmd/tray_assign` firmware handler — stores UID-to-tray mapping in NVS, triggers Spoolman weight lookup
- Wires Spoolman sync response to dashboard tray weight — weight auto-populates after tray assignment
- Fixes cold boot dashboard display — moves cache render to post-boot sequence
- Updates flow diagram for website

## Architecture

- Scanner is single source of truth for UID-to-tray mapping (no HA helpers)
- Two blueprints: loading (scan→load→assign) + dashboard (tray change→MQTT update)
- Deduction via `cmd/deduct_tray` is a planned follow-up (pending print_weight attribute verification — confirmed format: `"AMS 1 Tray 3": 11.01`)

## New Files

| File | Purpose |
|------|---------|
| `homeassistant/blueprints/spoolsense_bambu_dashboard.yaml` | HA blueprint: tray state → MQTT |
| `docs/bambu-dashboard-flow.html` | Visual data flow diagram |

## Test plan

- [x] Dashboard blueprint triggers on tray state change — verified on live HA
- [x] Loading blueprint sends cmd/tray_assign — verified scan→load flow
- [x] Dashboard renders correct trays from blueprint data
- [x] NVS cache survives cold boot (with RST pin wired)
- [x] Scan interruption → 5s revert to dashboard
- [x] Compile: esp32dev, esp32s3zero, esp32s3devkitc
- [ ] Spoolman weight lookup after tray_assign (needs tagged spool in AMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Bambu AMS Dashboard data flow page illustrating spool scan, dashboard update, and weight enrichment phases.

* **New Features**
  * New Home Assistant blueprint: SpoolSense → Bambu AMS Dashboard (ordered tray list → MQTT tray_update).
  * Tray assignment workflow via MQTT (tray_assign) and tray deduction command (deduct_tray) supported.
  * Dashboard display now initializes and falls back to a tray-dashboard or ready screen as appropriate.

* **Refactor**
  * Blueprints updated to accept a configurable scanner device ID and publish tray-indexed MQTT payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->