### PR TITLE
fix: link existing Spoolman spool when writing tag from picker (#130)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env]
-platform = espressif32
+platform = espressif32@6.10.0
 framework = arduino
 build_type = release
 board_build.partitions = partitions.csv

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -371,6 +371,7 @@ function prefillFromTag(fieldMap) {
 
 var _spoolmanPickerSpools = [];
 var _spoolmanPickerFieldMap = {};
+var _selectedSpoolId = -1;
 
 function renderSpoolmanPicker(containerId, fieldMap) {
   var container = document.getElementById(containerId);
@@ -434,6 +435,7 @@ function filterSpoolmanPicker(spools, query, fieldMap) {
 }
 
 function selectSpoolmanSpool(spoolId) {
+  _selectedSpoolId = spoolId;
   var spool = _spoolmanPickerSpools.find(function(s) { return s.id === spoolId; });
   if (spool) fillFromSpoolman(spool, _spoolmanPickerFieldMap);
 }
@@ -555,6 +557,17 @@ async function sharedWriteFlow(config) {
   statusView.classList.remove('hidden');
   backBtn.classList.add('hidden');
   anotherBtn.classList.add('hidden');
+
+  if (_selectedSpoolId > 0) {
+    try {
+      await api('/api/spoolman/pending-link', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({spool_id: _selectedSpoolId})
+      });
+    } catch(e) {}
+    _selectedSpoolId = -1;
+  }
 
   try {
     var presentStatus = await waitForTag(8000);

--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -1249,6 +1249,12 @@ bool SpoolmanManager::lookupSpoolByUid(const char* uid, SpoolDetails& outDetails
     return ok;
 }
 
+void SpoolmanManager::setPendingLink(int32_t spoolId) {
+    pendingLinkSpoolId_.store(spoolId);
+    pendingLinkSetAt_.store(millis());
+    Serial.printf("SpoolmanManager: Pending link set for spool %d\n", spoolId);
+}
+
 float SpoolmanManager::deductFromSpoolman(const char* uid, float grams) {
     if (!isConfigured()) return 0.0f;
     if (xSemaphoreTake(httpMutex_, HTTP_MUTEX_TIMEOUT) != pdTRUE) {
@@ -1321,6 +1327,29 @@ bool SpoolmanManager::syncSpool(const SpoolmanSyncRequest& req, int& resolvedSpo
 
     resolvedSpoolmanId = -1;
     bool success = false;
+
+    // If the writer pre-registered a spool to link, consume it and patch nfc_id before syncing.
+    // This prevents auto-sync from creating a duplicate when a pre-selected spool exists.
+    int32_t linkSpoolId = pendingLinkSpoolId_.exchange(-1);
+    if (linkSpoolId > 0) {
+        uint32_t age = millis() - pendingLinkSetAt_.load();
+        if (age < PENDING_LINK_TIMEOUT_MS) {
+            char patchBody[64];
+            snprintf(patchBody, sizeof(patchBody), "{\"extra\":{\"nfc_id\":\"\\\"%s\\\"\"}}", req.spool_id);
+            char patchPath[48];
+            snprintf(patchPath, sizeof(patchPath), "/api/v1/spool/%d", linkSpoolId);
+            String patchResp;
+            int patchCode = httpPatch(patchPath, patchBody, patchResp);
+            if (patchCode == 200) {
+                storeCachedSpoolmanId(req.spool_id, linkSpoolId);
+                Serial.printf("SpoolmanManager: Linked nfc_id=%s to spool %d via pending link\n", req.spool_id, linkSpoolId);
+            } else {
+                Serial.printf("SpoolmanManager: Pending link PATCH failed (HTTP %d) for spool %d\n", patchCode, linkSpoolId);
+            }
+        } else {
+            Serial.printf("SpoolmanManager: Pending link for spool %d expired (%ums old), discarding\n", linkSpoolId, age);
+        }
+    }
 
     // Prefer a known-good ID for this spool UID over potentially stale tag data.
     int32_t preferredSpoolmanId = req.spoolman_id;

--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -1250,8 +1250,10 @@ bool SpoolmanManager::lookupSpoolByUid(const char* uid, SpoolDetails& outDetails
 }
 
 void SpoolmanManager::setPendingLink(int32_t spoolId) {
-    pendingLinkSpoolId_.store(spoolId);
+    // Store timestamp before ID so that any reader seeing a valid ID is
+    // guaranteed the timestamp is already set (happens-before).
     pendingLinkSetAt_.store(millis());
+    pendingLinkSpoolId_.store(spoolId);
     Serial.printf("SpoolmanManager: Pending link set for spool %d\n", spoolId);
 }
 
@@ -1330,9 +1332,12 @@ bool SpoolmanManager::syncSpool(const SpoolmanSyncRequest& req, int& resolvedSpo
 
     // If the writer pre-registered a spool to link, consume it and patch nfc_id before syncing.
     // This prevents auto-sync from creating a duplicate when a pre-selected spool exists.
+    // Read timestamp before exchange: setPendingLink stores time before ID, so a valid ID
+    // guarantees the timestamp is already set (no race window on the age check).
+    uint32_t linkSetAt = pendingLinkSetAt_.load();
     int32_t linkSpoolId = pendingLinkSpoolId_.exchange(-1);
     if (linkSpoolId > 0) {
-        uint32_t age = millis() - pendingLinkSetAt_.load();
+        uint32_t age = millis() - linkSetAt;
         if (age < PENDING_LINK_TIMEOUT_MS) {
             char patchBody[64];
             snprintf(patchBody, sizeof(patchBody), "{\"extra\":{\"nfc_id\":\"\\\"%s\\\"\"}}", req.spool_id);

--- a/src/SpoolmanManager.h
+++ b/src/SpoolmanManager.h
@@ -1,6 +1,7 @@
 #ifndef SPOOLMAN_MANAGER_H
 #define SPOOLMAN_MANAGER_H
 
+#include <atomic>
 #include <cstdint>
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
@@ -53,6 +54,9 @@ public:
     bool isConfigured() const;
     bool getSpoolDetails(int32_t spoolmanId, SpoolDetails& outDetails);
     void invalidateCachedSpoolmanId(const char* spoolId);
+    // Pre-emptively link the next detected tag to an existing spool instead of auto-creating.
+    // Set before write flow starts; consumed on first tag sync within PENDING_LINK_TIMEOUT_MS.
+    void setPendingLink(int32_t spoolId);
 
     // Deduct weight directly in Spoolman for non-writable tags.
     // Returns grams deducted, or 0 on failure (caller should retry later).
@@ -99,6 +103,10 @@ private:
     static constexpr UBaseType_t TASK_PRIORITY = 1;
     static constexpr TickType_t HTTP_MUTEX_TIMEOUT = pdMS_TO_TICKS(10000);
     static constexpr uint32_t SYNC_CACHE_TTL_MS = 2 * 60 * 60 * 1000;  // 2 hours
+    static constexpr uint32_t PENDING_LINK_TIMEOUT_MS = 120000;         // 2 minutes
+
+    std::atomic<int32_t> pendingLinkSpoolId_{-1};
+    std::atomic<uint32_t> pendingLinkSetAt_{0};
 };
 
 #endif // SPOOLMAN_MANAGER_H

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -135,7 +135,8 @@ bool WebServerManager::begin(bool apMode, uint16_t port) {
     _server.on("/api/write-openspool", HTTP_POST, [this]() { handleApiWriteOpenSpool(); });
     _server.on("/api/register-uid",    HTTP_POST, [this]() { handleApiRegisterUid(); });
     _server.on("/api/spoolman/spools", HTTP_GET,  [this]() { handleApiSpoolmanSpools(); });
-    _server.on("/api/spoolman/link",   HTTP_POST, [this]() { handleApiSpoolmanLink(); });
+    _server.on("/api/spoolman/link",         HTTP_POST, [this]() { handleApiSpoolmanLink(); });
+    _server.on("/api/spoolman/pending-link", HTTP_POST, [this]() { handleApiSpoolmanPendingLink(); });
     _server.on("/api/spoolman/find-vendor",     HTTP_GET,  [this]() { handleApiSpoolmanFindVendor(); });
     _server.on("/api/spoolman/find-filament",   HTTP_GET,  [this]() { handleApiSpoolmanFindFilament(); });
     _server.on("/api/spoolman/save-enrichment", HTTP_POST, [this]() { handleApiSpoolmanSaveEnrichment(); });
@@ -611,6 +612,26 @@ void WebServerManager::handleApiSpoolmanLink() {
     }
 
     xSemaphoreGive(g_httpMutex);
+    _server.send(200, "application/json", "{\"success\":true}");
+}
+
+void WebServerManager::handleApiSpoolmanPendingLink() {
+    _server.sendHeader("Access-Control-Allow-Origin", "*");
+
+    StaticJsonDocument<128> doc;
+    if (deserializeJson(doc, _server.arg("plain"))) {
+        sendError(400, "Invalid JSON");
+        return;
+    }
+
+    int spoolId = doc["spool_id"] | -1;
+    if (spoolId <= 0) {
+        sendError(400, "spool_id required");
+        return;
+    }
+
+    SpoolmanManager::getInstance().setPendingLink(spoolId);
+    Serial.printf("WebServerManager: Pending link set for spool %d\n", spoolId);
     _server.send(200, "application/json", "{\"success\":true}");
 }
 

--- a/src/WebServerManager.h
+++ b/src/WebServerManager.h
@@ -69,6 +69,7 @@ private:
     void handleApiRegisterUid();
     void handleApiSpoolmanSpools();
     void handleApiSpoolmanLink();
+    void handleApiSpoolmanPendingLink();
     void handleApiSpoolmanFindVendor();
     void handleApiSpoolmanFindFilament();
     void handleApiSpoolmanSaveEnrichment();


### PR DESCRIPTION
## Summary

- When a spool is selected from the **Import from Spoolman** picker on a writer page and **Write Tag** is clicked, the JS now calls `POST /api/spoolman/pending-link` with the selected spool ID before waiting for a tag
- The firmware stores this as a pending link; on the next tag detection, `syncSpool()` patches `nfc_id` on the existing spool instead of auto-creating a duplicate
- Pending link expires after 2 minutes if no tag is placed

## Changes

- `SpoolmanManager`: `setPendingLink(int32_t)`, atomic `pendingLinkSpoolId_` + `pendingLinkSetAt_`, intercept block in `syncSpool()`
- `WebServerManager`: `POST /api/spoolman/pending-link` endpoint
- `SharedJS`: track `_selectedSpoolId` in picker, call pending-link at write start for all four writer pages

## Test plan

- [ ] Select an existing Spoolman spool from picker on OpenTag3D writer, click Write, place a tag — confirm spool gets `nfc_id` set, no duplicate created
- [ ] Write a fresh tag without selecting from picker — confirm spool is still auto-created as before
- [ ] Same on OpenPrintTag, TigerTag, OpenSpool writers
- [ ] Let pending link expire (>2min) without placing tag — confirm next write doesn't incorrectly link

Closes #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pending spool linking capability, allowing users to pre-select a spool before tag detection, which automatically links the next detected tag to the selected spool instead of creating a new one.
  * Introduced timeout mechanism for pending spool selections to prevent stale associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->