### PR TITLE
Release v1.7.4 — ESP32-C3 variant + roomonthethird usermod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,18 +36,24 @@ jobs:
       - name: Build ESP32-S3-DevKitC firmware
         run: pio run -e esp32s3devkitc
 
+      - name: Build ESP32-C3 firmware
+        run: pio run -e esp32c3
+
       - name: Prepare release artifacts
         run: |
           mkdir -p release
           cp .pio/build/esp32dev/firmware.bin release/spoolsense_scanner_esp32dev.bin
           cp .pio/build/esp32s3zero/firmware.bin release/spoolsense_scanner_esp32s3zero.bin
           cp .pio/build/esp32s3devkitc/firmware.bin release/spoolsense_scanner_esp32s3devkitc.bin
+          cp .pio/build/esp32c3/firmware.bin release/spoolsense_scanner_esp32c3.bin
           cp .pio/build/esp32dev/bootloader.bin release/bootloader_esp32dev.bin
           cp .pio/build/esp32s3zero/bootloader.bin release/bootloader_esp32s3zero.bin
           cp .pio/build/esp32s3devkitc/bootloader.bin release/bootloader_esp32s3devkitc.bin
+          cp .pio/build/esp32c3/bootloader.bin release/bootloader_esp32c3.bin
           cp .pio/build/esp32dev/partitions.bin release/partitions_esp32dev.bin
           cp .pio/build/esp32s3zero/partitions.bin release/partitions_esp32s3zero.bin
           cp .pio/build/esp32s3devkitc/partitions.bin release/partitions_esp32s3devkitc.bin
+          cp .pio/build/esp32c3/partitions.bin release/partitions_esp32c3.bin
           cp partitions.csv release/partitions.csv
 
       - name: Extract changelog for this version
@@ -74,12 +80,15 @@ jobs:
             release/spoolsense_scanner_esp32dev.bin
             release/spoolsense_scanner_esp32s3zero.bin
             release/spoolsense_scanner_esp32s3devkitc.bin
+            release/spoolsense_scanner_esp32c3.bin
             release/bootloader_esp32dev.bin
             release/bootloader_esp32s3zero.bin
             release/bootloader_esp32s3devkitc.bin
+            release/bootloader_esp32c3.bin
             release/partitions_esp32dev.bin
             release/partitions_esp32s3zero.bin
             release/partitions_esp32s3devkitc.bin
+            release/partitions_esp32c3.bin
             release/partitions.csv
 
       - name: Trigger web flasher update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.7.4] - 2026-04-22
+
+### Added
+
+- **ESP32-C3 SuperMini board variant** — new `esp32c3` PlatformIO env targeting HORNAXYS/Waveshare C3 SuperMini boards. Scoped to NFC reader (PN5180 or PN532) + I2C LCD + WS2812 status LED; TFT and keypad intentionally unsupported (single usable SPI controller and tight pin budget). `PIN_PN5180_RST` wired to GPIO 0 rather than a strap pin so the reader cannot force the board into download mode at POR. (#171, #172)
+- **`roomonthethird` case** — STEP/STL/F3D files for the SpoolSense NFC reader case organized under `usermods/roomonthethird/`.
+
+---
+
 ## [1.7.3] - 2026-04-20
 
 ### Added

--- a/include/BoardPins.h
+++ b/include/BoardPins.h
@@ -88,15 +88,24 @@
   // --- ESP32-C3 SuperMini pin mapping (HORNAXYS, Waveshare, etc.) ---
   // Scoped variant: NFC SPI reader + I2C LCD + WS2812 only. No TFT, no keypad.
   // Only one usable SPI controller, so TFT sharing is explicitly disabled here.
-  // Exposed GPIO: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 21. Strap pins: 2, 8, 9.
+  // Exposed GPIO: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 21.
+  // Strap pins on C3: GPIO 2, 8, 9 — these sample their state at POR to select
+  // boot mode. GPIO 2 must be HIGH, GPIO 9 HIGH for SPI-flash boot (LOW =
+  // download), GPIO 8 controls boot-log output. GPIO 2 is intentionally left
+  // unused so the board's own pull-up handles it — do not wire anything that
+  // could drive GPIO 2 LOW at POR.
   // PN5180 SPI
   #define PIN_PN5180_SCK   4
   #define PIN_PN5180_MISO  5
   #define PIN_PN5180_MOSI  6
   #define PIN_PN5180_NSS   7
   #define PIN_PN5180_BUSY  3
-  #define PIN_PN5180_RST   2   // Strap pin — must be HIGH at boot, forced HIGH in setup
+  #define PIN_PN5180_RST   0   // Non-strap GPIO — avoids GPIO 2 strap-pin risk if module drives RST low at POR
   #define PIN_PN5180_IRQ   10
+  // GPIO 20/21 are the C3's UART0 default pins. With ARDUINO_USB_CDC_ON_BOOT=1
+  // (set in platformio.ini), Serial routes to USB-CDC and UART0 is free for
+  // reuse as plain GPIO. Do not re-init UART0 or change the USB-CDC flag
+  // without reassigning these pins first.
   #define PIN_PN5180_GPIO  21
   #define PIN_PN5180_AUX   20
   // PN532 SPI (shares physical pins with PN5180; only one active at runtime)
@@ -106,7 +115,10 @@
   #define PIN_PN532_SS     PIN_PN5180_NSS
   #define PIN_PN532_IRQ    PIN_PN5180_IRQ
   #define PIN_PN532_RST    PIN_PN5180_RST
-  // LCD I2C (GPIO 8/9 are strap pins — require pull-up for normal boot)
+  // LCD I2C — GPIO 8/9 are strap pins. I2C backpacks (PCF8574) provide the
+  // required external pull-ups and idle SDA/SCL HIGH, which satisfies the POR
+  // strap condition. Do not wire devices that can drive these lines LOW before
+  // firmware releases the bus.
   #define PIN_LCD_SDA      8
   #define PIN_LCD_SCL      9
   // Status LED — external WS2812 (SuperMini onboard LED is single-color blue, not RGB)

--- a/include/BoardPins.h
+++ b/include/BoardPins.h
@@ -84,6 +84,50 @@
   #define PIN_TFT_RST        9
   #define PIN_TFT_BL        -1
 
+#elif defined(BOARD_ESP32_C3)
+  // --- ESP32-C3 SuperMini pin mapping (HORNAXYS, Waveshare, etc.) ---
+  // Scoped variant: NFC SPI reader + I2C LCD + WS2812 only. No TFT, no keypad.
+  // Only one usable SPI controller, so TFT sharing is explicitly disabled here.
+  // Exposed GPIO: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 21. Strap pins: 2, 8, 9.
+  // PN5180 SPI
+  #define PIN_PN5180_SCK   4
+  #define PIN_PN5180_MISO  5
+  #define PIN_PN5180_MOSI  6
+  #define PIN_PN5180_NSS   7
+  #define PIN_PN5180_BUSY  3
+  #define PIN_PN5180_RST   2   // Strap pin — must be HIGH at boot, forced HIGH in setup
+  #define PIN_PN5180_IRQ   10
+  #define PIN_PN5180_GPIO  21
+  #define PIN_PN5180_AUX   20
+  // PN532 SPI (shares physical pins with PN5180; only one active at runtime)
+  #define PIN_PN532_SCK    PIN_PN5180_SCK
+  #define PIN_PN532_MOSI   PIN_PN5180_MOSI
+  #define PIN_PN532_MISO   PIN_PN5180_MISO
+  #define PIN_PN532_SS     PIN_PN5180_NSS
+  #define PIN_PN532_IRQ    PIN_PN5180_IRQ
+  #define PIN_PN532_RST    PIN_PN5180_RST
+  // LCD I2C (GPIO 8/9 are strap pins — require pull-up for normal boot)
+  #define PIN_LCD_SDA      8
+  #define PIN_LCD_SCL      9
+  // Status LED — external WS2812 (SuperMini onboard LED is single-color blue, not RGB)
+  #define PIN_STATUS_LED   1
+  // Keypad — not supported on C3 (pin budget too tight); sentinels keep build working
+  #define PIN_KEYPAD_ROW1  -1
+  #define PIN_KEYPAD_ROW2  -1
+  #define PIN_KEYPAD_ROW3  -1
+  #define PIN_KEYPAD_ROW4  -1
+  #define PIN_KEYPAD_COL1  -1
+  #define PIN_KEYPAD_COL2  -1
+  #define PIN_KEYPAD_COL3  -1
+  // TFT — not supported on C3 (single usable SPI bus is dedicated to NFC reader)
+  #define PIN_TFT_MOSI     -1
+  #define PIN_TFT_SCLK     -1
+  #define PIN_TFT_MISO     -1
+  #define PIN_TFT_CS       -1
+  #define PIN_TFT_DC       -1
+  #define PIN_TFT_RST      -1
+  #define PIN_TFT_BL       -1
+
 #elif defined(BOARD_ESP32_S3)
   // --- Generic ESP32-S3 fallback (same as S3-Zero) ---
   #define PIN_PN5180_RST   4

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,6 +43,17 @@ build_flags =
 	-DBOARD_S3_ZERO=1
 	-DARDUINO_USB_CDC_ON_BOOT=1
 
+[env:esp32c3]
+board = esp32-c3-devkitm-1
+board_build.flash_size = 4MB
+board_build.flash_mode = dio
+board_upload.flash_size = 4MB
+build_flags =
+	${env.build_flags}
+	-DBOARD_ESP32_C3=1
+	-DARDUINO_USB_MODE=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
+
 [env:esp32s3devkitc]
 board = esp32-s3-devkitc-1
 board_build.cdc_on_boot = 1

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ board_build.partitions = partitions.csv
 monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
-	-DFIRMWARE_VERSION=\"1.7.3\"
+	-DFIRMWARE_VERSION=\"1.7.4\"
 lib_deps =
 	marcoschwartz/LiquidCrystal_I2C@^1.1.4
 	bblanchon/ArduinoJson@^7.0.0

--- a/src/TFTConfig.h
+++ b/src/TFTConfig.h
@@ -95,7 +95,7 @@ public:
     }
 };
 
-#else // WROOM
+#else // WROOM or C3
 
 class LGFX : public lgfx::LGFX_Device {
     lgfx::Panel_ST7789  _panel_st7789;
@@ -105,10 +105,15 @@ class LGFX : public lgfx::LGFX_Device {
 
 public:
     LGFX(TFTDriver driver = TFTDriver::ST7789) {
-        // SPI bus — VSPI. PN5180 uses HSPI via dedicated SPIClass instance.
+        // SPI bus — WROOM uses VSPI (PN5180 on HSPI). C3 has no VSPI; TFT is
+        // out of scope for C3 builds but LGFX must still link, so fall back to SPI2.
         {
             auto cfg = _bus_instance.config();
+#if defined(BOARD_ESP32_C3)
+            cfg.spi_host   = SPI2_HOST;  // C3 only has SPI2 — TFT not supported at runtime
+#else
             cfg.spi_host   = VSPI_HOST;
+#endif
             cfg.spi_mode   = 0;
             cfg.freq_write = 40000000;
             cfg.freq_read  = 16000000;

--- a/usermods/README.md
+++ b/usermods/README.md
@@ -8,6 +8,7 @@ Community-contributed modifications for the SpoolSense scanner. Each subdirector
 |-----|--------|-------------|
 | [jims_enclosure](jims_enclosure/) | Jim | 3-piece scanner enclosure for ESP32-S3-Zero + PN5180 |
 | [linuxgangster](linuxgangster/) | LinuxGangster | Standalone case (S3-Zero + PN532) + BoxTurtle PN532 tray |
+| [roomonthethird](roomonthethird/) | roomonthethird | SpoolSense NFC reader case — two-piece base + lid (STEP/STL/F3D) |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Promote `dev` to `main` for v1.7.4.

## What ships in 1.7.4

- **ESP32-C3 SuperMini board variant** (#171, #172) — new `esp32c3` PlatformIO env. Scoped to NFC reader (PN5180 or PN532) + I2C LCD + WS2812. No TFT/keypad (tight pin budget, single SPI controller). `PIN_PN5180_RST` on GPIO 0 to avoid strap-pin boot-mode risk.
- **`roomonthethird` case** — STEP/STL/F3D files added under `usermods/roomonthethird/`.

## Test plan

- [ ] After merge + tag: `release.yml` produces all 4 firmware sets (esp32dev, esp32s3zero, esp32s3devkitc, esp32c3) and creates a GitHub Release
- [ ] `spoolsense.org` `update-firmware.yml` run picks up the release and bumps all 4 manifests to 1.7.4
- [ ] `esp-web-tools` flasher shows ESP32-C3 SuperMini option and can flash the C3 binary