### PR TITLE
chore(release): v1.7.4 — ESP32-C3 variant + roomonthethird usermod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,18 +36,24 @@ jobs:
       - name: Build ESP32-S3-DevKitC firmware
         run: pio run -e esp32s3devkitc
 
+      - name: Build ESP32-C3 firmware
+        run: pio run -e esp32c3
+
       - name: Prepare release artifacts
         run: |
           mkdir -p release
           cp .pio/build/esp32dev/firmware.bin release/spoolsense_scanner_esp32dev.bin
           cp .pio/build/esp32s3zero/firmware.bin release/spoolsense_scanner_esp32s3zero.bin
           cp .pio/build/esp32s3devkitc/firmware.bin release/spoolsense_scanner_esp32s3devkitc.bin
+          cp .pio/build/esp32c3/firmware.bin release/spoolsense_scanner_esp32c3.bin
           cp .pio/build/esp32dev/bootloader.bin release/bootloader_esp32dev.bin
           cp .pio/build/esp32s3zero/bootloader.bin release/bootloader_esp32s3zero.bin
           cp .pio/build/esp32s3devkitc/bootloader.bin release/bootloader_esp32s3devkitc.bin
+          cp .pio/build/esp32c3/bootloader.bin release/bootloader_esp32c3.bin
           cp .pio/build/esp32dev/partitions.bin release/partitions_esp32dev.bin
           cp .pio/build/esp32s3zero/partitions.bin release/partitions_esp32s3zero.bin
           cp .pio/build/esp32s3devkitc/partitions.bin release/partitions_esp32s3devkitc.bin
+          cp .pio/build/esp32c3/partitions.bin release/partitions_esp32c3.bin
           cp partitions.csv release/partitions.csv
 
       - name: Extract changelog for this version
@@ -74,12 +80,15 @@ jobs:
             release/spoolsense_scanner_esp32dev.bin
             release/spoolsense_scanner_esp32s3zero.bin
             release/spoolsense_scanner_esp32s3devkitc.bin
+            release/spoolsense_scanner_esp32c3.bin
             release/bootloader_esp32dev.bin
             release/bootloader_esp32s3zero.bin
             release/bootloader_esp32s3devkitc.bin
+            release/bootloader_esp32c3.bin
             release/partitions_esp32dev.bin
             release/partitions_esp32s3zero.bin
             release/partitions_esp32s3devkitc.bin
+            release/partitions_esp32c3.bin
             release/partitions.csv
 
       - name: Trigger web flasher update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.7.4] - 2026-04-22
+
+### Added
+
+- **ESP32-C3 SuperMini board variant** — new `esp32c3` PlatformIO env targeting HORNAXYS/Waveshare C3 SuperMini boards. Scoped to NFC reader (PN5180 or PN532) + I2C LCD + WS2812 status LED; TFT and keypad intentionally unsupported (single usable SPI controller and tight pin budget). `PIN_PN5180_RST` wired to GPIO 0 rather than a strap pin so the reader cannot force the board into download mode at POR. (#171, #172)
+- **`roomonthethird` case** — STEP/STL/F3D files for the SpoolSense NFC reader case organized under `usermods/roomonthethird/`.
+
+---
+
 ## [1.7.3] - 2026-04-20
 
 ### Added

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ board_build.partitions = partitions.csv
 monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
-	-DFIRMWARE_VERSION=\"1.7.3\"
+	-DFIRMWARE_VERSION=\"1.7.4\"
 lib_deps =
 	marcoschwartz/LiquidCrystal_I2C@^1.1.4
 	bblanchon/ArduinoJson@^7.0.0


### PR DESCRIPTION
## Summary

Release prep for v1.7.4:

- Bump `FIRMWARE_VERSION` 1.7.3 → 1.7.4
- Add `esp32c3` build + artifacts to `release.yml` so CI produces the new firmware binary, bootloader, and partitions on tag push
- Add v1.7.4 CHANGELOG entry

## What ships in 1.7.4

- **ESP32-C3 SuperMini board variant** (#171, #172) — scoped to NFC reader + I2C LCD + WS2812 status LED; TFT/keypad not supported on C3. PN5180 RST on GPIO 0 to avoid strap-pin risk.
- **`roomonthethird` case** — new usermod with STEP/STL/F3D files.

## Test plan

- [x] esp32dev, esp32s3zero, esp32s3devkitc, esp32c3 all build green from this branch
- [x] `release.yml` YAML validates
- [ ] After merge to main + tag push: confirm CI produces all 4 firmware sets and GitHub Release is created
- [ ] Confirm spoolsense.org `update-firmware.yml` picks up new tag and updates all 4 manifests (companion PR in spoolsense.org repo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ESP32-C3 SuperMini board variant with integrated NFC reader, I2C LCD display, and WS2812 RGB status LED.
  * ESP32-C3-specific firmware binaries now available in releases for direct deployment.

* **Other**
  * Version bumped to 1.7.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->