### PR TITLE
feat(c3): ESP32-C3 SuperMini variant — PN5180/PN532 SPI + I2C LCD + WS2812

### DIFF
--- a/include/BoardPins.h
+++ b/include/BoardPins.h
@@ -88,15 +88,24 @@
   // --- ESP32-C3 SuperMini pin mapping (HORNAXYS, Waveshare, etc.) ---
   // Scoped variant: NFC SPI reader + I2C LCD + WS2812 only. No TFT, no keypad.
   // Only one usable SPI controller, so TFT sharing is explicitly disabled here.
-  // Exposed GPIO: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 21. Strap pins: 2, 8, 9.
+  // Exposed GPIO: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 21.
+  // Strap pins on C3: GPIO 2, 8, 9 — these sample their state at POR to select
+  // boot mode. GPIO 2 must be HIGH, GPIO 9 HIGH for SPI-flash boot (LOW =
+  // download), GPIO 8 controls boot-log output. GPIO 2 is intentionally left
+  // unused so the board's own pull-up handles it — do not wire anything that
+  // could drive GPIO 2 LOW at POR.
   // PN5180 SPI
   #define PIN_PN5180_SCK   4
   #define PIN_PN5180_MISO  5
   #define PIN_PN5180_MOSI  6
   #define PIN_PN5180_NSS   7
   #define PIN_PN5180_BUSY  3
-  #define PIN_PN5180_RST   2   // Strap pin — must be HIGH at boot, forced HIGH in setup
+  #define PIN_PN5180_RST   0   // Non-strap GPIO — avoids GPIO 2 strap-pin risk if module drives RST low at POR
   #define PIN_PN5180_IRQ   10
+  // GPIO 20/21 are the C3's UART0 default pins. With ARDUINO_USB_CDC_ON_BOOT=1
+  // (set in platformio.ini), Serial routes to USB-CDC and UART0 is free for
+  // reuse as plain GPIO. Do not re-init UART0 or change the USB-CDC flag
+  // without reassigning these pins first.
   #define PIN_PN5180_GPIO  21
   #define PIN_PN5180_AUX   20
   // PN532 SPI (shares physical pins with PN5180; only one active at runtime)
@@ -106,7 +115,10 @@
   #define PIN_PN532_SS     PIN_PN5180_NSS
   #define PIN_PN532_IRQ    PIN_PN5180_IRQ
   #define PIN_PN532_RST    PIN_PN5180_RST
-  // LCD I2C (GPIO 8/9 are strap pins — require pull-up for normal boot)
+  // LCD I2C — GPIO 8/9 are strap pins. I2C backpacks (PCF8574) provide the
+  // required external pull-ups and idle SDA/SCL HIGH, which satisfies the POR
+  // strap condition. Do not wire devices that can drive these lines LOW before
+  // firmware releases the bus.
   #define PIN_LCD_SDA      8
   #define PIN_LCD_SCL      9
   // Status LED — external WS2812 (SuperMini onboard LED is single-color blue, not RGB)

--- a/include/BoardPins.h
+++ b/include/BoardPins.h
@@ -84,6 +84,50 @@
   #define PIN_TFT_RST        9
   #define PIN_TFT_BL        -1
 
+#elif defined(BOARD_ESP32_C3)
+  // --- ESP32-C3 SuperMini pin mapping (HORNAXYS, Waveshare, etc.) ---
+  // Scoped variant: NFC SPI reader + I2C LCD + WS2812 only. No TFT, no keypad.
+  // Only one usable SPI controller, so TFT sharing is explicitly disabled here.
+  // Exposed GPIO: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 21. Strap pins: 2, 8, 9.
+  // PN5180 SPI
+  #define PIN_PN5180_SCK   4
+  #define PIN_PN5180_MISO  5
+  #define PIN_PN5180_MOSI  6
+  #define PIN_PN5180_NSS   7
+  #define PIN_PN5180_BUSY  3
+  #define PIN_PN5180_RST   2   // Strap pin — must be HIGH at boot, forced HIGH in setup
+  #define PIN_PN5180_IRQ   10
+  #define PIN_PN5180_GPIO  21
+  #define PIN_PN5180_AUX   20
+  // PN532 SPI (shares physical pins with PN5180; only one active at runtime)
+  #define PIN_PN532_SCK    PIN_PN5180_SCK
+  #define PIN_PN532_MOSI   PIN_PN5180_MOSI
+  #define PIN_PN532_MISO   PIN_PN5180_MISO
+  #define PIN_PN532_SS     PIN_PN5180_NSS
+  #define PIN_PN532_IRQ    PIN_PN5180_IRQ
+  #define PIN_PN532_RST    PIN_PN5180_RST
+  // LCD I2C (GPIO 8/9 are strap pins — require pull-up for normal boot)
+  #define PIN_LCD_SDA      8
+  #define PIN_LCD_SCL      9
+  // Status LED — external WS2812 (SuperMini onboard LED is single-color blue, not RGB)
+  #define PIN_STATUS_LED   1
+  // Keypad — not supported on C3 (pin budget too tight); sentinels keep build working
+  #define PIN_KEYPAD_ROW1  -1
+  #define PIN_KEYPAD_ROW2  -1
+  #define PIN_KEYPAD_ROW3  -1
+  #define PIN_KEYPAD_ROW4  -1
+  #define PIN_KEYPAD_COL1  -1
+  #define PIN_KEYPAD_COL2  -1
+  #define PIN_KEYPAD_COL3  -1
+  // TFT — not supported on C3 (single usable SPI bus is dedicated to NFC reader)
+  #define PIN_TFT_MOSI     -1
+  #define PIN_TFT_SCLK     -1
+  #define PIN_TFT_MISO     -1
+  #define PIN_TFT_CS       -1
+  #define PIN_TFT_DC       -1
+  #define PIN_TFT_RST      -1
+  #define PIN_TFT_BL       -1
+
 #elif defined(BOARD_ESP32_S3)
   // --- Generic ESP32-S3 fallback (same as S3-Zero) ---
   #define PIN_PN5180_RST   4

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,6 +43,17 @@ build_flags =
 	-DBOARD_S3_ZERO=1
 	-DARDUINO_USB_CDC_ON_BOOT=1
 
+[env:esp32c3]
+board = esp32-c3-devkitm-1
+board_build.flash_size = 4MB
+board_build.flash_mode = dio
+board_upload.flash_size = 4MB
+build_flags =
+	${env.build_flags}
+	-DBOARD_ESP32_C3=1
+	-DARDUINO_USB_MODE=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
+
 [env:esp32s3devkitc]
 board = esp32-s3-devkitc-1
 board_build.cdc_on_boot = 1

--- a/src/TFTConfig.h
+++ b/src/TFTConfig.h
@@ -95,7 +95,7 @@ public:
     }
 };
 
-#else // WROOM
+#else // WROOM or C3
 
 class LGFX : public lgfx::LGFX_Device {
     lgfx::Panel_ST7789  _panel_st7789;
@@ -105,10 +105,15 @@ class LGFX : public lgfx::LGFX_Device {
 
 public:
     LGFX(TFTDriver driver = TFTDriver::ST7789) {
-        // SPI bus — VSPI. PN5180 uses HSPI via dedicated SPIClass instance.
+        // SPI bus — WROOM uses VSPI (PN5180 on HSPI). C3 has no VSPI; TFT is
+        // out of scope for C3 builds but LGFX must still link, so fall back to SPI2.
         {
             auto cfg = _bus_instance.config();
+#if defined(BOARD_ESP32_C3)
+            cfg.spi_host   = SPI2_HOST;  // C3 only has SPI2 — TFT not supported at runtime
+#else
             cfg.spi_host   = VSPI_HOST;
+#endif
             cfg.spi_mode   = 0;
             cfg.freq_write = 40000000;
             cfg.freq_read  = 16000000;


### PR DESCRIPTION
## Summary

Adds ESP32-C3 SuperMini (HORNAXYS, Waveshare, etc.) as a supported board variant. Scoped build — NFC + LCD + status LED only.

Closes #171

## What works

- PN5180 **or** PN532 over SPI2 (shared pins, runtime selection via existing config)
- I2C LCD (LiquidCrystal_I2C) on GPIO 8/9
- External WS2812 status LED on GPIO 1

## What's out of scope

- **TFT display** — C3 has only one usable SPI controller (SPI2); dedicated to the NFC reader
- **Keypad** — pin budget too tight; only 13 exposed GPIOs, strap pins 2/8/9 are load-bearing
- **Onboard RGB** — SuperMini onboard LED is single-color blue on GPIO 8, not WS2812. External WS2812 required for status LED behavior

## Changes

- `platformio.ini` — new `[env:esp32c3]` block. Uses `ARDUINO_USB_MODE=1` + `ARDUINO_USB_CDC_ON_BOOT=1` for USB-Serial/JTAG (C3's native USB path). No `board_build.cdc_on_boot` (that's an S3-only option and breaks Serial on C3).
- `include/BoardPins.h` — new `BOARD_ESP32_C3` branch with C3 SuperMini pin map. Keypad and TFT pins defined as `-1` sentinels so code guarded by `PIN_… >= 0` compiles out cleanly.
- `src/TFTConfig.h` — added `#if defined(BOARD_ESP32_C3)` guard to select `SPI2_HOST` (C3 has no `VSPI_HOST`). TFTConfig must still link for C3 builds even though TFT hardware isn't wired.

## Memory usage

| Env | RAM | Flash | Build time |
|---|---|---|---|
| esp32dev (WROOM) | 20.0% | 84.6% | 14.9s |
| esp32s3zero | 19.6% | 82.2% | 15.2s |
| esp32s3devkitc | 19.6% | 82.4% | 14.9s |
| **esp32c3** | **17.7%** | **83.1%** | **14.3s** |

All existing envs build clean — no regression from the TFTConfig.h SPI_HOST guard.

## Test plan

- [x] esp32c3 env builds successfully
- [x] esp32dev, esp32s3zero, esp32s3devkitc regression builds pass
- [ ] Physical testing on HORNAXYS C3 SuperMini hardware (user-owned)
- [ ] Confirm PN5180 tag reads
- [ ] Confirm PN532 tag reads (shared-pin variant)
- [ ] Confirm I2C LCD renders on GPIO 8/9
- [ ] Confirm WS2812 status LED on GPIO 1
- [ ] Release workflow + web flasher manifest additions (follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive support for ESP32-C3 microcontroller boards, featuring integrated NFC connectivity, I2C LCD display interface, and programmable status LED capabilities.
  * Added dedicated PlatformIO build environment with optimized configuration for smooth ESP32-C3 development including native USB serial boot support.

* **Known Limitations**
  * TFT display rendering and keypad input functionality are not available on ESP32-C3 boards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->