### PR TITLE
fix: Firefox stale-cache ReferenceError on writer pages (#151)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env]
-platform = espressif32
+platform = espressif32@6.10.0
 framework = arduino
 build_type = release
 board_build.partitions = partitions.csv

--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -10,7 +10,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Configuration &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+  <link rel="stylesheet" href="/css/shared.css?v=)rawliteral" FIRMWARE_VERSION R"rawliteral(" />
   <style>
     .toggle-row{
       display:flex;align-items:center;justify-content:space-between;
@@ -250,7 +250,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">Settings are saved to NVS and persist across OTA updates.</div>
   </div>
 
-  <script src="/js/shared.js?v=1.7.0"></script>
+  <script src="/js/shared.js?v=)rawliteral" FIRMWARE_VERSION R"rawliteral("></script>
   <script>
     function togglePass(id, btn) {
       var el = document.getElementById(id);

--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -10,7 +10,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Configuration &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
   <style>
     .toggle-row{
       display:flex;align-items:center;justify-content:space-between;
@@ -250,7 +250,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">Settings are saved to NVS and persist across OTA updates.</div>
   </div>
 
-  <script src="/js/shared.js"></script>
+  <script src="/js/shared.js?v=1.7.0"></script>
   <script>
     function togglePass(id, btn) {
       var el = document.getElementById(id);

--- a/src/LandingHTML.h
+++ b/src/LandingHTML.h
@@ -10,7 +10,7 @@ const char LANDING_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>SpoolSense Scanner</title>
-  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
 </head>
 <body>
   <div class="wrap">
@@ -126,7 +126,7 @@ const char LANDING_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note" id="footerHostname" style="margin-top:28px">SpoolSense Scanner &mdash; spoolsense.local</div>
   </div>
 
-  <script src="/js/shared.js"></script>
+  <script src="/js/shared.js?v=1.7.0"></script>
   <script>
     fetch('/api/status').then(function(r){return r.json()}).then(function(d){
       if(d.device_id) document.getElementById('deviceId').textContent = d.device_id;

--- a/src/LandingHTML.h
+++ b/src/LandingHTML.h
@@ -10,7 +10,7 @@ const char LANDING_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>SpoolSense Scanner</title>
-  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+  <link rel="stylesheet" href="/css/shared.css?v=)rawliteral" FIRMWARE_VERSION R"rawliteral(" />
 </head>
 <body>
   <div class="wrap">
@@ -126,7 +126,7 @@ const char LANDING_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note" id="footerHostname" style="margin-top:28px">SpoolSense Scanner &mdash; spoolsense.local</div>
   </div>
 
-  <script src="/js/shared.js?v=1.7.0"></script>
+  <script src="/js/shared.js?v=)rawliteral" FIRMWARE_VERSION R"rawliteral("></script>
   <script>
     fetch('/api/status').then(function(r){return r.json()}).then(function(d){
       if(d.device_id) document.getElementById('deviceId').textContent = d.device_id;

--- a/src/LogViewerHTML.h
+++ b/src/LogViewerHTML.h
@@ -10,7 +10,7 @@ const char LOG_VIEWER_HTML[] PROGMEM = R"=====(
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Serial Log &mdash; SpoolSense</title>
-    <link rel="stylesheet" href="/css/shared.css" />
+    <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
     <style>
         .subtitle {
             color: var(--muted);

--- a/src/LogViewerHTML.h
+++ b/src/LogViewerHTML.h
@@ -10,7 +10,7 @@ const char LOG_VIEWER_HTML[] PROGMEM = R"=====(
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Serial Log &mdash; SpoolSense</title>
-    <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+    <link rel="stylesheet" href="/css/shared.css?v=)=====" FIRMWARE_VERSION R"=====(" />
     <style>
         .subtitle {
             color: var(--muted);

--- a/src/OpenPrintTagWriterHTML.h
+++ b/src/OpenPrintTagWriterHTML.h
@@ -14,7 +14,7 @@ const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>OpenPrintTag Writer &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
 </head>
 <body>
   <div class="wrap">
@@ -273,7 +273,7 @@ const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">OpenPrintTag format &mdash; ISO15693</div>
   </div>
 
-  <script src="/js/shared.js"></script>
+  <script src="/js/shared.js?v=1.7.0"></script>
   <script>
     var writerForm = document.getElementById('writerForm');
 

--- a/src/OpenPrintTagWriterHTML.h
+++ b/src/OpenPrintTagWriterHTML.h
@@ -14,7 +14,7 @@ const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>OpenPrintTag Writer &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+  <link rel="stylesheet" href="/css/shared.css?v=)rawliteral" FIRMWARE_VERSION R"rawliteral(" />
 </head>
 <body>
   <div class="wrap">
@@ -273,7 +273,7 @@ const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">OpenPrintTag format &mdash; ISO15693</div>
   </div>
 
-  <script src="/js/shared.js?v=1.7.0"></script>
+  <script src="/js/shared.js?v=)rawliteral" FIRMWARE_VERSION R"rawliteral("></script>
   <script>
     var writerForm = document.getElementById('writerForm');
 

--- a/src/OpenSpoolWriterHTML.h
+++ b/src/OpenSpoolWriterHTML.h
@@ -10,7 +10,7 @@ const char OPENSPOOL_WRITER_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>OpenSpool Writer &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
 </head>
 <body>
   <div class="wrap">
@@ -193,7 +193,7 @@ const char OPENSPOOL_WRITER_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">OpenSpool V1.0 &mdash; NDEF JSON on NTAG215/216</div>
   </div>
 
-  <script src="/js/shared.js"></script>
+  <script src="/js/shared.js?v=1.7.0"></script>
   <script>
     var writerForm = document.getElementById('writerForm');
 

--- a/src/OpenSpoolWriterHTML.h
+++ b/src/OpenSpoolWriterHTML.h
@@ -10,7 +10,7 @@ const char OPENSPOOL_WRITER_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>OpenSpool Writer &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+  <link rel="stylesheet" href="/css/shared.css?v=)rawliteral" FIRMWARE_VERSION R"rawliteral(" />
 </head>
 <body>
   <div class="wrap">
@@ -193,7 +193,7 @@ const char OPENSPOOL_WRITER_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">OpenSpool V1.0 &mdash; NDEF JSON on NTAG215/216</div>
   </div>
 
-  <script src="/js/shared.js?v=1.7.0"></script>
+  <script src="/js/shared.js?v=)rawliteral" FIRMWARE_VERSION R"rawliteral("></script>
   <script>
     var writerForm = document.getElementById('writerForm');
 

--- a/src/OpenTag3DWriterHTML.h
+++ b/src/OpenTag3DWriterHTML.h
@@ -10,7 +10,7 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>OpenTag3D Writer &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
 </head>
 <body>
   <div class="wrap">
@@ -322,7 +322,7 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">OpenTag3D v1.000 &mdash; NTAG215/216</div>
   </div>
 
-  <script src="/js/shared.js"></script>
+  <script src="/js/shared.js?v=1.7.0"></script>
   <script>
     var writerForm = document.getElementById('writerForm');
 

--- a/src/OpenTag3DWriterHTML.h
+++ b/src/OpenTag3DWriterHTML.h
@@ -10,7 +10,7 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>OpenTag3D Writer &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+  <link rel="stylesheet" href="/css/shared.css?v=)rawliteral" FIRMWARE_VERSION R"rawliteral(" />
 </head>
 <body>
   <div class="wrap">
@@ -322,7 +322,7 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">OpenTag3D v1.000 &mdash; NTAG215/216</div>
   </div>
 
-  <script src="/js/shared.js?v=1.7.0"></script>
+  <script src="/js/shared.js?v=)rawliteral" FIRMWARE_VERSION R"rawliteral("></script>
   <script>
     var writerForm = document.getElementById('writerForm');
 

--- a/src/ReaderHTML.h
+++ b/src/ReaderHTML.h
@@ -10,7 +10,7 @@ const char READER_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Tag Reader &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
 </head>
 <body>
   <div class="wrap">
@@ -63,7 +63,7 @@ const char READER_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">Stops polling once a tag is detected.</div>
   </div>
 
-  <script src="/js/shared.js"></script>
+  <script src="/js/shared.js?v=1.7.0"></script>
   <script>
     var noTag = document.getElementById('noTag');
     var tagView = document.getElementById('tagView');

--- a/src/ReaderHTML.h
+++ b/src/ReaderHTML.h
@@ -10,7 +10,7 @@ const char READER_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Tag Reader &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+  <link rel="stylesheet" href="/css/shared.css?v=)rawliteral" FIRMWARE_VERSION R"rawliteral(" />
 </head>
 <body>
   <div class="wrap">
@@ -63,7 +63,7 @@ const char READER_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">Stops polling once a tag is detected.</div>
   </div>
 
-  <script src="/js/shared.js?v=1.7.0"></script>
+  <script src="/js/shared.js?v=)rawliteral" FIRMWARE_VERSION R"rawliteral("></script>
   <script>
     var noTag = document.getElementById('noTag');
     var tagView = document.getElementById('tagView');

--- a/src/TigerTagWriterHTML.h
+++ b/src/TigerTagWriterHTML.h
@@ -10,7 +10,7 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>TigerTag Writer &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+  <link rel="stylesheet" href="/css/shared.css?v=)rawliteral" FIRMWARE_VERSION R"rawliteral(" />
 </head>
 <body>
   <div class="wrap">
@@ -331,7 +331,7 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">TigerTag V1.0 Maker format &mdash; 40 bytes, pages 4-13</div>
   </div>
 
-  <script src="/js/shared.js?v=1.7.0"></script>
+  <script src="/js/shared.js?v=)rawliteral" FIRMWARE_VERSION R"rawliteral("></script>
   <script>
     var writerForm = document.getElementById('writerForm');
 

--- a/src/TigerTagWriterHTML.h
+++ b/src/TigerTagWriterHTML.h
@@ -10,7 +10,7 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>TigerTag Writer &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
 </head>
 <body>
   <div class="wrap">
@@ -331,7 +331,7 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">TigerTag V1.0 Maker format &mdash; 40 bytes, pages 4-13</div>
   </div>
 
-  <script src="/js/shared.js"></script>
+  <script src="/js/shared.js?v=1.7.0"></script>
   <script>
     var writerForm = document.getElementById('writerForm');
 

--- a/src/TroubleshootingHTML.h
+++ b/src/TroubleshootingHTML.h
@@ -10,7 +10,7 @@ const char TROUBLESHOOTING_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Troubleshooting &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
   <style>
     .device-id-box {
       background: rgba(99,102,241,.12);

--- a/src/TroubleshootingHTML.h
+++ b/src/TroubleshootingHTML.h
@@ -10,7 +10,7 @@ const char TROUBLESHOOTING_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Troubleshooting &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+  <link rel="stylesheet" href="/css/shared.css?v=)rawliteral" FIRMWARE_VERSION R"rawliteral(" />
   <style>
     .device-id-box {
       background: rgba(99,102,241,.12);

--- a/src/UIDRegistrationHTML.h
+++ b/src/UIDRegistrationHTML.h
@@ -13,7 +13,7 @@ const char UID_REGISTRATION_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>UID Registration &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
 </head>
 <body>
   <div class="wrap">
@@ -187,7 +187,7 @@ const char UID_REGISTRATION_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">UID Registration &mdash; Spoolman spool via NFC tag UID</div>
   </div>
 
-  <script src="/js/shared.js"></script>
+  <script src="/js/shared.js?v=1.7.0"></script>
   <script>
     var registerForm = document.getElementById('registerForm');
     var uidValue = document.getElementById('uidValue');

--- a/src/UIDRegistrationHTML.h
+++ b/src/UIDRegistrationHTML.h
@@ -13,7 +13,7 @@ const char UID_REGISTRATION_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>UID Registration &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+  <link rel="stylesheet" href="/css/shared.css?v=)rawliteral" FIRMWARE_VERSION R"rawliteral(" />
 </head>
 <body>
   <div class="wrap">
@@ -187,7 +187,7 @@ const char UID_REGISTRATION_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">UID Registration &mdash; Spoolman spool via NFC tag UID</div>
   </div>
 
-  <script src="/js/shared.js?v=1.7.0"></script>
+  <script src="/js/shared.js?v=)rawliteral" FIRMWARE_VERSION R"rawliteral("></script>
   <script>
     var registerForm = document.getElementById('registerForm');
     var uidValue = document.getElementById('uidValue');

--- a/src/UpdateHTML.h
+++ b/src/UpdateHTML.h
@@ -10,7 +10,7 @@ const char UPDATE_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Firmware Update &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css" />
+  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
   <style>
     .progress-wrap{margin:16px 0}
     .progress-bar{
@@ -157,7 +157,7 @@ const char UPDATE_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">OTA updates write to the active partition. Keep USB cable handy as a fallback.</div>
   </div>
 
-  <script src="/js/shared.js"></script>
+  <script src="/js/shared.js?v=1.7.0"></script>
   <script>
     var currentVersion = '';
     var boardType = '';

--- a/src/UpdateHTML.h
+++ b/src/UpdateHTML.h
@@ -10,7 +10,7 @@ const char UPDATE_HTML[] PROGMEM = R"rawliteral(
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Firmware Update &mdash; SpoolSense</title>
-  <link rel="stylesheet" href="/css/shared.css?v=1.7.0" />
+  <link rel="stylesheet" href="/css/shared.css?v=)rawliteral" FIRMWARE_VERSION R"rawliteral(" />
   <style>
     .progress-wrap{margin:16px 0}
     .progress-bar{
@@ -157,7 +157,7 @@ const char UPDATE_HTML[] PROGMEM = R"rawliteral(
     <div class="footer-note">OTA updates write to the active partition. Keep USB cable handy as a fallback.</div>
   </div>
 
-  <script src="/js/shared.js?v=1.7.0"></script>
+  <script src="/js/shared.js?v=)rawliteral" FIRMWARE_VERSION R"rawliteral("></script>
   <script>
     var currentVersion = '';
     var boardType = '';

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -229,13 +229,13 @@ void WebServerManager::handleOpenSpoolWriter() {
 
 void WebServerManager::handleSharedCSS() {
     _server.sendHeader("Access-Control-Allow-Origin", "*");
-    _server.sendHeader("Cache-Control", "public, max-age=86400");
+    _server.sendHeader("Cache-Control", "no-store");
     _server.send_P(200, "text/css", SHARED_CSS);
 }
 
 void WebServerManager::handleSharedJS() {
     _server.sendHeader("Access-Control-Allow-Origin", "*");
-    _server.sendHeader("Cache-Control", "public, max-age=86400");
+    _server.sendHeader("Cache-Control", "no-store");
     _server.send_P(200, "application/javascript", SHARED_JS);
 }
 


### PR DESCRIPTION
## Summary

- Firefox cached `shared.js` from a previous firmware with `max-age=86400`, causing `sharedWriteFlow is not defined` on all writer pages
- Changed `Cache-Control` for `shared.css` and `shared.js` to `no-store` — browsers never cache these files again
- Added `?v=FIRMWARE_VERSION` query string to all `shared.css` / `shared.js` references to bust existing stale caches immediately on first load
- Version is wired to the `FIRMWARE_VERSION` build flag via C string literal concatenation — auto-updates with every release, no manual step needed
- Pinned `espressif32@6.10.0` to prevent Arduino 3.x auto-upgrade breaking the build

Fixes #151

## Test plan

- [ ] Load writer page in Firefox — confirm no `sharedWriteFlow is not defined` error
- [ ] Load writer page in Chrome — confirm no regressions
- [ ] Check page source — confirm `?v=1.7.0` appears on shared.css and shared.js references
- [ ] Bump `FIRMWARE_VERSION` in platformio.ini, rebuild — confirm version string updates in compiled HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned ESP32 platform to version 6.10.0 for build consistency
  
* **Bug Fixes**
  * Updated asset caching behavior to ensure users receive fresh stylesheets and scripts when firmware updates are installed
  * Added firmware version identifiers to all static asset requests across web interface pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->