### PR TITLE
feat: Bambu Lab MIFARE Classic tag reading (#24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ build/
 lancedb/
 .mex/
 .ragcode/
+.DS_Store
+.superpowers/

--- a/docs/superpowers/plans/2026-04-14-bambu-mifare-classic-plan.md
+++ b/docs/superpowers/plans/2026-04-14-bambu-mifare-classic-plan.md
@@ -1,0 +1,837 @@
+# Bambu MIFARE Classic Tag Reading Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Read encrypted Bambu Lab MIFARE Classic filament tags on both PN5180 and PN532 readers, parse filament data, and publish via MQTT/web UI/Spoolman.
+
+**Architecture:** HKDF key derivation (mbedtls) produces per-tag sector keys from UID. New `mifareAuthenticate()` in PN5180ISO14443 and PN532 wrapper enables encrypted block reads. BambuTagParser decodes block data into a struct consumed by the existing tag pipeline.
+
+**Tech Stack:** C++/Arduino, ESP32 mbedtls (HMAC-SHA256), PN5180 SPI, Adafruit PN532 I2C, ArduinoJson
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `lib/bambutag/BambuKeyDeriver.h` | BambuKeys struct, deriveBambuKeys() declaration |
+| Create | `lib/bambutag/BambuKeyDeriver.cpp` | HKDF-Extract + HKDF-Expand using mbedtls |
+| Create | `lib/bambutag/BambuTagParser.h` | BambuTagData struct, parseBambuBlocks() declaration |
+| Create | `lib/bambutag/BambuTagParser.cpp` | LE block decoding into BambuTagData fields |
+| Modify | `lib/PN5180/PN5180ISO14443.h` | Add mifareAuthenticate() declaration |
+| Modify | `lib/PN5180/PN5180ISO14443.cpp` | AUTH command, Crypto1 enable/disable, error recovery |
+| Modify | `src/NFCConnectionI.h` | Add virtual mifareAuthenticate(), mifareClassicRead() |
+| Modify | `src/HardwareNFCConnection.h` | Add mifareAuthenticate(), mifareClassicRead() |
+| Modify | `src/HardwareNFCConnection.cpp` | PN5180 wrapper calling iso14443a_ methods |
+| Modify | `src/HardwareNFCConnectionPN532.h` | Add mifareAuthenticate(), mifareClassicRead() |
+| Modify | `src/HardwareNFCConnectionPN532.cpp` | PN532 wrapper calling Adafruit mifareclassic_* |
+| Modify | `src/NFCManager.h` | BambuTagData storage + getter |
+| Modify | `src/NFCManager.cpp` | Bambu auth+read flow in handleNewTag |
+| Modify | `src/ApplicationManager.cpp` | Populate TagStateFields from BambuTagData |
+| Modify | `src/TagStateJson.h` | Add optional filament_length_m field |
+| Modify | `src/ConversionUtils.cpp` | tagFormatString returns "bambu" for BambuTag |
+| Modify | `src/WebServerManager.cpp` | serializeBambuTagStatus() |
+| Modify | `src/ReaderHTML.h` | renderBambu() + routing |
+
+---
+
+### Task 1: BambuKeyDeriver — HKDF Key Derivation
+
+**Files:**
+- Create: `lib/bambutag/BambuKeyDeriver.h`
+- Create: `lib/bambutag/BambuKeyDeriver.cpp`
+
+- [ ] **Step 1: Create BambuKeyDeriver header**
+
+```cpp
+// lib/bambutag/BambuKeyDeriver.h
+#pragma once
+
+#include <cstdint>
+
+struct BambuKeys {
+    uint8_t keys[96];  // 16 sectors x 6-byte Key A
+
+    const uint8_t* sectorKey(uint8_t sector) const {
+        return &keys[sector * 6];
+    }
+
+    const uint8_t* blockKey(uint8_t block) const {
+        return sectorKey(block / 4);
+    }
+};
+
+// Derive 16 MIFARE Classic sector keys from a Bambu tag UID using HKDF (HMAC-SHA256).
+// uid: 4 or 7 byte tag UID from ISO14443A activation.
+// Returns BambuKeys with 96 bytes of key material.
+BambuKeys deriveBambuKeys(const uint8_t* uid, uint8_t uidLen);
+```
+
+- [ ] **Step 2: Create BambuKeyDeriver implementation**
+
+```cpp
+// lib/bambutag/BambuKeyDeriver.cpp
+#include "BambuKeyDeriver.h"
+#include <mbedtls/md.h>
+#include <cstring>
+
+// Master key from Bambu Research Group / SpoolEase
+static const uint8_t BAMBU_MASTER_KEY[16] = {
+    0x9A, 0x75, 0x9C, 0xF2, 0xC4, 0xF7, 0xCA, 0xFF,
+    0x22, 0x2C, 0xB9, 0x76, 0x9B, 0x41, 0xBC, 0x96
+};
+
+static const uint8_t BAMBU_CONTEXT[] = { 'R', 'F', 'I', 'D', '-', 'A', '\0' };  // "RFID-A\0"
+
+BambuKeys deriveBambuKeys(const uint8_t* uid, uint8_t uidLen) {
+    BambuKeys result;
+    memset(&result, 0, sizeof(result));
+
+    const mbedtls_md_info_t* mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    const size_t hashLen = 32;  // SHA256 output
+    const size_t totalLen = 96; // 16 sectors * 6 bytes
+
+    // HKDF-Extract: PRK = HMAC-SHA256(salt=master_key, IKM=uid)
+    uint8_t prk[32];
+    mbedtls_md_hmac(mdInfo, BAMBU_MASTER_KEY, sizeof(BAMBU_MASTER_KEY),
+                    uid, uidLen, prk);
+
+    // HKDF-Expand: generate ceil(96/32) = 3 blocks
+    uint8_t okm[96];
+    uint8_t t[32];
+    size_t tLen = 0;
+    size_t okmOffset = 0;
+    uint8_t n = (totalLen + hashLen - 1) / hashLen;
+
+    for (uint8_t i = 1; i <= n; i++) {
+        mbedtls_md_context_t ctx;
+        mbedtls_md_init(&ctx);
+        mbedtls_md_setup(&ctx, mdInfo, 1);  // 1 = HMAC
+        mbedtls_md_hmac_starts(&ctx, prk, sizeof(prk));
+        if (tLen > 0) {
+            mbedtls_md_hmac_update(&ctx, t, tLen);
+        }
+        mbedtls_md_hmac_update(&ctx, BAMBU_CONTEXT, sizeof(BAMBU_CONTEXT));
+        mbedtls_md_hmac_update(&ctx, &i, 1);
+        mbedtls_md_hmac_finish(&ctx, t);
+        mbedtls_md_free(&ctx);
+        tLen = hashLen;
+
+        size_t copyLen = totalLen - okmOffset;
+        if (copyLen > hashLen) copyLen = hashLen;
+        memcpy(okm + okmOffset, t, copyLen);
+        okmOffset += copyLen;
+    }
+
+    memcpy(result.keys, okm, 96);
+    return result;
+}
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `pio run -e esp32s3devkitc`
+Expected: SUCCESS (library auto-discovered by PlatformIO LDF)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/bambutag/BambuKeyDeriver.h lib/bambutag/BambuKeyDeriver.cpp
+git commit -m "feat(#24): add BambuKeyDeriver — HKDF key derivation for MIFARE Classic"
+```
+
+---
+
+### Task 2: BambuTagParser — Block Data Decoding
+
+**Files:**
+- Create: `lib/bambutag/BambuTagParser.h`
+- Create: `lib/bambutag/BambuTagParser.cpp`
+
+- [ ] **Step 1: Create BambuTagParser header**
+
+```cpp
+// lib/bambutag/BambuTagParser.h
+#pragma once
+
+#include <cstdint>
+
+struct BambuTagData {
+    bool valid = false;
+    char material_variant[16] = {};   // Block 1
+    char filament_type[16] = {};      // Block 2
+    uint8_t color_r = 0;              // Block 5
+    uint8_t color_g = 0;
+    uint8_t color_b = 0;
+    uint8_t color_a = 0;
+    uint16_t weight_g = 0;            // Block 5 — AMS-updated remaining weight
+    float diameter_mm = 0.0f;         // Block 5
+    uint16_t drying_temp = 0;         // Block 6
+    uint16_t drying_time = 0;         // Block 6
+    uint16_t bed_temp = 0;            // Block 6
+    uint16_t hotend_min = 0;          // Block 6
+    uint16_t hotend_max = 0;          // Block 6
+    char production_date[20] = {};    // Block 13
+    uint32_t filament_length_m = 0;   // Block 14
+    uint8_t color_extended[16] = {};  // Block 16 (raw)
+};
+
+// Block indices into the blocks array (must match read order)
+// Read order: [1, 2, 4, 5, 6, 13, 14, 16]
+static constexpr uint8_t BAMBU_BLOCKS[] = { 1, 2, 4, 5, 6, 13, 14, 16 };
+static constexpr uint8_t BAMBU_BLOCK_COUNT = 8;
+
+// Parse 8 raw 16-byte MIFARE Classic blocks into BambuTagData.
+// blocks[0] = block 1, blocks[1] = block 2, blocks[2] = block 4, etc.
+bool parseBambuBlocks(const uint8_t blocks[][16], BambuTagData& out);
+```
+
+- [ ] **Step 2: Create BambuTagParser implementation**
+
+```cpp
+// lib/bambutag/BambuTagParser.cpp
+#include "BambuTagParser.h"
+#include <cstring>
+
+static uint16_t readU16LE(const uint8_t* p) {
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+static float readFloatLE(const uint8_t* p) {
+    float val;
+    memcpy(&val, p, sizeof(float));
+    return val;
+}
+
+bool parseBambuBlocks(const uint8_t blocks[][16], BambuTagData& out) {
+    memset(&out, 0, sizeof(out));
+
+    // blocks[0] = block 1: Material variant ID (first 8 bytes) + Material ID (last 8 bytes)
+    memcpy(out.material_variant, blocks[0], 15);
+    out.material_variant[15] = '\0';
+    // Trim trailing nulls/spaces
+    for (int i = 14; i >= 0; i--) {
+        if (out.material_variant[i] == '\0' || out.material_variant[i] == ' ') {
+            out.material_variant[i] = '\0';
+        } else break;
+    }
+
+    // blocks[1] = block 2: Filament type string (null-terminated ASCII)
+    memcpy(out.filament_type, blocks[1], 15);
+    out.filament_type[15] = '\0';
+    for (int i = 14; i >= 0; i--) {
+        if (out.filament_type[i] == '\0' || out.filament_type[i] == ' ') {
+            out.filament_type[i] = '\0';
+        } else break;
+    }
+
+    // blocks[2] = block 4: Detailed filament specs (format varies, skip for now)
+
+    // blocks[3] = block 5: RGBA (4 bytes), weight (uint16 LE at offset 4), diameter (float LE at offset 8)
+    out.color_r = blocks[3][0];
+    out.color_g = blocks[3][1];
+    out.color_b = blocks[3][2];
+    out.color_a = blocks[3][3];
+    out.weight_g = readU16LE(&blocks[3][4]);
+    out.diameter_mm = readFloatLE(&blocks[3][8]);
+
+    // blocks[4] = block 6: drying_temp(2), drying_time(2), bed_temp(2), hotend_min(2), hotend_max(2)
+    out.drying_temp = readU16LE(&blocks[4][0]);
+    out.drying_time = readU16LE(&blocks[4][2]);
+    out.bed_temp = readU16LE(&blocks[4][4]);
+    out.hotend_min = readU16LE(&blocks[4][6]);
+    out.hotend_max = readU16LE(&blocks[4][8]);
+
+    // blocks[5] = block 13: Production date as ASCII
+    memcpy(out.production_date, blocks[5], 16);
+    out.production_date[16] = '\0';
+    // Trim trailing nulls
+    for (int i = 15; i >= 0; i--) {
+        if (out.production_date[i] == '\0' || out.production_date[i] == ' ') {
+            out.production_date[i] = '\0';
+        } else break;
+    }
+
+    // blocks[6] = block 14: Filament length
+    out.filament_length_m = readU16LE(&blocks[6][0]);
+
+    // blocks[7] = block 16: Extended color data (raw)
+    memcpy(out.color_extended, blocks[7], 16);
+
+    out.valid = (out.filament_type[0] != '\0');
+    return out.valid;
+}
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `pio run -e esp32s3devkitc`
+Expected: SUCCESS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/bambutag/BambuTagParser.h lib/bambutag/BambuTagParser.cpp
+git commit -m "feat(#24): add BambuTagParser — decode MIFARE Classic block data"
+```
+
+---
+
+### Task 3: PN5180 MIFARE Classic Authentication
+
+**Files:**
+- Modify: `lib/PN5180/PN5180ISO14443.h`
+- Modify: `lib/PN5180/PN5180ISO14443.cpp`
+
+- [ ] **Step 1: Add mifareAuthenticate declaration to header**
+
+In `lib/PN5180/PN5180ISO14443.h`, add after the `mifareHalt()` declaration (line 41):
+
+```cpp
+  // MIFARE Classic authentication using internal Crypto1 engine.
+  // keyType: 0x60 = Key A, 0x61 = Key B
+  // key: 6-byte authentication key
+  // uid: tag UID (4 or 7 bytes from activateTypeA)
+  // uidLen: length of uid array
+  // Returns true if authentication succeeded (Crypto1 active).
+  bool mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t *key,
+                          const uint8_t *uid, uint8_t uidLen);
+```
+
+- [ ] **Step 2: Implement mifareAuthenticate in PN5180ISO14443.cpp**
+
+Add before the `mifareHalt()` function:
+
+```cpp
+bool PN5180ISO14443::mifareAuthenticate(uint8_t blockNo, uint8_t keyType,
+                                         const uint8_t *key, const uint8_t *uid,
+                                         uint8_t uidLen) {
+    // MIFARE Classic AUTH command: keyType(1) + blockNo(1) + key(6) + UID(4)
+    // Total: 12 bytes. Only first 4 bytes of UID used for auth.
+    uint8_t cmd[12];
+    cmd[0] = keyType;   // 0x60 = AUTH_A, 0x61 = AUTH_B
+    cmd[1] = blockNo;
+    memcpy(cmd + 2, key, 6);
+    // Use first 4 bytes of UID (MIFARE Classic standard)
+    uint8_t uidCopyLen = (uidLen < 4) ? uidLen : 4;
+    memcpy(cmd + 8, uid, uidCopyLen);
+
+    // Enable Crypto1 in SYSTEM_CONFIG (bit 6 = MFC_CRYPTO_ON)
+    writeRegisterWithOrMask(SYSTEM_CONFIG, 0x00000040);
+
+    // Clear IRQ status before sending
+    clearIRQStatus(0x000FFFFF);
+
+    // Set transceive command in SYSTEM_CONFIG
+    writeRegisterWithOrMask(SYSTEM_CONFIG, 0x00000003);  // COMMAND = Transceive
+
+    if (!sendData(cmd, 12, 0x00)) {
+        Serial.println("PN5180: mifareAuthenticate sendData failed");
+        // Clear Crypto1 and recover
+        writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFBF);
+        writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFF8);
+        clearIRQStatus(0x000FFFFF);
+        return false;
+    }
+
+    // Wait for RX_IRQ indicating authentication response
+    unsigned long startMs = millis();
+    while (!(getIRQStatus() & RX_IRQ_STAT)) {
+        if (millis() - startMs > 150) {
+            Serial.printf("PN5180: mifareAuthenticate timeout for block %d\n", blockNo);
+            writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFBF);
+            writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFF8);
+            clearIRQStatus(0x000FFFFF);
+            return false;
+        }
+        delay(1);
+    }
+
+    // Check for authentication error (RX error IRQ)
+    uint32_t irqStatus = getIRQStatus();
+    clearIRQStatus(0x000FFFFF);
+
+    if (irqStatus & (0x01 << 17)) {  // RX_SOF_DET_IRQ_STAT check for protocol error
+        // Authentication likely failed — read a dummy byte to check
+    }
+
+    // Verify Crypto1 is active by checking SYSTEM_CONFIG bit 6
+    uint32_t sysConfig;
+    readRegister(SYSTEM_CONFIG, &sysConfig);
+    if (!(sysConfig & 0x00000040)) {
+        Serial.printf("PN5180: mifareAuthenticate Crypto1 not active after auth for block %d\n", blockNo);
+        writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFF8);
+        clearIRQStatus(0x000FFFFF);
+        return false;
+    }
+
+    return true;
+}
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `pio run -e esp32s3devkitc`
+Expected: SUCCESS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/PN5180/PN5180ISO14443.h lib/PN5180/PN5180ISO14443.cpp
+git commit -m "feat(#24): add mifareAuthenticate to PN5180ISO14443"
+```
+
+---
+
+### Task 4: NFCConnectionI + Hardware Wrappers
+
+**Files:**
+- Modify: `src/NFCConnectionI.h`
+- Modify: `src/HardwareNFCConnection.h`
+- Modify: `src/HardwareNFCConnection.cpp`
+- Modify: `src/HardwareNFCConnectionPN532.h`
+- Modify: `src/HardwareNFCConnectionPN532.cpp`
+
+- [ ] **Step 1: Add virtual methods to NFCConnectionI**
+
+In `src/NFCConnectionI.h`, add after the `ntagGetVersion` method (line 31):
+
+```cpp
+    // MIFARE Classic authentication. keyType: 0x60=Key A, 0x61=Key B.
+    // Returns true if sector containing blockNo is now authenticated.
+    virtual bool mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t* key) { return false; }
+
+    // Read a single MIFARE Classic 16-byte block (requires prior authentication).
+    virtual bool mifareClassicRead(uint8_t blockNo, uint8_t* buffer) { return false; }
+```
+
+- [ ] **Step 2: Add declarations to HardwareNFCConnection.h**
+
+After the `ntagGetVersion` declaration (line 28):
+
+```cpp
+    bool mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t* key) override;
+    bool mifareClassicRead(uint8_t blockNo, uint8_t* buffer) override;
+```
+
+- [ ] **Step 3: Implement in HardwareNFCConnection.cpp**
+
+Add at the end of the file, before the closing:
+
+```cpp
+bool HardwareNFCConnection::mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t* key) {
+    if (!iso14443a_) return false;
+    return iso14443a_->mifareAuthenticate(blockNo, keyType, key, currentUid_, 4);
+}
+
+bool HardwareNFCConnection::mifareClassicRead(uint8_t blockNo, uint8_t* buffer) {
+    if (!iso14443a_) return false;
+    return iso14443a_->mifareBlockRead(blockNo, buffer);
+}
+```
+
+- [ ] **Step 4: Add declarations to HardwareNFCConnectionPN532.h**
+
+After the `ntagGetVersion` declaration (line 21):
+
+```cpp
+    bool mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t* key) override;
+    bool mifareClassicRead(uint8_t blockNo, uint8_t* buffer) override;
+```
+
+- [ ] **Step 5: Implement in HardwareNFCConnectionPN532.cpp**
+
+Add at the end of the file:
+
+```cpp
+bool HardwareNFCConnectionPN532::mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t* key) {
+    if (!pn532_ || !ready_) return false;
+    // Adafruit PN532: keyNumber 0=KEYA, 1=KEYB
+    uint8_t keyNumber = (keyType == 0x61) ? 1 : 0;
+    return pn532_->mifareclassic_AuthenticateBlock(
+        currentUid_, currentUidLen_, blockNo, keyNumber, const_cast<uint8_t*>(key));
+}
+
+bool HardwareNFCConnectionPN532::mifareClassicRead(uint8_t blockNo, uint8_t* buffer) {
+    if (!pn532_ || !ready_) return false;
+    return pn532_->mifareclassic_ReadDataBlock(blockNo, buffer);
+}
+```
+
+- [ ] **Step 6: Build to verify compilation**
+
+Run: `pio run -e esp32s3devkitc`
+Expected: SUCCESS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/NFCConnectionI.h src/HardwareNFCConnection.h src/HardwareNFCConnection.cpp \
+        src/HardwareNFCConnectionPN532.h src/HardwareNFCConnectionPN532.cpp
+git commit -m "feat(#24): add mifareAuthenticate + mifareClassicRead to NFC interface"
+```
+
+---
+
+### Task 5: NFCManager — Bambu Tag Detection and Reading
+
+**Files:**
+- Modify: `src/NFCManager.h`
+- Modify: `src/NFCManager.cpp`
+
+- [ ] **Step 1: Add BambuTagData storage to NFCManager.h**
+
+Add include at top:
+```cpp
+#include "BambuTagParser.h"
+```
+
+Add alongside the other `lastXxxValid_` members (after line 175):
+```cpp
+    BambuTagData lastBambuTag_;
+    bool lastBambuTagValid_ = false;
+```
+
+Add public getter alongside `getLastTigerTagData` (after line 79):
+```cpp
+    bool getLastBambuTagData(BambuTagData& out);
+```
+
+- [ ] **Step 2: Implement getter in NFCManager.cpp**
+
+Add alongside the other `getLastXxx` implementations:
+
+```cpp
+bool NFCManager::getLastBambuTagData(BambuTagData& out) {
+    if (!lastBambuTagValid_) return false;
+    out = lastBambuTag_;
+    return true;
+}
+```
+
+- [ ] **Step 3: Add Bambu read flow to handleNewTag**
+
+Replace the existing BambuTag block in `handleNewTag()` (lines 476-498) with:
+
+```cpp
+    // Bambu tags use MIFARE Classic — attempt key derivation + authenticated read
+    if (scan.kind == TagKind::BambuTag) {
+        BambuTagData bambuData;
+        bool readOk = readBambuTag(uid, uidLength, bambuData);
+
+        if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+            memcpy(currentSpool.spool_id, scan.uid_hex, sizeof(scan.uid_hex));
+            memcpy(currentSpool.uid, uid, uidLength);
+            currentSpool.uid_length = uidLength;
+            currentSpool.present = true;
+            currentSpool.blank_tag_present = false;
+            currentSpool.kind = TagKind::BambuTag;
+            currentSpool.variant = NtagVariant::Unknown;
+            currentSpool.tag_data_valid = readOk;
+            lastBambuTagValid_ = readOk;
+            if (readOk) lastBambuTag_ = bambuData;
+            lastTigerTagValid_ = false;
+            lastOpenTag3DValid_ = false;
+            lastOpenSpoolValid_ = false;
+            memcpy(lastSeenUid, uid, uidLength);
+            lastSeenUidLength = uidLength;
+            lastSeenValid = true;
+            lastSeenMs = millis();
+            xSemaphoreGive(tagMutex);
+        }
+
+        if (readOk) {
+            Serial.printf("NFCManager: Bambu tag — %s, %ug, #%02X%02X%02X\n",
+                          bambuData.filament_type, bambuData.weight_g,
+                          bambuData.color_r, bambuData.color_g, bambuData.color_b);
+            LogBuffer::getInstance().logPrintf("Bambu: %s %ug\n",
+                          bambuData.filament_type, bambuData.weight_g);
+        } else {
+            Serial.printf("NFCManager: Bambu tag — UID=%s (auth failed, no data)\n", scan.uid_hex);
+            LogBuffer::getInstance().logPrintf("Bambu tag: %s (no data)\n", scan.uid_hex);
+        }
+        sendGenericTagMessage();
+        return;
+    }
+```
+
+- [ ] **Step 4: Add readBambuTag private method**
+
+Add to NFCManager.h private section:
+```cpp
+    bool readBambuTag(const uint8_t* uid, uint8_t uidLength, BambuTagData& out);
+```
+
+Implement in NFCManager.cpp:
+
+```cpp
+#include "BambuKeyDeriver.h"
+#include "BambuTagParser.h"
+
+bool NFCManager::readBambuTag(const uint8_t* uid, uint8_t uidLength, BambuTagData& out) {
+    BambuKeys keys = deriveBambuKeys(uid, uidLength);
+    uint8_t blocks[BAMBU_BLOCK_COUNT][16];
+    uint8_t lastAuthSector = 0xFF;
+
+    for (uint8_t i = 0; i < BAMBU_BLOCK_COUNT; i++) {
+        uint8_t blockNo = BAMBU_BLOCKS[i];
+        uint8_t sector = blockNo / 4;
+
+        // Only re-authenticate when changing sectors
+        if (sector != lastAuthSector) {
+            if (!connection_->mifareAuthenticate(blockNo, 0x60, keys.blockKey(blockNo))) {
+                Serial.printf("NFCManager: Bambu auth failed on block %d (sector %d)\n", blockNo, sector);
+                if (i == 0) return false;  // First block auth fail = not a Bambu tag
+                continue;  // Skip this block but try remaining
+            }
+            lastAuthSector = sector;
+        }
+
+        if (!connection_->mifareClassicRead(blockNo, blocks[i])) {
+            Serial.printf("NFCManager: Bambu block read failed on block %d\n", blockNo);
+            memset(blocks[i], 0, 16);
+        }
+    }
+
+    return parseBambuBlocks(blocks, out);
+}
+```
+
+- [ ] **Step 5: Build to verify compilation**
+
+Run: `pio run -e esp32s3devkitc`
+Expected: SUCCESS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NFCManager.h src/NFCManager.cpp
+git commit -m "feat(#24): Bambu tag detection — key derivation + authenticated block reads"
+```
+
+---
+
+### Task 6: MQTT + TagStateJson Integration
+
+**Files:**
+- Modify: `src/TagStateJson.h`
+- Modify: `src/ConversionUtils.cpp`
+- Modify: `src/ApplicationManager.cpp`
+
+- [ ] **Step 1: Add filament_length_m to TagStateFields**
+
+In `src/TagStateJson.h`, add after `float diameter_mm;` (line 29):
+
+```cpp
+    uint32_t filament_length_m;
+```
+
+In `buildTagStateJson`, add after the `diameter_mm` line (after line 54):
+
+```cpp
+    if (f.filament_length_m > 0) doc["filament_length_m"] = f.filament_length_m;
+```
+
+- [ ] **Step 2: Update tagFormatString for BambuTag**
+
+In `src/ConversionUtils.cpp`, change the BambuTag case (around line 80):
+
+```cpp
+        case TagKind::BambuTag:     return "bambu";
+```
+
+(Currently returns `"uid_only"`, change to `"bambu"`)
+
+- [ ] **Step 3: Populate TagStateFields from BambuTagData in ApplicationManager**
+
+In `src/ApplicationManager.cpp`, find `handleSpoolDetected` where it builds `TagStateFields f`. Add a block to populate from BambuTagData. After the existing tag format population code, in the section where the display spool is built, add Bambu data population:
+
+Find the section where `f` (TagStateFields) is populated before `buildTagStateJson`. Add:
+
+```cpp
+    // Populate from Bambu tag data if available
+    BambuTagData bambuData;
+    if (state.kind == TagKind::BambuTag && NFCManager::getInstance().getLastBambuTagData(bambuData)) {
+        strncpy(f.material_name, bambuData.filament_type, sizeof(f.material_name) - 1);
+        strncpy(f.material_type, bambuData.filament_type, sizeof(f.material_type) - 1);
+        snprintf(f.color, sizeof(f.color), "#%02X%02X%02X",
+                 bambuData.color_r, bambuData.color_g, bambuData.color_b);
+        f.initial_weight_g = bambuData.weight_g;
+        f.remaining_g = bambuData.weight_g;
+        f.min_print_temp = bambuData.hotend_min;
+        f.max_print_temp = bambuData.hotend_max;
+        f.min_bed_temp = bambuData.bed_temp;
+        f.diameter_mm = bambuData.diameter_mm;
+        f.filament_length_m = bambuData.filament_length_m;
+        spool.hasColor = true;
+    }
+```
+
+- [ ] **Step 4: Build to verify compilation**
+
+Run: `pio run -e esp32s3devkitc`
+Expected: SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/TagStateJson.h src/ConversionUtils.cpp src/ApplicationManager.cpp
+git commit -m "feat(#24): publish Bambu tag data via MQTT — material, color, weight, temps"
+```
+
+---
+
+### Task 7: Web UI — Status API + Reader Page
+
+**Files:**
+- Modify: `src/WebServerManager.cpp`
+- Modify: `src/ReaderHTML.h`
+
+- [ ] **Step 1: Add serializeBambuTagStatus to WebServerManager**
+
+Add include at top of WebServerManager.cpp:
+```cpp
+#include "BambuTagParser.h"
+```
+
+Add new serializer alongside the existing ones (after `serializeOpenSpoolStatus`):
+
+```cpp
+void WebServerManager::serializeBambuTagStatus(JsonDocument& doc) {
+    BambuTagData bt;
+    if (!NFCManager::getInstance().getLastBambuTagData(bt) || !bt.valid) return;
+
+    JsonObject obj = doc.createNestedObject("bambu");
+    obj["filament_type"] = bt.filament_type;
+    obj["material_variant"] = bt.material_variant;
+
+    char colorHex[8];
+    snprintf(colorHex, sizeof(colorHex), "#%02X%02X%02X", bt.color_r, bt.color_g, bt.color_b);
+    obj["color_hex"] = colorHex;
+
+    obj["weight_g"] = bt.weight_g;
+    if (bt.diameter_mm > 0.0f) obj["diameter_mm"] = bt.diameter_mm;
+    if (bt.hotend_min > 0) obj["hotend_min"] = bt.hotend_min;
+    if (bt.hotend_max > 0) obj["hotend_max"] = bt.hotend_max;
+    if (bt.bed_temp > 0) obj["bed_temp"] = bt.bed_temp;
+    if (bt.drying_temp > 0) obj["drying_temp"] = bt.drying_temp;
+    if (bt.drying_time > 0) obj["drying_time"] = bt.drying_time;
+    if (bt.production_date[0]) obj["production_date"] = bt.production_date;
+    if (bt.filament_length_m > 0) obj["filament_length_m"] = bt.filament_length_m;
+}
+```
+
+Add declaration to `src/WebServerManager.h`:
+```cpp
+    void serializeBambuTagStatus(JsonDocument& doc);
+```
+
+- [ ] **Step 2: Wire into handleApiStatus switch**
+
+In `handleApiStatus()`, find the switch on `state.kind` (around line 1233). Change the BambuTag case from `break;` to:
+
+```cpp
+            case TagKind::BambuTag:     serializeBambuTagStatus(doc); break;
+```
+
+- [ ] **Step 3: Add renderBambu to ReaderHTML.h**
+
+Add after the `renderOpenSpool` function:
+
+```javascript
+    function renderBambu(s) {
+      var t = s.bambu || {};
+      var html = '';
+      html += row('Format', 'Bambu Lab');
+      html += row('UID', s.uid || '&mdash;');
+      if (t.filament_type) html += row('Filament', t.filament_type);
+      if (t.material_variant) html += row('Variant', t.material_variant);
+      if (t.color_hex) html += row('Color', colorValue(t.color_hex));
+      if (t.weight_g !== undefined) html += row('Weight', t.weight_g + ' g');
+      if (t.diameter_mm) html += row('Diameter', t.diameter_mm + ' mm');
+      if (t.hotend_min && t.hotend_max) html += row('Nozzle Temp', t.hotend_min + ' \u2013 ' + t.hotend_max + ' \u00B0C');
+      if (t.bed_temp) html += row('Bed Temp', t.bed_temp + ' \u00B0C');
+      if (t.drying_temp) html += row('Dry', t.drying_temp + ' \u00B0C / ' + (t.drying_time || '?') + ' hrs');
+      if (t.production_date) html += row('Produced', t.production_date);
+      if (t.filament_length_m) html += row('Filament Length', t.filament_length_m + ' m');
+      if (s.spoolman) {
+        if (s.spoolman.remaining_g !== undefined) {
+          html += row('Remaining', s.spoolman.remaining_g.toFixed(1) + ' g' + spoolmanBadge());
+        }
+        if (s.spoolman.spool_id !== undefined && s.spoolman.spool_id > 0) {
+          html += row('Spoolman ID', '#' + s.spoolman.spool_id + spoolmanBadge());
+        }
+      }
+      return html;
+    }
+```
+
+- [ ] **Step 4: Add BambuTag routing in render function**
+
+Find the render function's tag_kind routing (around line 344-350). Add BambuTag case:
+
+```javascript
+      } else if (kind === 'BambuTag' && s.bambu) {
+        html = renderBambu(s);
+```
+
+- [ ] **Step 5: Build to verify compilation**
+
+Run: `pio run -e esp32s3devkitc`
+Expected: SUCCESS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/WebServerManager.cpp src/WebServerManager.h src/ReaderHTML.h
+git commit -m "feat(#24): Bambu tag display on reader page + /api/status serialization"
+```
+
+---
+
+### Task 8: End-to-End Test on Hardware
+
+- [ ] **Step 1: Flash firmware**
+
+Run: `pio run -e esp32s3devkitc -t upload --upload-port /dev/cu.usbmodem3101`
+Expected: Upload SUCCESS
+
+- [ ] **Step 2: Test with Bambu Lab spool tag**
+
+1. Place a Bambu Lab filament spool on the scanner
+2. Check serial output for: `NFCManager: Bambu tag — PLA Basic, 1000g, #RRGGBB`
+3. If auth fails: `NFCManager: Bambu tag — UID=XXXXXXXX (auth failed, no data)`
+
+- [ ] **Step 3: Verify web reader page**
+
+1. Open `http://spoolsense.local/reader`
+2. Scan the Bambu tag
+3. Verify all fields display: Filament type, color swatch, weight, temps, diameter, production date
+
+- [ ] **Step 4: Verify MQTT payload**
+
+Check MQTT topic `spoolsense/tag/state` for:
+- `tag_format: "bambu"`
+- `material_name: "PLA Basic"` (or whatever the tag has)
+- `color: "#RRGGBB"`
+- `initial_weight_g` and `remaining_g` populated
+- Temp fields populated
+
+- [ ] **Step 5: Verify Spoolman lookup**
+
+If the Bambu spool UID is registered in Spoolman, verify the enrichment badge appears on the reader page.
+
+- [ ] **Step 6: Test with non-Bambu MIFARE Classic tag (if available)**
+
+Place a non-Bambu MIFARE Classic tag. Verify auth fails gracefully and tag falls back to GenericUidTag behavior.
+
+- [ ] **Step 7: Test with NTAG/OpenTag3D/TigerTag**
+
+Verify existing tag formats still work — no regressions from the new authentication code path.
+
+- [ ] **Step 8: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(#24): address issues found during hardware testing"
+```

--- a/docs/superpowers/specs/2026-04-14-bambu-mifare-classic-design.md
+++ b/docs/superpowers/specs/2026-04-14-bambu-mifare-classic-design.md
@@ -1,0 +1,186 @@
+# Bambu MIFARE Classic Tag Reading — Design Spec
+
+## Goal
+
+Add full Bambu Lab MIFARE Classic tag reading to the SpoolSense scanner on both PN5180 and PN532 readers. Derive per-tag authentication keys from the UID using HKDF, read filament data blocks, and publish to MQTT/HA/Spoolman using the existing tag pipeline.
+
+## Background
+
+Bambu Lab filament spools use MIFARE Classic 1K tags with per-tag encryption keys derived from the UID via HKDF (HMAC-SHA256). The community (SpoolEase by yanshay, Bambu Research Group) has reverse-engineered the key derivation algorithm and block layout. The AMS writes updated weight data back to the tag during prints, making block 5's weight field a live value — not just factory initial weight.
+
+**Scope**: Read-only. Bambu tags have an RSA-2048 signature (sectors 10-15) that prevents writing without Bambu's private key. No project in the community supports writing.
+
+**Follow-up**: Issue #157 tracks Spoolman weight sync for mixed environments (user has both SpoolSense/Voron printers and a Bambu AMS — tag weight may change between scans).
+
+## Key Derivation Algorithm
+
+Ported from SpoolEase (`shared/src/pn532_ext.rs`):
+
+- **Master key**: `9A 75 9C F2 C4 F7 CA FF 22 2C B9 76 9B 41 BC 96` (16 bytes)
+- **HKDF-Extract**: `PRK = HMAC-SHA256(master_key, uid)`
+- **HKDF-Expand**: Context = `"RFID-A\0"` (7 bytes), generate 96 bytes (16 sectors x 6-byte Key A)
+- **Key B**: Always `00 00 00 00 00 00` (unused for reads)
+- `sectorKey(n)` = bytes `[n*6 .. (n+1)*6]` from expanded output
+- `blockKey(blockNo)` = `sectorKey(blockNo / 4)`
+
+Uses ESP32's built-in mbedtls (`mbedtls_md_hmac()` with `MBEDTLS_MD_SHA256`) — no new dependency.
+
+## Bambu Tag Block Layout
+
+MIFARE Classic 1K = 16 sectors x 4 blocks = 64 blocks. Every 4th block is a sector trailer (keys + access bits). All data is little-endian.
+
+### Blocks Read: `[1, 2, 4, 5, 6, 13, 14, 16]`
+
+| Block | Sector | Content |
+|-------|--------|---------|
+| 1 | 0 | Material variant ID (8 bytes) + Material ID (8 bytes) |
+| 2 | 0 | Filament type string (e.g. "PLA Basic", null-terminated ASCII) |
+| 4 | 1 | Detailed filament specs |
+| 5 | 1 | RGBA color (4 bytes), weight in grams (uint16 LE), diameter as float LE |
+| 6 | 1 | Drying temp/time (uint16 LE), bed temp, hotend min/max |
+| 13 | 3 | Production date as ASCII: `YYYY_MM_DD_HH_MM` |
+| 14 | 3 | Filament length (factory static, never updated by AMS) |
+| 16 | 4 | Extended color information |
+
+**Block 5 weight is live-updated by the AMS** — represents current remaining weight, not factory initial. This is critical for mixed-environment users (#157).
+
+## Architecture
+
+### Layer 1: NFC Library — MIFARE Classic Authentication
+
+**PN5180ISO14443** (in `lib/PN5180/`):
+
+```cpp
+bool mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t *key,
+                        const uint8_t *uid, uint8_t uidLen);
+```
+
+- Sends AUTH command (0x60 = Key A, 0x61 = Key B) with block number, key, and UID
+- PN5180 internal Crypto1 engine handles the challenge-response
+- On success: sets `MFC_CRYPTO_ON` bit (bit 6) in `SYSTEM_CONFIG` register
+- After auth, existing `mifareBlockRead()` reads encrypted blocks transparently
+- Auth failure recovery: clear Crypto1 bit (`SYSTEM_CONFIG & 0xFFFFFFBF`), force transceiver idle (`SYSTEM_CONFIG & 0xFFFFFFF8`), flush RX, clear all IRQs
+
+**HardwareNFCConnection** (PN5180 wrapper):
+
+```cpp
+bool mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t *key);
+```
+
+Passes through to PN5180 method using UID captured during `activateTypeA`.
+
+**HardwareNFCConnectionPN532** (PN532 wrapper):
+
+Same interface. Calls Adafruit PN532 library's `mifareclassic_AuthenticateBlock()`.
+
+### Layer 2: Key Derivation — BambuKeyDeriver
+
+New library: `lib/bambutag/`
+
+```cpp
+struct BambuKeys {
+    uint8_t keys[96];  // 16 sectors x 6 bytes
+    const uint8_t* sectorKey(uint8_t sector) const;
+    const uint8_t* blockKey(uint8_t block) const;
+};
+
+BambuKeys deriveBambuKeys(const uint8_t* uid, uint8_t uidLen);
+```
+
+- Stateless, stack-allocated (96 bytes), no heap
+- Uses `mbedtls_md_hmac()` from ESP32 framework
+
+### Layer 3: Tag Data Parsing — BambuTagParser
+
+New library: `lib/bambutag/`
+
+```cpp
+struct BambuTagData {
+    bool valid;
+    char material_variant[16];
+    char filament_type[16];
+    uint8_t color_r, color_g, color_b, color_a;
+    uint16_t weight_g;
+    float diameter_mm;
+    uint16_t drying_temp;
+    uint16_t drying_time;
+    uint16_t bed_temp;
+    uint16_t hotend_min;
+    uint16_t hotend_max;
+    char production_date[20];
+    uint32_t filament_length_m;
+    uint8_t color_extended[16];
+};
+
+bool parseBambuBlocks(const uint8_t blocks[8][16], BambuTagData& out);
+```
+
+- Takes 8 raw 16-byte block buffers, populates struct
+- All uint16 fields decoded as little-endian
+- No NFC dependency — purely data transformation, testable without hardware
+
+### Layer 4: Integration
+
+**NFCManager detection flow** (after `activateTypeA`):
+
+1. Check SAK byte — `0x08` = MIFARE Classic 1K
+2. Derive keys: `BambuKeys keys = deriveBambuKeys(uid, uidLen)`
+3. For each block in `[1, 2, 4, 5, 6, 13, 14, 16]`:
+   - `mifareAuthenticate(block, KEY_A, keys.blockKey(block))`
+   - `mifareBlockRead(block, buffer)`
+4. If first auth fails → not a Bambu tag → fall back to `GenericUidTag`
+5. Parse blocks: `parseBambuBlocks(blocks, bambuData)`
+6. Set `TagKind::BambuTag`, store `BambuTagData`, send `SPOOL_DETECTED`
+
+**MQTT / Home Assistant** (`TagStateFields` mapping):
+
+| TagStateFields | BambuTagData source |
+|---|---|
+| `material_name` | `filament_type` |
+| `color` | RGBA → `#RRGGBB` |
+| `initial_weight_g` | `weight_g` (AMS-updated) |
+| `min_print_temp` | `hotend_min` |
+| `max_print_temp` | `hotend_max` |
+| `min_bed_temp` | `bed_temp` |
+| `diameter_mm` | `diameter_mm` |
+| `tag_format` | `"bambu"` |
+| `filament_length_m` (new, optional) | `filament_length_m` |
+
+**TFT Display**: "Bambu" colored label, material + color swatch.
+
+**Web UI Reader Page**: `serializeBambuTagStatus()` adds `"bambu"` JSON object to `/api/status`. Reader page renders all fields.
+
+**Spoolman**: UID used as `nfc_id` for lookup, same as `GenericUidTag`. Bambu tag data populates Spoolman fields on first scan if no spool exists.
+
+## File Changes
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `lib/bambutag/BambuKeyDeriver.h` | HKDF key derivation (header) |
+| Create | `lib/bambutag/BambuKeyDeriver.cpp` | HKDF implementation using mbedtls |
+| Create | `lib/bambutag/BambuTagParser.h` | `BambuTagData` struct + parser (header) |
+| Create | `lib/bambutag/BambuTagParser.cpp` | Block parsing implementation |
+| Modify | `lib/PN5180/PN5180ISO14443.h` | Add `mifareAuthenticate()` declaration |
+| Modify | `lib/PN5180/PN5180ISO14443.cpp` | Implement MIFARE Classic auth + Crypto1 |
+| Modify | `src/HardwareNFCConnection.h` | Add virtual `mifareAuthenticate()` |
+| Modify | `src/HardwareNFCConnection.cpp` | PN5180 wrapper implementation |
+| Modify | `src/HardwareNFCConnectionPN532.h` | Add `mifareAuthenticate()` |
+| Modify | `src/HardwareNFCConnectionPN532.cpp` | PN532 wrapper via Adafruit lib |
+| Modify | `src/NFCManager.h` | Store `BambuTagData`, add getter |
+| Modify | `src/NFCManager.cpp` | Bambu detection flow in readAndParseTag |
+| Modify | `src/ApplicationManager.cpp` | Populate TagStateFields from BambuTagData |
+| Modify | `src/TagStateJson.h` | Add optional `filament_length_m` |
+| Modify | `src/WebServerManager.cpp` | `serializeBambuTagStatus()` |
+| Modify | `src/TFTManager.cpp` | Bambu tag label on TFT |
+| Modify | `src/ReaderHTML.h` | Render Bambu data on reader page |
+
+## Dependencies
+
+- **mbedtls**: Ships with ESP32 Arduino framework. Used for HMAC-SHA256 in key derivation. No new library dependency.
+- **Adafruit PN532**: Already in `platformio.ini`. Has `mifareclassic_AuthenticateBlock()` built in.
+
+## Out of Scope
+
+- Writing to Bambu tags (RSA-2048 signature prevents this)
+- Spoolman weight sync from AMS-updated tags (tracked in #157)
+- Bambu tag data on writer pages (read-only format, no writer needed)

--- a/lib/PN5180/PN5180.cpp
+++ b/lib/PN5180/PN5180.cpp
@@ -409,6 +409,34 @@ bool PN5180::loadRFConfig(uint8_t txConf, uint8_t rxConf) {
 }
 
 /*
+ * MFC_AUTHENTICATE - 0x1C
+ * MIFARE Classic authentication using the PN5180 internal Crypto1 engine.
+ * Returns true if authentication succeeded (response byte == 0).
+ */
+bool PN5180::mfcAuthenticate(const uint8_t *key, uint8_t keyType, uint8_t blockNo, const uint8_t *uid) {
+  // PN5180 host command 0x0C: [cmd][key(6)][keyType(0x60/0x61)][block][uid(4)]
+  uint8_t cmd[13];
+  cmd[0] = 0x0C;
+  memcpy(&cmd[1], key, 6);
+  cmd[7] = keyType;
+  cmd[8] = blockNo;
+  memcpy(&cmd[9], uid, 4);
+
+  uint8_t response = 0xFF;
+  pn5180_spi.beginTransaction(PN5180_SPI_SETTINGS);
+  bool ok = transceiveCommand(cmd, 13, &response, 1);
+  pn5180_spi.endTransaction();
+
+  if (!ok || response != 0x00) {
+    Serial.printf("PN5180: mfcAuthenticate block %d failed (ok=%d resp=0x%02X)\n", blockNo, ok, response);
+    writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFBF);  // clear Crypto1
+    writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFF8);  // force idle
+    clearIRQStatus(0x000FFFFF);
+  }
+  return ok && (response == 0x00);
+}
+
+/*
  * RF_ON - 0x16
  * This command is used to switch on the internal RF field. If enabled the TX_RFON_IRQ is
  * set after the field is switched on.

--- a/lib/PN5180/PN5180.cpp
+++ b/lib/PN5180/PN5180.cpp
@@ -409,7 +409,7 @@ bool PN5180::loadRFConfig(uint8_t txConf, uint8_t rxConf) {
 }
 
 /*
- * MFC_AUTHENTICATE - 0x1C
+ * MFC_AUTHENTICATE - 0x0C
  * MIFARE Classic authentication using the PN5180 internal Crypto1 engine.
  * Returns true if authentication succeeded (response byte == 0).
  */

--- a/lib/PN5180/PN5180.h
+++ b/lib/PN5180/PN5180.h
@@ -120,7 +120,7 @@ public:
   /* cmd 0x0a */
   uint8_t * readData(int len, uint8_t *buffer = NULL);
 
-  /* cmd 0x1C */
+  /* cmd 0x0C */
   bool mfcAuthenticate(const uint8_t *key, uint8_t keyType, uint8_t blockNo, const uint8_t *uid);
 
   /* cmd 0x11 */

--- a/lib/PN5180/PN5180.h
+++ b/lib/PN5180/PN5180.h
@@ -120,6 +120,9 @@ public:
   /* cmd 0x0a */
   uint8_t * readData(int len, uint8_t *buffer = NULL);
 
+  /* cmd 0x1C */
+  bool mfcAuthenticate(const uint8_t *key, uint8_t keyType, uint8_t blockNo, const uint8_t *uid);
+
   /* cmd 0x11 */
   bool loadRFConfig(uint8_t txConf, uint8_t rxConf);
 

--- a/lib/PN5180/PN5180ISO14443.cpp
+++ b/lib/PN5180/PN5180ISO14443.cpp
@@ -269,41 +269,7 @@ bool PN5180ISO14443::mifareHalt() {
 
 bool PN5180ISO14443::mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t *key,
                                         const uint8_t *uid, uint8_t uidLen) {
-	uint8_t cmd[12];
-	cmd[0] = keyType;
-	cmd[1] = blockNo;
-	memcpy(&cmd[2], key, 6);
-	memcpy(&cmd[8], uid, 4);
-
-	writeRegisterWithOrMask(SYSTEM_CONFIG, 0x00000040);
-	clearIRQStatus(0x000FFFFF);
-
-	if (!sendData(cmd, 12, 0x00)) {
-		writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFBF);
-		writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFF8);
-		clearIRQStatus(0x000FFFFF);
-		return false;
-	}
-
-	bool rxReceived = false;
-	bool errorSeen = false;
-	for (int i = 0; i < 150; i++) {
-		uint32_t irq = getIRQStatus();
-		if (irq & GENERAL_ERROR_IRQ_STAT) { errorSeen = true; break; }
-		if (irq & RX_IRQ_STAT) { rxReceived = true; break; }
-		delay(1);
-	}
-
-	clearIRQStatus(0x000FFFFF);
-
-	if (!rxReceived || errorSeen) {
-		writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFBF);
-		writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFF8);
-		clearIRQStatus(0x000FFFFF);
-		return false;
-	}
-
-	return true;
+	return mfcAuthenticate(key, keyType, blockNo, uid);
 }
 
 uint8_t PN5180ISO14443::readCardSerial(uint8_t *buffer) {

--- a/lib/PN5180/PN5180ISO14443.cpp
+++ b/lib/PN5180/PN5180ISO14443.cpp
@@ -269,7 +269,9 @@ bool PN5180ISO14443::mifareHalt() {
 
 bool PN5180ISO14443::mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t *key,
                                         const uint8_t *uid, uint8_t uidLen) {
-	return mfcAuthenticate(key, keyType, blockNo, uid);
+	if (uidLen < 4) return false;
+	// MIFARE Classic auth uses last 4 bytes of UID (matters for 7-byte UIDs)
+	return mfcAuthenticate(key, keyType, blockNo, uid + (uidLen - 4));
 }
 
 uint8_t PN5180ISO14443::readCardSerial(uint8_t *buffer) {

--- a/lib/PN5180/PN5180ISO14443.cpp
+++ b/lib/PN5180/PN5180ISO14443.cpp
@@ -267,6 +267,45 @@ bool PN5180ISO14443::mifareHalt() {
 	return true;
 }
 
+bool PN5180ISO14443::mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t *key,
+                                        const uint8_t *uid, uint8_t uidLen) {
+	uint8_t cmd[12];
+	cmd[0] = keyType;
+	cmd[1] = blockNo;
+	memcpy(&cmd[2], key, 6);
+	memcpy(&cmd[8], uid, 4);
+
+	writeRegisterWithOrMask(SYSTEM_CONFIG, 0x00000040);
+	clearIRQStatus(0x000FFFFF);
+
+	if (!sendData(cmd, 12, 0x00)) {
+		writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFBF);
+		writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFF8);
+		clearIRQStatus(0x000FFFFF);
+		return false;
+	}
+
+	bool rxReceived = false;
+	bool errorSeen = false;
+	for (int i = 0; i < 150; i++) {
+		uint32_t irq = getIRQStatus();
+		if (irq & GENERAL_ERROR_IRQ_STAT) { errorSeen = true; break; }
+		if (irq & RX_IRQ_STAT) { rxReceived = true; break; }
+		delay(1);
+	}
+
+	clearIRQStatus(0x000FFFFF);
+
+	if (!rxReceived || errorSeen) {
+		writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFBF);
+		writeRegisterWithAndMask(SYSTEM_CONFIG, 0xFFFFFFF8);
+		clearIRQStatus(0x000FFFFF);
+		return false;
+	}
+
+	return true;
+}
+
 uint8_t PN5180ISO14443::readCardSerial(uint8_t *buffer) {
 
     uint8_t response[10];

--- a/lib/PN5180/PN5180ISO14443.h
+++ b/lib/PN5180/PN5180ISO14443.h
@@ -39,6 +39,8 @@ public:
   uint8_t mifareBlockWrite16(uint8_t blockno, uint8_t *buffer);
   bool mifareBlockWrite4(uint8_t pageno, const uint8_t *data);
   bool mifareHalt();
+  bool mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t *key,
+                          const uint8_t *uid, uint8_t uidLen);
   /*
    * Helper functions
    */

--- a/lib/bambutag/BambuKeyDeriver.cpp
+++ b/lib/bambutag/BambuKeyDeriver.cpp
@@ -1,0 +1,63 @@
+#include "BambuKeyDeriver.h"
+#include <mbedtls/md.h>
+#include <cstring>
+
+static const uint8_t MASTER_KEY[16] = {
+    0x9A, 0x75, 0x9C, 0xF2, 0xC4, 0xF7, 0xCA, 0xFF,
+    0x22, 0x2C, 0xB9, 0x76, 0x9B, 0x41, 0xBC, 0x96
+};
+
+static const uint8_t CONTEXT[] = {
+    'R', 'F', 'I', 'D', '-', 'A', 0x00
+};
+static const size_t CONTEXT_LEN = 7;
+
+BambuKeys deriveBambuKeys(const uint8_t* uid, uint8_t uidLen) {
+    BambuKeys result;
+
+    // HKDF-Extract: PRK = HMAC-SHA256(salt=master_key, IKM=uid)
+    const mbedtls_md_info_t* md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    uint8_t prk[32];
+    mbedtls_md_hmac(md_info, MASTER_KEY, 16, uid, uidLen, prk);
+
+    // HKDF-Expand: generate 96 bytes (3 blocks of 32 bytes each)
+    mbedtls_md_context_t ctx;
+    mbedtls_md_init(&ctx);
+    mbedtls_md_setup(&ctx, md_info, 1);
+
+    uint8_t previous[32] = {0};
+    uint8_t T[32];
+    size_t bytes_generated = 0;
+    uint8_t counter = 1;
+
+    // Generate 3 blocks of 32 bytes each
+    for (int i = 0; i < 3; i++) {
+        mbedtls_md_hmac_starts(&ctx, prk, 32);
+
+        // Add previous output (empty for first iteration)
+        if (i > 0) {
+            mbedtls_md_hmac_update(&ctx, previous, 32);
+        }
+
+        // Add context
+        mbedtls_md_hmac_update(&ctx, CONTEXT, CONTEXT_LEN);
+
+        // Add counter byte
+        mbedtls_md_hmac_update(&ctx, &counter, 1);
+
+        mbedtls_md_hmac_finish(&ctx, T);
+
+        // Copy output (all 32 bytes for the last block, exact amount for final block)
+        size_t copy_len = (bytes_generated + 32 <= 96) ? 32 : (96 - bytes_generated);
+        memcpy(&result.keys[bytes_generated], T, copy_len);
+        bytes_generated += copy_len;
+
+        // Save T for next iteration
+        memcpy(previous, T, 32);
+        counter++;
+    }
+
+    mbedtls_md_free(&ctx);
+
+    return result;
+}

--- a/lib/bambutag/BambuKeyDeriver.h
+++ b/lib/bambutag/BambuKeyDeriver.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <cstdint>
+
+struct BambuKeys {
+    uint8_t keys[96];
+    const uint8_t* sectorKey(uint8_t sector) const { return &keys[sector * 6]; }
+    const uint8_t* blockKey(uint8_t block) const { return sectorKey(block / 4); }
+};
+
+BambuKeys deriveBambuKeys(const uint8_t* uid, uint8_t uidLen);

--- a/lib/bambutag/BambuTagParser.cpp
+++ b/lib/bambutag/BambuTagParser.cpp
@@ -1,0 +1,64 @@
+#include "BambuTagParser.h"
+#include <cstring>
+
+static uint16_t readU16LE(const uint8_t* p) {
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+static float readFloatLE(const uint8_t* p) {
+    union { uint32_t i; float f; } u;
+    u.i = (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+    return u.f;
+}
+
+static void trimString(char* str, size_t max_len) {
+    size_t len = 0;
+    while (len < max_len && str[len] != '\0') len++;
+    while (len > 0 && (str[len - 1] == ' ' || str[len - 1] == '\0')) len--;
+    str[len] = '\0';
+}
+
+bool parseBambuBlocks(const uint8_t blocks[][16], BambuTagData& out) {
+    // blocks[0] = block 1: Material variant (null-terminated ASCII, 16 bytes)
+    memcpy(out.material_variant, blocks[0], 16);
+    out.material_variant[15] = '\0';
+    trimString(out.material_variant, 15);
+
+    // blocks[1] = block 2: Filament type string (null-terminated ASCII)
+    memcpy(out.filament_type, blocks[1], 16);
+    out.filament_type[15] = '\0';
+    trimString(out.filament_type, 15);
+
+    // blocks[2] = block 4: Detailed filament specs (not parsed)
+
+    // blocks[3] = block 5: RGBA color (4 bytes at 0), weight (uint16 LE at 4), diameter (float LE at 8)
+    out.color_r = blocks[3][0];
+    out.color_g = blocks[3][1];
+    out.color_b = blocks[3][2];
+    out.color_a = blocks[3][3];
+    out.weight_g = readU16LE(&blocks[3][4]);
+    out.diameter_mm = readFloatLE(&blocks[3][8]);
+
+    // blocks[4] = block 6: drying_temp (uint16 LE at 0), drying_time (uint16 LE at 2),
+    // bed_temp (uint16 LE at 4), hotend_min (uint16 LE at 6), hotend_max (uint16 LE at 8)
+    out.drying_temp = readU16LE(&blocks[4][0]);
+    out.drying_time = readU16LE(&blocks[4][2]);
+    out.bed_temp = readU16LE(&blocks[4][4]);
+    out.hotend_min = readU16LE(&blocks[4][6]);
+    out.hotend_max = readU16LE(&blocks[4][8]);
+
+    // blocks[5] = block 13: Production date (null-terminated ASCII)
+    memcpy(out.production_date, blocks[5], 16);
+    out.production_date[19] = '\0';
+    trimString(out.production_date, 19);
+
+    // blocks[6] = block 14: Filament length (uint16 LE at offset 0, in meters)
+    out.filament_length_m = readU16LE(&blocks[6][0]);
+
+    // blocks[7] = block 16: Extended color data (raw 16 bytes)
+    memcpy(out.color_extended, blocks[7], 16);
+
+    out.valid = (out.filament_type[0] != '\0');
+
+    return true;
+}

--- a/lib/bambutag/BambuTagParser.cpp
+++ b/lib/bambutag/BambuTagParser.cpp
@@ -6,9 +6,10 @@ static uint16_t readU16LE(const uint8_t* p) {
 }
 
 static float readFloatLE(const uint8_t* p) {
-    union { uint32_t i; float f; } u;
-    u.i = (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
-    return u.f;
+    uint32_t bits = (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+    float val;
+    memcpy(&val, &bits, sizeof(float));
+    return val;
 }
 
 static void trimString(char* str, size_t max_len) {
@@ -39,9 +40,8 @@ bool parseBambuBlocks(const uint8_t blocks[][16], BambuTagData& out) {
     out.weight_g = readU16LE(&blocks[3][4]);
     out.diameter_mm = readFloatLE(&blocks[3][8]);
 
-    // blocks[4] = block 6: layout from raw data analysis
-    // [0-1] drying_temp, [2-3] drying_time, [4-7] reserved,
-    // [8-9] hotend_max, [10-11] hotend_min
+    // blocks[4] = block 6: [0-1] drying_temp, [2-3] drying_time, [4-5] bed_temp,
+    // [6-7] unused, [8-9] hotend_max, [10-11] hotend_min
     out.drying_temp = readU16LE(&blocks[4][0]);
     out.drying_time = readU16LE(&blocks[4][2]);
     out.bed_temp = readU16LE(&blocks[4][4]);

--- a/lib/bambutag/BambuTagParser.cpp
+++ b/lib/bambutag/BambuTagParser.cpp
@@ -39,21 +39,22 @@ bool parseBambuBlocks(const uint8_t blocks[][16], BambuTagData& out) {
     out.weight_g = readU16LE(&blocks[3][4]);
     out.diameter_mm = readFloatLE(&blocks[3][8]);
 
-    // blocks[4] = block 6: drying_temp (uint16 LE at 0), drying_time (uint16 LE at 2),
-    // bed_temp (uint16 LE at 4), hotend_min (uint16 LE at 6), hotend_max (uint16 LE at 8)
+    // blocks[4] = block 6: layout from raw data analysis
+    // [0-1] drying_temp, [2-3] drying_time, [4-7] reserved,
+    // [8-9] hotend_max, [10-11] hotend_min
     out.drying_temp = readU16LE(&blocks[4][0]);
     out.drying_time = readU16LE(&blocks[4][2]);
     out.bed_temp = readU16LE(&blocks[4][4]);
-    out.hotend_min = readU16LE(&blocks[4][6]);
     out.hotend_max = readU16LE(&blocks[4][8]);
+    out.hotend_min = readU16LE(&blocks[4][10]);
 
     // blocks[5] = block 13: Production date (null-terminated ASCII)
     memcpy(out.production_date, blocks[5], 16);
     out.production_date[19] = '\0';
     trimString(out.production_date, 19);
 
-    // blocks[6] = block 14: Filament length (uint16 LE at offset 0, in meters)
-    out.filament_length_m = readU16LE(&blocks[6][0]);
+    // blocks[6] = block 14: Filament length (uint16 LE at offset 4, in meters)
+    out.filament_length_m = readU16LE(&blocks[6][4]);
 
     // blocks[7] = block 16: Extended color data (raw 16 bytes)
     memcpy(out.color_extended, blocks[7], 16);

--- a/lib/bambutag/BambuTagParser.h
+++ b/lib/bambutag/BambuTagParser.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <cstdint>
+
+struct BambuTagData {
+    bool valid = false;
+    char material_variant[16] = {};
+    char filament_type[16] = {};
+    uint8_t color_r = 0, color_g = 0, color_b = 0, color_a = 0;
+    uint16_t weight_g = 0;
+    float diameter_mm = 0.0f;
+    uint16_t drying_temp = 0;
+    uint16_t drying_time = 0;
+    uint16_t bed_temp = 0;
+    uint16_t hotend_min = 0;
+    uint16_t hotend_max = 0;
+    char production_date[20] = {};
+    uint32_t filament_length_m = 0;
+    uint8_t color_extended[16] = {};
+};
+
+static constexpr uint8_t BAMBU_BLOCKS[] = { 1, 2, 4, 5, 6, 13, 14, 16 };
+static constexpr uint8_t BAMBU_BLOCK_COUNT = 8;
+
+bool parseBambuBlocks(const uint8_t blocks[][16], BambuTagData& out);

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -442,7 +442,7 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
         if (strcmp(s.tag_format, "OpenPrintTag") == 0) spool.tagType = 1;
         else if (strcmp(s.tag_format, "TigerTag") == 0) spool.tagType = 2;
         else if (strcmp(s.tag_format, "OpenTag3D") == 0) spool.tagType = 3;
-        else if (strcmp(s.tag_format, "BambuTag") == 0) spool.tagType = 4;
+        else if (strcmp(s.tag_format, "bambu") == 0) spool.tagType = 4;
         else if (strcmp(s.tag_format, "OpenSpool") == 0) spool.tagType = 6;
         else spool.tagType = 0;
         display_->showSpool(spool);

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -512,6 +512,7 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
             f.min_print_temp = bambuData.hotend_min;
             f.max_print_temp = bambuData.hotend_max;
             f.min_bed_temp = bambuData.bed_temp;
+            f.max_bed_temp = bambuData.bed_temp;
             f.diameter_mm = bambuData.diameter_mm;
             f.filament_length_m = bambuData.filament_length_m;
         }

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -481,7 +481,7 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
         f.tag_data_valid = true;
         f.tag_format = "unknown";
 #ifndef NATIVE_TEST
-        CurrentSpoolState spoolState;
+        CurrentSpoolState spoolState = {};
         if (NFCManager::getInstance().getCurrentSpoolState(spoolState))
             f.tag_format = tagKindToMqttFormat(spoolState.kind);
 #endif
@@ -499,6 +499,23 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
         f.max_bed_temp = s.max_bed_temp;
         f.density = s.density;
         f.diameter_mm = s.diameter;
+
+#ifndef NATIVE_TEST
+        BambuTagData bambuData;
+        if (spoolState.kind == TagKind::BambuTag && NFCManager::getInstance().getLastBambuTagData(bambuData)) {
+            strncpy(f.material_name, bambuData.filament_type, sizeof(f.material_name) - 1);
+            strncpy(f.material_type, bambuData.filament_type, sizeof(f.material_type) - 1);
+            snprintf(f.color, sizeof(f.color), "#%02X%02X%02X",
+                     bambuData.color_r, bambuData.color_g, bambuData.color_b);
+            f.initial_weight_g = bambuData.weight_g;
+            f.remaining_g = bambuData.weight_g;
+            f.min_print_temp = bambuData.hotend_min;
+            f.max_print_temp = bambuData.hotend_max;
+            f.min_bed_temp = bambuData.bed_temp;
+            f.diameter_mm = bambuData.diameter_mm;
+            f.filament_length_m = bambuData.filament_length_m;
+        }
+#endif
 
         char json[512];
         buildTagStateJson(json, sizeof(json), f);

--- a/src/ConversionUtils.cpp
+++ b/src/ConversionUtils.cpp
@@ -77,7 +77,7 @@ const char* tagKindToMqttFormat(TagKind kind) {
         case TagKind::OpenTag3D:    return "opentag3d";
         case TagKind::OpenSpoolTag: return "openspool";
         case TagKind::GenericUidTag: return "uid_only";
-        case TagKind::BambuTag:     return "uid_only";
+        case TagKind::BambuTag:     return "bambu";
         default:                    return "unknown";
     }
 }

--- a/src/HardwareNFCConnection.cpp
+++ b/src/HardwareNFCConnection.cpp
@@ -500,6 +500,16 @@ void HardwareNFCConnection::logDiagnostics() {
     #endif
 }
 
+bool HardwareNFCConnection::mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t* key) {
+    if (!iso14443a_) return false;
+    return iso14443a_->mifareAuthenticate(blockNo, keyType, key, currentUid_, 4);
+}
+
+bool HardwareNFCConnection::mifareClassicRead(uint8_t blockNo, uint8_t* buffer) {
+    if (!iso14443a_) return false;
+    return iso14443a_->mifareBlockRead(blockNo, buffer);
+}
+
 bool HardwareNFCConnection::ntagGetVersion(uint8_t* versionOut) {
     // Returns cached version from detectTag() — GET_VERSION must be sent while the tag
     // is in ACTIVE state (after SELECT, before HALT). Can't send it here because the

--- a/src/HardwareNFCConnection.h
+++ b/src/HardwareNFCConnection.h
@@ -26,6 +26,8 @@ public:
     uint8_t getLastSAK() const override { return lastSAK_; }
     uint16_t getLastATQA() const override { return lastATQA_; }
     bool ntagGetVersion(uint8_t* versionOut) override;
+    bool mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t* key) override;
+    bool mifareClassicRead(uint8_t blockNo, uint8_t* buffer) override;
     void getReaderInfo(char* buf, size_t len) const override;
     // Diagnostics: log RF_STATUS, IRQ_STATUS, SYSTEM_STATUS registers
     void logDiagnostics() override;

--- a/src/HardwareNFCConnectionPN532.cpp
+++ b/src/HardwareNFCConnectionPN532.cpp
@@ -218,6 +218,18 @@ void HardwareNFCConnectionPN532::logDiagnostics() {
     }
 }
 
+bool HardwareNFCConnectionPN532::mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t* key) {
+    if (!pn532_ || !ready_) return false;
+    uint8_t keyNumber = (keyType == 0x61) ? 1 : 0;
+    return pn532_->mifareclassic_AuthenticateBlock(
+        currentUid_, currentUidLen_, blockNo, keyNumber, const_cast<uint8_t*>(key));
+}
+
+bool HardwareNFCConnectionPN532::mifareClassicRead(uint8_t blockNo, uint8_t* buffer) {
+    if (!pn532_ || !ready_) return false;
+    return pn532_->mifareclassic_ReadDataBlock(blockNo, buffer);
+}
+
 bool HardwareNFCConnectionPN532::ntagGetVersion(uint8_t* versionOut) {
     if (!pn532_ || !ready_ || !versionOut) return false;
 

--- a/src/HardwareNFCConnectionPN532.h
+++ b/src/HardwareNFCConnectionPN532.h
@@ -19,6 +19,8 @@ public:
     uint8_t getLastSAK() const override { return lastSAK_; }
     uint16_t getLastATQA() const override { return lastATQA_; }
     bool ntagGetVersion(uint8_t* versionOut) override;
+    bool mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t* key) override;
+    bool mifareClassicRead(uint8_t blockNo, uint8_t* buffer) override;
     void setCurrentUid(const uint8_t* uid, uint8_t length) override;
     opt_nfc_hal_t* getHal() override;
     // keepSession is ignored: PN532 manages tag activation per-page via reactivateTag()

--- a/src/NFCConnectionI.h
+++ b/src/NFCConnectionI.h
@@ -30,6 +30,12 @@ public:
     // NTAG GET_VERSION (0x60) — returns 8-byte version info for NTAG/Ultralight EV1.
     virtual bool ntagGetVersion(uint8_t* versionOut) { return false; }
 
+    // MIFARE Classic authentication. keyType: 0x60=Key A, 0x61=Key B.
+    virtual bool mifareAuthenticate(uint8_t blockNo, uint8_t keyType, const uint8_t* key) { return false; }
+
+    // Read a single MIFARE Classic 16-byte block (requires prior authentication).
+    virtual bool mifareClassicRead(uint8_t blockNo, uint8_t* buffer) { return false; }
+
     // Set current UID for addressed read/write commands
     virtual void setCurrentUid(const uint8_t* uid, uint8_t length) = 0;
 

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -515,11 +515,12 @@ void NFCManager::handleNewTag(uint8_t* uid, uint8_t uidLength) {
                           bambuData.color_r, bambuData.color_g, bambuData.color_b);
             LogBuffer::getInstance().logPrintf("Bambu: %s %ug\n",
                           bambuData.filament_type, bambuData.weight_g);
+            sendBambuDetectedMessage();
         } else {
             Serial.printf("NFCManager: Bambu tag — UID=%s (auth failed, no data)\n", scan.uid_hex);
             LogBuffer::getInstance().logPrintf("Bambu tag: %s (no data)\n", scan.uid_hex);
+            sendGenericTagMessage();
         }
-        sendGenericTagMessage();
         return;
     }
 
@@ -968,6 +969,49 @@ void NFCManager::sendSpoolDetectedMessage(bool suppress_spoolman_sync) {
             s.primary_color[0], s.primary_color[1], s.primary_color[2],
             s.kg_remaining * 1000.0f);
     }
+
+    ApplicationManager::getInstance().sendMessage(msg);
+}
+
+void NFCManager::sendBambuDetectedMessage() {
+    if (!lastBambuTagValid_) return;
+
+    const BambuTagData& bt = lastBambuTag_;
+    AppMessage msg;
+    msg.type = AppMessageType::SPOOL_DETECTED;
+    memset(&msg.payload.spoolDetected, 0, sizeof(msg.payload.spoolDetected));
+
+    strncpy(msg.payload.spoolDetected.spool_id, currentSpool.spool_id,
+            sizeof(msg.payload.spoolDetected.spool_id) - 1);
+
+    msg.payload.spoolDetected.material_type = materialTypeFromString(bt.filament_type);
+    strncpy(msg.payload.spoolDetected.material_name, bt.filament_type,
+            sizeof(msg.payload.spoolDetected.material_name) - 1);
+
+    msg.payload.spoolDetected.primary_color[0] = bt.color_r;
+    msg.payload.spoolDetected.primary_color[1] = bt.color_g;
+    msg.payload.spoolDetected.primary_color[2] = bt.color_b;
+    msg.payload.spoolDetected.has_color = true;
+
+    msg.payload.spoolDetected.kg_remaining = bt.weight_g / 1000.0f;
+    msg.payload.spoolDetected.initial_weight_g = bt.weight_g;
+    msg.payload.spoolDetected.diameter = bt.diameter_mm;
+    msg.payload.spoolDetected.min_print_temp = bt.hotend_min;
+    msg.payload.spoolDetected.max_print_temp = bt.hotend_max;
+    msg.payload.spoolDetected.min_bed_temp = bt.bed_temp;
+    msg.payload.spoolDetected.dry_temp = bt.drying_temp;
+    msg.payload.spoolDetected.dry_time_hours = bt.drying_time;
+    msg.payload.spoolDetected.spoolman_id = -1;
+
+    strncpy(msg.payload.spoolDetected.tag_format, "bambu",
+            sizeof(msg.payload.spoolDetected.tag_format) - 1);
+
+    Serial.printf("--- BambuDetected payload ---\n");
+    Serial.printf("  uid:      %s\n", msg.payload.spoolDetected.spool_id);
+    Serial.printf("  material: %s\n", bt.filament_type);
+    Serial.printf("  color:    #%02X%02X%02X\n", bt.color_r, bt.color_g, bt.color_b);
+    Serial.printf("  weight:   %ug  diameter: %.2fmm\n", bt.weight_g, bt.diameter_mm);
+    Serial.printf("-----------------------------\n");
 
     ApplicationManager::getInstance().sendMessage(msg);
 }
@@ -2424,6 +2468,10 @@ bool NFCManager::readBambuTag(const uint8_t* uid, uint8_t uidLength, BambuTagDat
         if (!connection_->mifareClassicRead(blockNo, blocks[i])) {
             Serial.printf("NFCManager: Bambu block read failed on block %d\n", blockNo);
             memset(blocks[i], 0, 16);
+        } else {
+            Serial.printf("NFCManager: Bambu block %d: ", blockNo);
+            for (int b = 0; b < 16; b++) Serial.printf("%02X ", blocks[i][b]);
+            Serial.println();
         }
     }
 

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -2414,6 +2414,7 @@ bool NFCManager::readBambuTag(const uint8_t* uid, uint8_t uidLength, BambuTagDat
         if (sector != lastAuthSector) {
             if (!connection_->mifareAuthenticate(blockNo, 0x60, keys.blockKey(blockNo))) {
                 Serial.printf("NFCManager: Bambu auth failed on block %d (sector %d)\n", blockNo, sector);
+                LogBuffer::getInstance().logPrintf("Bambu auth fail blk %d sec %d\n", blockNo, sector);
                 if (i == 0) return false;
                 continue;
             }

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -2,6 +2,8 @@
 #include "ConversionUtils.h"
 #include "TigerTagParser.h"
 #include "OpenSpoolParser.h"
+#include "BambuKeyDeriver.h"
+#include "BambuTagParser.h"
 #ifndef NATIVE_TEST
   #include "ApplicationManager.h"
   #include "HardwareNFCConnection.h"
@@ -119,6 +121,15 @@ bool NFCManager::getLastOpenSpoolData(OpenSpoolData& out) {
     if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(50)) != pdTRUE) return false;
     bool valid = lastOpenSpoolValid_;
     if (valid) out = lastOpenSpool_;
+    xSemaphoreGive(tagMutex);
+    return valid;
+}
+
+bool NFCManager::getLastBambuTagData(BambuTagData& out) {
+    if (tagMutex == nullptr) return false;
+    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(50)) != pdTRUE) return false;
+    bool valid = lastBambuTagValid_;
+    if (valid) out = lastBambuTag_;
     xSemaphoreGive(tagMutex);
     return valid;
 }
@@ -473,8 +484,10 @@ void NFCManager::handleNewTag(uint8_t* uid, uint8_t uidLength) {
     Serial.println("NFCManager: New spool detected, reading tag...");
     TagScanResult scan = classifyTag(uid, uidLength);
 
-    // Bambu tags use MIFARE Classic (encrypted) — we can only read the UID
     if (scan.kind == TagKind::BambuTag) {
+        BambuTagData bambuData;
+        bool readOk = readBambuTag(uid, uidLength, bambuData);
+
         if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
             memcpy(currentSpool.spool_id, scan.uid_hex, sizeof(scan.uid_hex));
             memcpy(currentSpool.uid, uid, uidLength);
@@ -483,16 +496,29 @@ void NFCManager::handleNewTag(uint8_t* uid, uint8_t uidLength) {
             currentSpool.blank_tag_present = false;
             currentSpool.kind = TagKind::BambuTag;
             currentSpool.variant = NtagVariant::Unknown;
-            currentSpool.tag_data_valid = false;
+            currentSpool.tag_data_valid = readOk;
+            lastBambuTagValid_ = readOk;
+            if (readOk) lastBambuTag_ = bambuData;
             lastTigerTagValid_ = false;
-            memcpy(lastSeenUid, uid, uidLength);  // dedup: don't re-read same tag next cycle
+            lastOpenTag3DValid_ = false;
+            lastOpenSpoolValid_ = false;
+            memcpy(lastSeenUid, uid, uidLength);
             lastSeenUidLength = uidLength;
             lastSeenValid = true;
             lastSeenMs = millis();
             xSemaphoreGive(tagMutex);
         }
-        Serial.printf("NFCManager: Bambu Lab tag — UID=%s (encrypted, no data access)\n", scan.uid_hex);
-        LogBuffer::getInstance().logPrintf("Bambu Lab tag: %s (encrypted)\n", scan.uid_hex);
+
+        if (readOk) {
+            Serial.printf("NFCManager: Bambu tag — %s, %ug, #%02X%02X%02X\n",
+                          bambuData.filament_type, bambuData.weight_g,
+                          bambuData.color_r, bambuData.color_g, bambuData.color_b);
+            LogBuffer::getInstance().logPrintf("Bambu: %s %ug\n",
+                          bambuData.filament_type, bambuData.weight_g);
+        } else {
+            Serial.printf("NFCManager: Bambu tag — UID=%s (auth failed, no data)\n", scan.uid_hex);
+            LogBuffer::getInstance().logPrintf("Bambu tag: %s (no data)\n", scan.uid_hex);
+        }
         sendGenericTagMessage();
         return;
     }
@@ -2374,4 +2400,31 @@ void NFCManager::updateRecentSpoolSyncStatus(const char* spool_id, bool synced) 
 bool NFCManager::isWriteQueueEmpty() const {
     if (!writeQueue) return true;
     return uxQueueMessagesWaiting(writeQueue) == 0;
+}
+
+bool NFCManager::readBambuTag(const uint8_t* uid, uint8_t uidLength, BambuTagData& out) {
+    BambuKeys keys = deriveBambuKeys(uid, uidLength);
+    uint8_t blocks[BAMBU_BLOCK_COUNT][16];
+    uint8_t lastAuthSector = 0xFF;
+
+    for (uint8_t i = 0; i < BAMBU_BLOCK_COUNT; i++) {
+        uint8_t blockNo = BAMBU_BLOCKS[i];
+        uint8_t sector = blockNo / 4;
+
+        if (sector != lastAuthSector) {
+            if (!connection_->mifareAuthenticate(blockNo, 0x60, keys.blockKey(blockNo))) {
+                Serial.printf("NFCManager: Bambu auth failed on block %d (sector %d)\n", blockNo, sector);
+                if (i == 0) return false;
+                continue;
+            }
+            lastAuthSector = sector;
+        }
+
+        if (!connection_->mifareClassicRead(blockNo, blocks[i])) {
+            Serial.printf("NFCManager: Bambu block read failed on block %d\n", blockNo);
+            memset(blocks[i], 0, 16);
+        }
+    }
+
+    return parseBambuBlocks(blocks, out);
 }

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -146,6 +146,7 @@ private:
     bool executeOpenSpoolWrite(const NFCWriteRequest& request);
     bool executeAtomicWrite(const NFCWriteRequest& request);
     bool readBambuTag(const uint8_t* uid, uint8_t uidLength, BambuTagData& out);
+    void sendBambuDetectedMessage();
     void forceRescan();
     void sendSpoolUpdatedMessage(uint32_t request_id, NFCWriteType type, bool success);
 

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -14,6 +14,7 @@
 #include "TigerTagParser.h"
 #include "OpenSpoolParser.h"
 #include "opentag3d_lib.h"
+#include "BambuTagParser.h"
 
 // Sidecar for WRITE_ATOMIC: filled by HTTP handler, consumed by scan task.
 // All fields are optional — only those with has_* = true are applied.
@@ -77,6 +78,7 @@ public:
     bool getLastTigerTagData(TigerTagData& out);
     bool getLastOpenTag3DData(opentag3d_t& out);
     bool getLastOpenSpoolData(OpenSpoolData& out);
+    bool getLastBambuTagData(BambuTagData& out);
     // Returns reader identification string (e.g. "PN5180 v3.4", "PN532 v1.6")
     bool getNfcReaderInfo(char* buf, size_t len) const;
     void pauseScanTask();
@@ -143,6 +145,7 @@ private:
     bool executeOpenTag3DWrite(const NFCWriteRequest& request);
     bool executeOpenSpoolWrite(const NFCWriteRequest& request);
     bool executeAtomicWrite(const NFCWriteRequest& request);
+    bool readBambuTag(const uint8_t* uid, uint8_t uidLength, BambuTagData& out);
     void forceRescan();
     void sendSpoolUpdatedMessage(uint32_t request_id, NFCWriteType type, bool success);
 
@@ -173,6 +176,8 @@ private:
     bool lastOpenTag3DValid_ = false;
     OpenSpoolData lastOpenSpool_;
     bool lastOpenSpoolValid_ = false;
+    BambuTagData lastBambuTag_;
+    bool lastBambuTagValid_ = false;
 
     // Resolved Spoolman data for the current generic UID tag
     GenericTagSpoolInfo lastGenericTagSpoolInfo_ = {};

--- a/src/ReaderHTML.h
+++ b/src/ReaderHTML.h
@@ -206,6 +206,32 @@ const char READER_HTML[] PROGMEM = R"rawliteral(
       return html;
     }
 
+    function renderBambu(s) {
+      var t = s.bambu || {};
+      var html = '';
+      html += row('Format', 'Bambu Lab');
+      html += row('UID', s.uid || '&mdash;');
+      if (t.filament_type) html += row('Filament', t.filament_type);
+      if (t.material_variant) html += row('Variant', t.material_variant);
+      if (t.color_hex) html += row('Color', colorValue(t.color_hex));
+      if (t.weight_g !== undefined) html += row('Weight', t.weight_g + ' g');
+      if (t.diameter_mm) html += row('Diameter', t.diameter_mm + ' mm');
+      if (t.hotend_min && t.hotend_max) html += row('Nozzle Temp', t.hotend_min + ' \u2013 ' + t.hotend_max + ' \u00B0C');
+      if (t.bed_temp) html += row('Bed Temp', t.bed_temp + ' \u00B0C');
+      if (t.drying_temp) html += row('Dry', t.drying_temp + ' \u00B0C / ' + (t.drying_time || '?') + ' hrs');
+      if (t.production_date) html += row('Produced', t.production_date);
+      if (t.filament_length_m) html += row('Filament Length', t.filament_length_m + ' m');
+      if (s.spoolman) {
+        if (s.spoolman.remaining_g !== undefined) {
+          html += row('Remaining', s.spoolman.remaining_g.toFixed(1) + ' g' + spoolmanBadge());
+        }
+        if (s.spoolman.spool_id !== undefined && s.spoolman.spool_id > 0) {
+          html += row('Spoolman ID', '#' + s.spoolman.spool_id + spoolmanBadge());
+        }
+      }
+      return html;
+    }
+
     function renderGenericUid(s) {
       var html = '';
       html += row('Format', tagKindLabel(s.tag_kind));
@@ -347,6 +373,8 @@ const char READER_HTML[] PROGMEM = R"rawliteral(
         html = renderOpenTag3D(s);
       } else if (kind === 'OpenSpoolTag' && s.openspool) {
         html = renderOpenSpool(s);
+      } else if (kind === 'BambuTag' && s.bambu) {
+        html = renderBambu(s);
       } else if (kind === 'OpenPrintTag' || (s.tag_data_valid && !kind)) {
         html = renderOpenPrintTag(s);
       } else {

--- a/src/TagStateJson.h
+++ b/src/TagStateJson.h
@@ -27,6 +27,7 @@ struct TagStateFields {
     int16_t max_bed_temp;
     float density;
     float diameter_mm;
+    uint32_t filament_length_m;
 };
 
 // Build full tag state JSON. Optional temp/density/diameter fields included only when non-zero.
@@ -50,8 +51,9 @@ inline size_t buildTagStateJson(char* out, size_t outSize, const TagStateFields&
     if (f.max_print_temp != 0) doc["max_print_temp"] = f.max_print_temp;
     if (f.min_bed_temp != 0)   doc["min_bed_temp"] = f.min_bed_temp;
     if (f.max_bed_temp != 0)   doc["max_bed_temp"] = f.max_bed_temp;
-    if (f.density > 0.0f)      doc["density"] = f.density;
-    if (f.diameter_mm > 0.0f)  doc["diameter_mm"] = f.diameter_mm;
+    if (f.density > 0.0f)           doc["density"] = f.density;
+    if (f.diameter_mm > 0.0f)       doc["diameter_mm"] = f.diameter_mm;
+    if (f.filament_length_m > 0)    doc["filament_length_m"] = f.filament_length_m;
 
     return serializeJson(doc, out, outSize);
 }

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -34,6 +34,7 @@
 #include "ApplicationManager.h"
 #include "ConversionUtils.h"
 #include "TigerTagParser.h"
+#include "BambuTagParser.h"
 #include "HomeAssistantManager.h"
 #include "SpoolmanManager.h"
 #include "DisplayI.h"
@@ -1129,6 +1130,29 @@ void WebServerManager::serializeOpenSpoolStatus(JsonDocument& doc) {
     if (os.max_temp > 0) obj["max_temp"] = os.max_temp;
 }
 
+void WebServerManager::serializeBambuTagStatus(JsonDocument& doc) {
+    BambuTagData bt;
+    if (!NFCManager::getInstance().getLastBambuTagData(bt) || !bt.valid) return;
+
+    JsonObject obj = doc.createNestedObject("bambu");
+    obj["filament_type"] = bt.filament_type;
+    obj["material_variant"] = bt.material_variant;
+
+    char colorHex[8];
+    snprintf(colorHex, sizeof(colorHex), "#%02X%02X%02X", bt.color_r, bt.color_g, bt.color_b);
+    obj["color_hex"] = colorHex;
+
+    obj["weight_g"] = bt.weight_g;
+    if (bt.diameter_mm > 0.0f) obj["diameter_mm"] = bt.diameter_mm;
+    if (bt.hotend_min > 0) obj["hotend_min"] = bt.hotend_min;
+    if (bt.hotend_max > 0) obj["hotend_max"] = bt.hotend_max;
+    if (bt.bed_temp > 0) obj["bed_temp"] = bt.bed_temp;
+    if (bt.drying_temp > 0) obj["drying_temp"] = bt.drying_temp;
+    if (bt.drying_time > 0) obj["drying_time"] = bt.drying_time;
+    if (bt.production_date[0]) obj["production_date"] = bt.production_date;
+    if (bt.filament_length_m > 0) obj["filament_length_m"] = bt.filament_length_m;
+}
+
 void WebServerManager::serializeGenericUidStatus(JsonDocument& doc) {
     GenericTagSpoolInfo spoolInfo;
     NFCManager::getInstance().getGenericTagSpoolInfo(spoolInfo);
@@ -1235,7 +1259,7 @@ void WebServerManager::handleApiStatus() {
             case TagKind::OpenTag3D:    serializeOpenTag3DStatus(doc); break;
             case TagKind::OpenSpoolTag: serializeOpenSpoolStatus(doc); break;
             case TagKind::GenericUidTag: serializeGenericUidStatus(doc); break;
-            case TagKind::BambuTag:     break;
+            case TagKind::BambuTag:     serializeBambuTagStatus(doc); break;
             default:                    serializeOpenPrintTagStatus(doc, state); break;
         }
 

--- a/src/WebServerManager.h
+++ b/src/WebServerManager.h
@@ -92,6 +92,7 @@ private:
     void serializeTigerTagStatus(JsonDocument& doc);
     void serializeOpenTag3DStatus(JsonDocument& doc);
     void serializeOpenSpoolStatus(JsonDocument& doc);
+    void serializeBambuTagStatus(JsonDocument& doc);
     void serializeGenericUidStatus(JsonDocument& doc);
     void serializeOpenPrintTagStatus(JsonDocument& doc, const CurrentSpoolState& state);
     void serializeEnrichment(JsonDocument& doc);


### PR DESCRIPTION
## Summary
- Read encrypted Bambu Lab MIFARE Classic filament tags on PN5180 (PN532 wrappers included, untested)
- HKDF key derivation (HMAC-SHA256 via mbedtls) derives per-tag sector keys from UID
- Reads 8 data blocks: material, filament type, color, weight, diameter, temps, production date, filament length
- Full pipeline: TFT display (Bambu green label), web reader page, MQTT/HA publishing, Spoolman sync

## Implementation
- `lib/bambutag/BambuKeyDeriver` — HKDF-Extract + Expand, 96 bytes of key material
- `lib/bambutag/BambuTagParser` — Decodes raw 16-byte blocks into `BambuTagData` struct
- `lib/PN5180/PN5180::mfcAuthenticate()` — Host command 0x0C with 1-byte response
- `src/NFCConnectionI` — Virtual `mifareAuthenticate()` + `mifareClassicRead()` on both readers
- `src/NFCManager::readBambuTag()` — Key derivation, per-sector auth, block reads, parsing
- `src/NFCManager::sendBambuDetectedMessage()` — Dedicated payload builder (not reusing OPT path)
- `src/WebServerManager::serializeBambuTagStatus()` — `/api/status` JSON serialization
- `src/ReaderHTML.h` — `renderBambu()` display function

## Hardware tested
- PN5180 + ESP32-S3-DevKitC-1 against Bambu Lab PLA spool tag (UID: D3D54539)
- All 8 blocks read successfully: PLA, A01-Y3, #E8DBB7, 1000g, 1.75mm, 190-230°C nozzle, 55°C/8hr dry, 315m filament
- NTAG/OpenTag3D regression test: pass

## Known limitations
- PN532 path compiled but not hardware tested (no PN532 + MIFARE Classic tag available)
- Weight field (block 5) may be factory initial — AMS may update filament length (block 14) instead. Needs a partially-used spool to confirm. Tracked in #157
- Read-only: Bambu RSA-2048 signature prevents writes

## Related
- Closes #24
- Follow-up: #157 (AMS weight sync in mixed environments)
- Follow-up: #159 (rename sendSpoolDetectedMessage tech debt)

## Test plan
- [x] Bambu PLA tag: full data read on reader page
- [x] TFT display: Bambu green label with material + color
- [x] MQTT: tag_format "bambu" with all fields
- [x] Spoolman: UID lookup + spool creation
- [x] NTAG regression: OpenTag3D tag reads correctly
- [ ] PN532 hardware test (deferred — no hardware available)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading encrypted Bambu Lab MIFARE Classic filament tags with NFC readers.
  * Enhanced tag information display to show Bambu filament properties including type, variant, color, weight, diameter, temperature ranges, drying parameters, and filament length.
  * Integrated Bambu tag data with MQTT/Home Assistant and web API status serialization.

* **Chores**
  * Updated `.gitignore` to exclude system-generated files and build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->