### PR TITLE
refactor(#159): rename sendSpoolDetectedMessage → sendOpenPrintTagMessage

### DIFF
--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -689,7 +689,7 @@ bool NFCManager::readAndParseTag(uint8_t* uid, uint8_t uid_length) {
 
     Serial.printf("NFCManager: Parsed spool %s\n", currentSpool.spool_id);
 
-    sendSpoolDetectedMessage();
+    sendOpenPrintTagMessage();
 
     // Update dedup state
     memcpy(lastSeenUid, uid, uid_length);
@@ -801,7 +801,7 @@ bool NFCManager::formatNewSpool() {
 
                 if (queueEmpty) {
                     // No batched writes - send SpoolDetected immediately
-                    sendSpoolDetectedMessage();
+                    sendOpenPrintTagMessage();
                     Serial.println("NFCManager: formatNewSpool() complete - verified (queue empty, sent SpoolDetected)");
                 } else {
                     // Batched writes pending - set suppression flag
@@ -845,7 +845,7 @@ bool NFCManager::formatNewSpool() {
 
     if (queueEmpty) {
         // No batched writes - send SpoolDetected immediately
-        sendSpoolDetectedMessage();
+        sendOpenPrintTagMessage();
         Serial.println("NFCManager: formatNewSpool() complete - unverified (queue empty, sent SpoolDetected)");
     } else {
         // Batched writes pending - set suppression flag
@@ -859,7 +859,7 @@ bool NFCManager::formatNewSpool() {
     return true;
 }
 
-void NFCManager::sendSpoolDetectedMessage(bool suppress_spoolman_sync) {
+void NFCManager::sendOpenPrintTagMessage(bool suppress_spoolman_sync) {
     if (!currentSpool.tag_data_valid) {
         return;
     }
@@ -1535,9 +1535,9 @@ void NFCManager::processWriteQueue() {
             suppressReDetectionUid_[0] = '\0';
             batchHadSuppressSync_ = false;
 
-            // Send SpoolDetected under mutex — sendSpoolDetectedMessage reads currentSpool.tag_data
+            // Send SpoolDetected under mutex — sendOpenPrintTagMessage reads currentSpool.tag_data
             if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-                sendSpoolDetectedMessage(hadSuppressSync);
+                sendOpenPrintTagMessage(hadSuppressSync);
                 xSemaphoreGive(tagMutex);
             }
         }
@@ -1585,7 +1585,7 @@ bool NFCManager::writeRawTag() {
                 currentSpool.kind = TagKind::OpenPrintTag;
                 lastSeenValid = false;  // Force re-detection on next scan
                 addToRecentSpools();
-                sendSpoolDetectedMessage();
+                sendOpenPrintTagMessage();
                 xSemaphoreGive(tagMutex);
 
                 rawWritePending_ = false;
@@ -1618,7 +1618,7 @@ bool NFCManager::writeRawTag() {
     currentSpool.kind = TagKind::OpenPrintTag;
     lastSeenValid = false;
     addToRecentSpools();
-    sendSpoolDetectedMessage();
+    sendOpenPrintTagMessage();
     xSemaphoreGive(tagMutex);
 
     rawWritePending_ = false;
@@ -1964,7 +1964,7 @@ bool NFCManager::executeAtomicWrite(const NFCWriteRequest& request) {
     currentSpool.blank_tag_present = false;
     currentSpool.kind = TagKind::OpenPrintTag;
     addToRecentSpools();
-    sendSpoolDetectedMessage();
+    sendOpenPrintTagMessage();
     xSemaphoreGive(tagMutex);
 
     Serial.println("NFCManager: WRITE_ATOMIC complete");
@@ -2071,7 +2071,7 @@ bool NFCManager::executeWrite(const NFCWriteRequest& request) {
                 currentSpool.kind = TagKind::OpenPrintTag;
                 lastSeenValid = false;
                 addToRecentSpools();
-                sendSpoolDetectedMessage();
+                sendOpenPrintTagMessage();
                 xSemaphoreGive(tagMutex);
                 return true;
             }

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -130,7 +130,7 @@ private:
                               uint8_t* outBuf, uint16_t outBufSize);
     bool formatNewSpool();
     TagScanResult classifyTag(const uint8_t* uid, uint8_t uid_length);
-    void sendSpoolDetectedMessage(bool suppress_spoolman_sync = false);
+    void sendOpenPrintTagMessage(bool suppress_spoolman_sync = false);
     void sendBlankTagMessage();
     void sendGenericTagMessage();
     void sendTigerTagMessage(const TigerTagData& tt);


### PR DESCRIPTION
Closes #159.

## Summary
- Renames `NFCManager::sendSpoolDetectedMessage` → `sendOpenPrintTagMessage` to reflect its actual scope (OpenPrintTag-only; uses `opt_get_*` CBOR accessors and sets `tag_format = "OpenPrintTag"`).
- 1 declaration + 1 definition + 9 call sites + 1 comment reference, all in `src/NFCManager.{h,cpp}`.
- No behavior change. Pure rename.

## Why
The old name implied it handled any spool-detection event. As we add Bambu / TigerTag / OpenSpool / OpenTag3D sender paths, the ambiguity makes the code harder to reason about. This rename makes it obvious which format the function belongs to and sets up per-format senders cleanly.

## Test plan
- [x] Builds clean on `esp32s3zero`, `esp32dev`, `esp32s3devkitc`
- [x] `review-remote` (qwen3-coder:30b) — no issues
- [x] Physical test on ESP32-S3-DevKitC: OpenPrintTag scan works (display, LED, MQTT), other tag formats still route correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements for enhanced maintainability. No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->