### PR TITLE
fix: writer Read enrichment polling + format detection grace period

### DIFF
--- a/src/OpenTag3DWriterHTML.h
+++ b/src/OpenTag3DWriterHTML.h
@@ -604,10 +604,10 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
           if (dEl) dEl.value = Math.round(ot.diameter_mm * 1000);
         }
         if (ot.color_name) setVal('color_name', ot.color_name);
-        if (ot.modifiers) setVal('material_modifiers', ot.modifiers);
-        if (ot.serial_number) setVal('serial_number', ot.serial_number);
-        if (ot.measured_weight_g) setVal('measured_filament_weight_g', ot.measured_weight_g);
-        if (ot.empty_spool_g) setVal('empty_spool_weight_g', ot.empty_spool_g);
+        setVal('material_modifiers', ot.modifiers || '');
+        setVal('serial_number', ot.serial_number || '');
+        setVal('measured_filament_weight_g', ot.measured_weight_g || '');
+        setVal('empty_spool_weight_g', ot.empty_spool_g || '');
         var matEl = document.getElementById('base_material');
         if (matEl) matEl.dispatchEvent(new Event('input'));
       },

--- a/src/OpenTag3DWriterHTML.h
+++ b/src/OpenTag3DWriterHTML.h
@@ -604,6 +604,10 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
           if (dEl) dEl.value = Math.round(ot.diameter_mm * 1000);
         }
         if (ot.color_name) setVal('color_name', ot.color_name);
+        if (ot.modifiers) setVal('material_modifiers', ot.modifiers);
+        if (ot.serial_number) setVal('serial_number', ot.serial_number);
+        if (ot.measured_weight_g) setVal('measured_filament_weight_g', ot.measured_weight_g);
+        if (ot.empty_spool_g) setVal('empty_spool_weight_g', ot.empty_spool_g);
         var matEl = document.getElementById('base_material');
         if (matEl) matEl.dispatchEvent(new Event('input'));
       },

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -687,18 +687,22 @@ function setupReadButton(config) {
     setReadWaiting(false);
   }
 
+  var enrichTimer = null;
   function pollForEnrichment() {
+    if (enrichTimer) clearInterval(enrichTimer);
     var attempts = 0;
-    var timer = setInterval(function() {
+    enrichTimer = setInterval(function() {
       attempts++;
       if (attempts > 8) {
-        clearInterval(timer);
+        clearInterval(enrichTimer);
+        enrichTimer = null;
         if (config.showMatchBadge) config.showMatchBadge('no Spoolman match');
         return;
       }
       fetch('/api/status').then(function(r) { return r.json(); }).then(function(s) {
         if (s.spoolman && s.spoolman.spool_id > 0) {
-          clearInterval(timer);
+          clearInterval(enrichTimer);
+          enrichTimer = null;
           if (config.fillEnrichment) config.fillEnrichment(s);
           if (config.showMatchBadge) config.showMatchBadge('Spool #' + s.spoolman.spool_id + ' matched');
         }

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -658,6 +658,7 @@ function setupReadButton(config) {
   async function startRead() {
     setReadWaiting(true);
     var deadline = Date.now() + 30000;
+    var wrongKindSeen = 0;
     while (readWaiting && Date.now() < deadline) {
       try {
         var status = await fetch('/api/status').then(function(r) { return r.json(); });
@@ -668,18 +669,41 @@ function setupReadButton(config) {
             if (status.spoolman && status.spoolman.spool_id > 0) {
               config.showMatchBadge('Spool #' + status.spoolman.spool_id + ' matched');
             } else {
-              config.showMatchBadge('no Spoolman match');
+              config.showMatchBadge('Looking up Spoolman...');
+              pollForEnrichment();
             }
           }
           break;
         } else if (status.present) {
-          if (config.showMatchBadge) config.showMatchBadge(config.wrongKindMsg);
-          break;
+          wrongKindSeen++;
+          if (wrongKindSeen >= 4) {
+            if (config.showMatchBadge) config.showMatchBadge(config.wrongKindMsg);
+            break;
+          }
         }
       } catch(e) {}
       await new Promise(function(r) { setTimeout(r, 500); });
     }
     setReadWaiting(false);
+  }
+
+  function pollForEnrichment() {
+    var attempts = 0;
+    var timer = setInterval(function() {
+      attempts++;
+      if (attempts > 8) {
+        clearInterval(timer);
+        if (config.showMatchBadge) config.showMatchBadge('no Spoolman match');
+        return;
+      }
+      fetch('/api/status').then(function(r) { return r.json(); }).then(function(s) {
+        if (s.spoolman && s.spoolman.spool_id > 0) {
+          clearInterval(timer);
+          if (config.fillEnrichment) config.fillEnrichment(s);
+          if (config.showMatchBadge) config.showMatchBadge('Spool #' + s.spoolman.spool_id + ' matched');
+        }
+      }).catch(function(){});
+    }, 1000);
   }
 
   readBtn.onclick = startRead;

--- a/src/TigerTagWriterHTML.h
+++ b/src/TigerTagWriterHTML.h
@@ -642,6 +642,19 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
         if (tt.dry_time_hours) setVal('dry_time', tt.dry_time_hours);
         if (tt.material_id !== undefined) document.getElementById('material_id').value = tt.material_id;
         if (tt.brand_id !== undefined) document.getElementById('brand_id').value = tt.brand_id;
+        if (tt.diameter_mm) {
+          var dVal = tt.diameter_mm < 2 ? '56' : '221';
+          document.getElementById('diameter_id').value = dVal;
+        }
+        function selectByText(selId, name) {
+          if (!name) return;
+          var sel = document.getElementById(selId);
+          for (var i = 0; i < sel.options.length; i++) {
+            if (sel.options[i].text === name) { sel.value = sel.options[i].value; return; }
+          }
+        }
+        selectByText('aspect1_id', tt.aspect1_name);
+        selectByText('aspect2_id', tt.aspect2_name);
         syncMaterialId();
       },
       fillEnrichment: function(status) {


### PR DESCRIPTION
## Summary
- Writer Read button now polls for Spoolman enrichment after tag detect instead of immediately showing "no Spoolman match" (#101 item 1)
- Adds `pollForEnrichment()` to `setupReadButton` in SharedJS — polls `/api/status` every 1s (up to 8 attempts) for Spoolman data
- Shows "Looking up Spoolman..." during enrichment polling
- Format detection grace period: waits 4 polls (2s) before declaring wrong format, preventing false "wrong format" when `tag_kind` hasn't resolved from `GenericUidTag` yet

Closes item 1 of #101.

## Test plan
- [x] Open any writer page (OpenTag3D, TigerTag, OpenSpool)
- [x] Click Read, place matching tag — enrichment shows "Looking up Spoolman..." then resolves to "Spool #X matched"
- [x] Place wrong-format tag — "wrong format" appears after ~2s grace period (not instant)
- [x] Tested on hardware (ESP32-S3-DevKitC)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended form auto-population with additional scanned tag data: material modifiers, serial number, and weight information
  * Asynchronous Spoolman enrichment lookup with improved status messaging ("Looking up Spoolman...")
  * Enhanced automatic form field prefill for diameter and aspect dropdowns

* **Bug Fixes**
  * Improved tolerance for repeated incorrect tag detection scenarios with refined response behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->