### PR TITLE
feat(wifi): keep-awake toggle to disable modem sleep

### DIFF
--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -96,6 +96,16 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
                 </div>
               </div>
             </div>
+            <div class="toggle-row" style="margin-top:10px">
+              <div>
+                <span class="toggle-label">Keep WiFi radio awake</span>
+                <div style="font-size:11px;color:#71717A;margin-top:4px">Disables modem sleep. Improves RSSI and response time on weak signals, uses slightly more power.</div>
+              </div>
+              <label class="toggle-switch">
+                <input type="checkbox" id="wifi_keep_awake" />
+                <span class="toggle-track"></span>
+              </label>
+            </div>
           </section>
 
           <section>
@@ -284,6 +294,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
       });
       if (cfg.nfc_reader) document.getElementById('nfc_reader').value = cfg.nfc_reader;
       document.getElementById('bambu_dashboard').checked = !!cfg.bambu_dashboard;
+      document.getElementById('wifi_keep_awake').checked = !!cfg.wifi_keep_awake;
       maybeSetValue('moonraker_url', cfg.moonraker_url);
       // Password placeholders
       if (cfg.wifi_pass_set) document.getElementById('wifi_pass').placeholder = '(set) Leave blank to keep';
@@ -342,7 +353,8 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
         prusalink_on: document.getElementById('prusalink_on').checked ? 1 : 0,
         prusalink_url: document.getElementById('prusalink_url').value.trim(),
         prusalink_api_key: document.getElementById('prusalink_api_key').value,
-        bambu_dashboard: document.getElementById('bambu_dashboard').checked ? 1 : 0
+        bambu_dashboard: document.getElementById('bambu_dashboard').checked ? 1 : 0,
+        wifi_keep_awake: document.getElementById('wifi_keep_awake').checked ? 1 : 0
       };
 
       fetch('/api/config', {

--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -98,11 +98,11 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
             </div>
             <div class="toggle-row" style="margin-top:10px">
               <div>
-                <span class="toggle-label">Keep WiFi radio awake</span>
+                <span id="wifi_keep_awake_label" class="toggle-label">Keep WiFi radio awake</span>
                 <div style="font-size:11px;color:#71717A;margin-top:4px">Disables modem sleep. Improves RSSI and response time on weak signals, uses slightly more power.</div>
               </div>
               <label class="toggle-switch">
-                <input type="checkbox" id="wifi_keep_awake" />
+                <input type="checkbox" id="wifi_keep_awake" aria-labelledby="wifi_keep_awake_label" />
                 <span class="toggle-track"></span>
               </label>
             </div>
@@ -136,9 +136,9 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
           <section>
             <h2 class="section-title">Spoolman</h2>
             <div class="toggle-row" style="margin-bottom:14px">
-              <span class="toggle-label">Enable Spoolman</span>
+              <span id="spoolman_on_label" class="toggle-label">Enable Spoolman</span>
               <label class="toggle-switch">
-                <input type="checkbox" id="spoolman_on" />
+                <input type="checkbox" id="spoolman_on" aria-labelledby="spoolman_on_label" />
                 <span class="toggle-track"></span>
               </label>
             </div>
@@ -161,9 +161,9 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
             <h2 class="section-title">PrusaLink</h2>
             <div class="hint" style="margin-bottom:12px">Connect to a Prusa printer for automatic filament tracking. Get the API key from your printer's web interface.</div>
             <div class="toggle-row" style="margin-bottom:14px">
-              <span class="toggle-label">Enable PrusaLink</span>
+              <span id="prusalink_on_label" class="toggle-label">Enable PrusaLink</span>
               <label class="toggle-switch">
-                <input type="checkbox" id="prusalink_on" />
+                <input type="checkbox" id="prusalink_on" aria-labelledby="prusalink_on_label" />
                 <span class="toggle-track"></span>
               </label>
             </div>
@@ -195,36 +195,36 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
             <div class="hint" style="margin-bottom:12px">Enable or disable optional hardware peripherals. Changes take effect after reboot.</div>
             <div style="display:grid;gap:10px">
               <div class="toggle-row">
-                <span class="toggle-label">LCD Display</span>
+                <span id="lcd_enabled_label" class="toggle-label">LCD Display</span>
                 <label class="toggle-switch">
-                  <input type="checkbox" id="lcd_enabled" />
+                  <input type="checkbox" id="lcd_enabled" aria-labelledby="lcd_enabled_label" />
                   <span class="toggle-track"></span>
                 </label>
               </div>
               <div class="toggle-row">
-                <span class="toggle-label">Status LED</span>
+                <span id="led_enabled_label" class="toggle-label">Status LED</span>
                 <label class="toggle-switch">
-                  <input type="checkbox" id="led_enabled" />
+                  <input type="checkbox" id="led_enabled" aria-labelledby="led_enabled_label" />
                   <span class="toggle-track"></span>
                 </label>
               </div>
               <div class="toggle-row">
-                <span class="toggle-label">3x4 Matrix Keypad</span>
+                <span id="keypad_enabled_label" class="toggle-label">3x4 Matrix Keypad</span>
                 <label class="toggle-switch">
-                  <input type="checkbox" id="keypad_enabled" />
+                  <input type="checkbox" id="keypad_enabled" aria-labelledby="keypad_enabled_label" />
                   <span class="toggle-track"></span>
                 </label>
               </div>
               <div class="toggle-row">
-                <span class="toggle-label">TFT Display (240x240)</span>
+                <span id="tft_enabled_label" class="toggle-label">TFT Display (240x240)</span>
                 <label class="toggle-switch">
-                  <input type="checkbox" id="tft_enabled" />
+                  <input type="checkbox" id="tft_enabled" aria-labelledby="tft_enabled_label" />
                   <span class="toggle-track"></span>
                 </label>
               </div>
               <div class="toggle-row" id="tft_driver_row" style="display:none">
-                <span class="toggle-label">TFT Driver</span>
-                <select id="tft_driver" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text);font-size:0.95em">
+                <span id="tft_driver_label" class="toggle-label">TFT Driver</span>
+                <select id="tft_driver" aria-labelledby="tft_driver_label" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text);font-size:0.95em">
                   <option value="st7789">ST7789 (square)</option>
                   <option value="gc9a01">GC9A01 (round)</option>
                 </select>
@@ -232,15 +232,15 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
             </div>
             <div style="display:grid;gap:10px">
               <div class="toggle-row">
-                <span class="toggle-label">Bambu AMS Dashboard (TFT)</span>
+                <span id="bambu_dashboard_label" class="toggle-label">Bambu AMS Dashboard (TFT)</span>
                 <label class="toggle-switch">
-                  <input type="checkbox" id="bambu_dashboard" />
+                  <input type="checkbox" id="bambu_dashboard" aria-labelledby="bambu_dashboard_label" />
                   <span class="toggle-track"></span>
                 </label>
               </div>
               <div class="toggle-row">
-                <span class="toggle-label">NFC Reader</span>
-                <select id="nfc_reader" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text);font-size:0.95em">
+                <span id="nfc_reader_label" class="toggle-label">NFC Reader</span>
+                <select id="nfc_reader" aria-labelledby="nfc_reader_label" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text);font-size:0.95em">
                   <option value="pn5180">PN5180 (ISO15693 + ISO14443A)</option>
                   <option value="pn532">PN532 (ISO14443A only)</option>
                 </select>

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -35,6 +35,7 @@ static const char* NVS_KEY_NFC_READER    = "nfc_reader";
 static const char* NVS_KEY_HOSTNAME      = "hostname";
 static const char* NVS_KEY_LOW_SPOOL     = "low_spool_g";
 static const char* NVS_KEY_BAMBU_DASH    = "bambu_dash";
+static const char* NVS_KEY_WIFI_AWAKE    = "wifi_awake";
 
 // Sanitize hostname: enforce mDNS naming constraints (lowercase alphanum + hyphens,
 // no leading/trailing hyphens) and reject empty strings to avoid boot-time errors.
@@ -253,6 +254,10 @@ bool ConfigurationManager::loadFromNVS() {
         _bambuDashboard = prefs.getBool(NVS_KEY_BAMBU_DASH, false);
         anyOverride = true;
     }
+    if (prefs.isKey(NVS_KEY_WIFI_AWAKE)) {
+        _wifiKeepAwake = prefs.getBool(NVS_KEY_WIFI_AWAKE, false);
+        anyOverride = true;
+    }
 
     prefs.end();
     return anyOverride;
@@ -359,6 +364,10 @@ bool ConfigurationManager::isBambuDashboardEnabled() const {
     return _bambuDashboard;
 }
 
+bool ConfigurationManager::isWifiKeepAwakeEnabled() const {
+    return _wifiKeepAwake;
+}
+
 void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     memset(&out, 0, sizeof(out));
     strncpy(out.wifi_ssid, _ssid, sizeof(out.wifi_ssid) - 1);
@@ -383,6 +392,7 @@ void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     strncpy(out.hostname, _hostname, sizeof(out.hostname) - 1);
     out.low_spool_threshold_g = _lowSpoolThreshold;
     out.bambu_dashboard = _bambuDashboard ? 1 : 0;
+    out.wifi_keep_awake = _wifiKeepAwake ? 1 : 0;
 }
 
 #ifndef NATIVE_TEST
@@ -427,6 +437,7 @@ bool ConfigurationManager::saveToNVS(const ConfigUpdate& update) {
     prefs.putString(NVS_KEY_HOSTNAME, sanitizedHostname);
     prefs.putUShort(NVS_KEY_LOW_SPOOL, update.low_spool_threshold_g);
     prefs.putBool(NVS_KEY_BAMBU_DASH, update.bambu_dashboard != 0);
+    prefs.putBool(NVS_KEY_WIFI_AWAKE, update.wifi_keep_awake != 0);
 
     // Invalidate Spoolman enrichment cache on config change to force re-fetch
     // (config change could invalidate cached spool lookups)

--- a/src/ConfigurationManager.h
+++ b/src/ConfigurationManager.h
@@ -40,6 +40,7 @@ struct ConfigUpdate {
     char hostname[33];   // max 32 chars + null
     uint16_t low_spool_threshold_g;  // grams below which LED breathes (default 100)
     uint8_t bambu_dashboard;
+    uint8_t wifi_keep_awake;  // disable WiFi modem sleep (better RSSI, more power)
 };
 
 class ConfigurationManager {
@@ -88,6 +89,10 @@ public:
     uint16_t getLowSpoolThreshold() const;
 
     bool isBambuDashboardEnabled() const;
+
+    // When true, firmware calls WiFi.setSleep(false) after WiFi.begin so the
+    // radio stays fully powered. Trades idle current for better RSSI/latency.
+    bool isWifiKeepAwakeEnabled() const;
 
     // Web config support
     void getCurrentConfig(ConfigUpdate& out) const;
@@ -139,6 +144,7 @@ private:
     char _tftDriver[8] = "st7789";
     uint16_t _lowSpoolThreshold = 100;  // grams
     bool _bambuDashboard = false;
+    bool _wifiKeepAwake = false;
 
     bool _initialized = false;
 };

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -724,6 +724,7 @@ void WebServerManager::handleApiGetConfig() {
     doc["hostname"] = cfg.hostname;
     doc["low_spool_threshold_g"] = cfg.low_spool_threshold_g;
     doc["bambu_dashboard"] = cfg.bambu_dashboard;
+    doc["wifi_keep_awake"] = cfg.wifi_keep_awake;
     doc["tft_enabled"] = cfg.tft_enabled;
     doc["tft_driver"] = cfg.tft_driver;
     doc["ap_mode"] = _apMode;
@@ -782,6 +783,7 @@ void WebServerManager::handleApiPostConfig() {
     sanitizeHostname(update.hostname, sizeof(update.hostname));
     update.low_spool_threshold_g = doc["low_spool_threshold_g"] | (uint16_t)100;
     update.bambu_dashboard = doc["bambu_dashboard"] | 0;
+    update.wifi_keep_awake = doc["wifi_keep_awake"] | 0;
 
     if (update.wifi_ssid[0] == '\0') {
         sendError(400, "WiFi SSID is required");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,6 +104,9 @@ void initWiFi() {
 
   WiFi.setHostname(config.getHostname());
   WiFi.begin(config.getWiFiSSID(), config.getWiFiPassword());
+  // Keep-awake disables WIFI_PS_MIN_MODEM (Arduino default). Users on weak
+  // networks report ~10 dB better RSSI with modem sleep off; costs idle current.
+  WiFi.setSleep(!config.isWifiKeepAwakeEnabled());
 
   int attempts = 0;
   while (WiFi.status() != WL_CONNECTED && attempts < 30) {


### PR DESCRIPTION
## Summary

- New NVS-backed config toggle **Keep WiFi radio awake** (default **off**). When enabled, firmware calls `WiFi.setSleep(false)` after `WiFi.begin()` to disable `WIFI_PS_MIN_MODEM`.
- Arduino-ESP32 defaults modem sleep on, which can make reported RSSI look ~10 dB worse than ESPHome on identical hardware. Discord report today: -84 dBm on our firmware vs much stronger signal with ESPHome on the same D1 mini / ESP32 DevKitC boards.
- Trades a small amount of idle current for better RSSI and lower ping — appropriate for USB-powered scanners, opt-in so existing installs aren't surprised.

## Changes

| file | change |
|---|---|
| `ConfigurationManager.h/.cpp` | `wifi_keep_awake` struct field, `NVS_KEY_WIFI_AWAKE = "wifi_awake"`, `isWifiKeepAwakeEnabled()` getter, load/save wiring |
| `ConfigHTML.h` | toggle row in WiFi section with help text, load + submit JS |
| `WebServerManager.cpp` | `/api/config` GET exposes it, POST parses it |
| `main.cpp` | `WiFi.setSleep(!config.isWifiKeepAwakeEnabled())` after `WiFi.begin()` |

Plumbing mirrors the existing `bambu_dashboard` pattern.

## Test plan

- [x] Builds clean on `esp32dev`, `esp32s3devkitc`, `esp32s3zero` (espressif32@6.10.0)
- [ ] Flash to test board, confirm toggle persists across reboot
- [ ] A/B RSSI with toggle off vs on against the same AP, same location
- [ ] Ask Discord reporter to test and report delta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WiFi radio power management option in Network settings. Users can now toggle the "Keep WiFi radio awake" setting to control whether the WiFi radio enters sleep mode, helping optimize power consumption while maintaining connectivity preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->