### PR TITLE
chore: gitignore mex backup/clone dirs and dedupe .mex/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,13 +18,14 @@ docs/superpowers/
 .mcp.json
 CODE-REVIEW.md
 .mex/
+.mex.backup-*/
+.mex.old-clone/
 test-preview/
 .gstack/
 build/
 .worktrees/
 .cocoindex_code/
 lancedb/
-.mex/
 .ragcode/
 .DS_Store
 .superpowers/


### PR DESCRIPTION
## Summary
- Add `.mex.backup-*/` to `.gitignore` — covers timestamped scaffold backups
- Add `.mex.old-clone/` to `.gitignore` — covers the renamed original mex source clone
- Remove a duplicate `.mex/` entry that had crept in

No functional changes — `.gitignore` hygiene only. Unblocks keeping local mex backups around without risk of them being committed or swept up by git operations.

## Test plan
- [x] `git status` shows backup dirs as ignored
- [x] `git check-ignore .mex.backup-2026-04-16 .mex.old-clone` returns the pattern matches
- [x] No duplicate `.mex/` line in `.gitignore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ignore additional backup and clone directories.

**Note:** This is an internal development configuration change with no impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->