### PR TITLE
Release v1.7.5 — Snapmaker U1 direct-mode integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.7.5] - 2026-04-29
+
+### Added
+
+- **Snapmaker U1 direct-mode integration** — scanner pushes scan results to a Snapmaker U1's external filament-detection endpoint via HTTP. New **Snapmaker U1 Integration** section on the config page binds a scanner to a toolhead channel (0–3). All 6 tag formats route through this path: smart tags publish on detection, generic UID tags publish after Spoolman lookup. Per-material temperature defaults (PLA/PETG/ABS/ASA/TPU/PVA/PC/PA) fill gaps for tags missing data; Spoolman augment overlays extra fields without overwriting on-tag values. Hostname auto-suggest sets `spoolsense-tN` when a channel is picked, simplifying multi-scanner deployments. Requires [paxx12 Extended Firmware](https://github.com/paxx12/SnapmakerU1-Extended-Firmware) (develop branch) with **Filament Detection: External** enabled in the firmware-config page. (#98, #182)
+
+---
+
 ## [1.7.4] - 2026-04-22
 
 ### Added

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ board_build.partitions = partitions.csv
 monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
-	-DFIRMWARE_VERSION=\"1.7.4\"
+	-DFIRMWARE_VERSION=\"1.7.5\"
 lib_deps =
 	marcoschwartz/LiquidCrystal_I2C@^1.1.4
 	bblanchon/ArduinoJson@^7.0.0

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -19,6 +19,7 @@
   #include <WiFi.h>
   #include <HTTPClient.h>
   #include <Preferences.h>
+  #include <ArduinoJson.h>
   extern LEDManager ledManager;
 #else
   #include "platform/NativePlatform.h"
@@ -848,6 +849,21 @@ void ApplicationManager::handleSpoolmanSynced(const AppMessage& msg) {
     float kgRemaining = msg.payload.spoolmanSynced.kg_remaining;
 
 #ifndef NATIVE_TEST
+    // Snapmaker U1 direct-mode (Phase 1): push channel state to the extended firmware's
+    // /printer/filament_detect/set endpoint. Only fires for generic UID tags — smart tag
+    // formats (OpenSpool, OPT, TigerTag, OT3D) carry their own data and will be published
+    // from handleSpoolDetected in a follow-up phase.
+    if (msg.payload.spoolmanSynced.success && msg.payload.spoolmanSynced.is_uid_lookup
+            && msg.payload.spoolmanSynced.spoolman_id > 0) {
+        CurrentSpoolState pubState;
+        if (NFCManager::getInstance().getCurrentSpoolState(pubState)
+                && pubState.kind == TagKind::GenericUidTag) {
+            publishToU1(msg.payload.spoolmanSynced);
+        }
+    }
+#endif
+
+#ifndef NATIVE_TEST
     // Generic tag writeback: populate NFC tag with Spoolman data if lookup succeeded
     if (msg.payload.spoolmanSynced.is_uid_lookup && msg.payload.spoolmanSynced.success) {
         // Safety: verify tag still present and matches UID (may have been removed during Spoolman request)
@@ -1438,5 +1454,118 @@ bool ApplicationManager::sendAssignSpool(const char* toolNumber) {
 #else
     (void)toolNumber;
     return true;  // Native test: pretend success
+#endif
+}
+
+bool ApplicationManager::publishToU1(const SpoolmanSyncedPayload& sync) {
+    // Snapmaker U1 direct-mode (Phase 1): POST scan result to extended firmware's
+    // /printer/filament_detect/set endpoint. Requires "Filament Detection: External" on the U1.
+    // Runs on the dispatch loop on every successful generic-UID Spoolman lookup, so this path
+    // must NOT block: short mutex wait + 30s reachability backoff after a transport failure.
+#ifndef NATIVE_TEST
+    auto& cfg = ConfigurationManager::getInstance();
+    if (!cfg.isU1Enabled()) return false;
+    if (sync.spoolman_id <= 0) return false;
+
+    uint32_t now = millis();
+    if (moonrakerBackoffUntilMs_ != 0 && (int32_t)(now - moonrakerBackoffUntilMs_) < 0) {
+        return false;
+    }
+
+    const char* moonrakerUrl = cfg.getMoonrakerURL();
+    if (!moonrakerUrl || moonrakerUrl[0] == '\0') return false;
+
+    uint8_t channel = cfg.getU1Channel();
+    if (channel > 3) return false;  // belt-and-braces; loader already clamps
+
+    extern SemaphoreHandle_t g_httpMutex;
+    if (g_httpMutex && xSemaphoreTake(g_httpMutex, pdMS_TO_TICKS(250)) != pdTRUE) {
+        Serial.println("ApplicationManager: HTTP mutex busy for publishToU1");
+        return false;
+    }
+
+    // Build the U1 extended-firmware schema. Optional fields are omitted when empty/zero
+    // so the firmware applies its own defaults rather than receiving "" / 0 sentinels.
+    StaticJsonDocument<512> body;
+    body["channel"] = channel;
+    JsonObject info = body.createNestedObject("info");
+
+    if (sync.manufacturer[0] != '\0') info["VENDOR"] = sync.manufacturer;
+
+    // material_name is e.g. "PLA" or "PLA Matte"; split on first space so the U1 can render
+    // "Matte" as a SUB_TYPE chip in Fluidd. Single-word names go to MAIN_TYPE only.
+    if (sync.material_name[0] != '\0') {
+        const char* mat = sync.material_name;
+        const char* space = strchr(mat, ' ');
+        if (space && space != mat) {
+            char main[16] = {0};
+            size_t mlen = (size_t)(space - mat);
+            if (mlen >= sizeof(main)) mlen = sizeof(main) - 1;
+            memcpy(main, mat, mlen);
+            info["MAIN_TYPE"] = main;
+            info["SUB_TYPE"] = space + 1;
+        } else {
+            info["MAIN_TYPE"] = mat;
+        }
+    }
+
+    if (sync.color_hex[0] != '\0') {
+        const char* h = (sync.color_hex[0] == '#') ? sync.color_hex + 1 : sync.color_hex;
+        unsigned int r = 0, g = 0, b = 0;
+        if (sscanf(h, "%02x%02x%02x", &r, &g, &b) == 3) {
+            info["RGB_1"] = (long)((r << 16) | (g << 8) | b);
+            info["ALPHA"] = 255;
+        }
+    }
+
+    // Spoolman exposes a single extruder/bed temp; the U1 schema wants min+max.
+    // Use the same value for both so the printer never under-shoots its hot-end target.
+    if (sync.extruder_temp > 0) {
+        info["HOTEND_MIN_TEMP"] = sync.extruder_temp;
+        info["HOTEND_MAX_TEMP"] = sync.extruder_temp;
+    }
+    if (sync.bed_temp > 0) info["BED_TEMP"] = sync.bed_temp;
+
+    // CARD_UID: parse spool_id hex string into byte array (e.g., "04A1B2C3" -> [4,161,178,195]).
+    JsonArray uidArr = info.createNestedArray("CARD_UID");
+    size_t hexLen = strlen(sync.spool_id);
+    for (size_t i = 0; i + 1 < hexLen; i += 2) {
+        char hex[3] = { sync.spool_id[i], sync.spool_id[i + 1], 0 };
+        uidArr.add((int)strtoul(hex, nullptr, 16));
+    }
+
+    String payload;
+    serializeJson(body, payload);
+
+    char url[192];
+    snprintf(url, sizeof(url), "%s/printer/filament_detect/set", moonrakerUrl);
+
+    WiFiClient client;
+    HTTPClient http;
+    http.setConnectTimeout(1000);
+    http.setTimeout(2000);
+    http.begin(client, url);
+    http.addHeader("Content-Type", "application/json");
+    int code = http.POST(payload);
+    http.end();
+
+    if (g_httpMutex) xSemaphoreGive(g_httpMutex);
+
+    Serial.printf("ApplicationManager: publishToU1 channel=%u spool=%d — HTTP %d\n",
+                  (unsigned)channel, sync.spoolman_id, code);
+
+    if (code < 0) {
+        // HTTPClient transport failure (connect refused, timeout, etc.) — back off so the
+        // next scan doesn't re-block the dispatch loop on the same unreachable host.
+        moonrakerBackoffUntilMs_ = millis() + MOONRAKER_BACKOFF_MS;
+        Serial.printf("ApplicationManager: U1/Moonraker unreachable — backing off %u ms\n",
+                      (unsigned)MOONRAKER_BACKOFF_MS);
+        return false;
+    }
+    moonrakerBackoffUntilMs_ = 0;  // server responded — clear any prior backoff
+    return code >= 200 && code < 300;
+#else
+    (void)sync;
+    return true;
 #endif
 }

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -19,7 +19,7 @@
   #include <WiFi.h>
   #include <HTTPClient.h>
   #include <Preferences.h>
-  #include <ArduinoJson.h>
+  #include "U1Manager.h"
   extern LEDManager ledManager;
 #else
   #include "platform/NativePlatform.h"
@@ -527,6 +527,14 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
     }
 
 #ifndef NATIVE_TEST
+    // Snapmaker U1 direct-mode: publish on-tag data to the U1 immediately. Smart tags
+    // already carry vendor/material/color/temps so this gives Fluidd a near-instant
+    // update without waiting on Spoolman. U1Manager handles per-material defaults
+    // for missing fields and registers a pending augment if Spoolman might fill gaps.
+    U1Manager::getInstance().publishFromDetection(msg.payload.spoolDetected);
+#endif
+
+#ifndef NATIVE_TEST
     // Spoolman sync: auto-update remaining weight (SELF_DIRECTED mode only)
     // Suppress flag can gate this per-tag (e.g., after batch write to Spoolman)
     if (automationMode == AutomationMode::SELF_DIRECTED &&
@@ -849,17 +857,14 @@ void ApplicationManager::handleSpoolmanSynced(const AppMessage& msg) {
     float kgRemaining = msg.payload.spoolmanSynced.kg_remaining;
 
 #ifndef NATIVE_TEST
-    // Snapmaker U1 direct-mode (Phase 1): push channel state to the extended firmware's
-    // /printer/filament_detect/set endpoint. Only fires for generic UID tags — smart tag
-    // formats (OpenSpool, OPT, TigerTag, OT3D) carry their own data and will be published
-    // from handleSpoolDetected in a follow-up phase.
-    if (msg.payload.spoolmanSynced.success && msg.payload.spoolmanSynced.is_uid_lookup
-            && msg.payload.spoolmanSynced.spoolman_id > 0) {
-        CurrentSpoolState pubState;
-        if (NFCManager::getInstance().getCurrentSpoolState(pubState)
-                && pubState.kind == TagKind::GenericUidTag) {
-            publishToU1(msg.payload.spoolmanSynced);
-        }
+    // Snapmaker U1 direct-mode: hand the sync result to U1Manager. It handles
+    // the generic-UID single-POST path AND the smart-tag augment path (POST 2)
+    // when a pending augment was registered by handleSpoolDetected. No-op when
+    // U1 integration is disabled.
+    {
+        CurrentSpoolState u1State;
+        NFCManager::getInstance().getCurrentSpoolState(u1State);
+        U1Manager::getInstance().publishFromSpoolmanSync(msg.payload.spoolmanSynced, u1State);
     }
 #endif
 
@@ -1457,115 +1462,3 @@ bool ApplicationManager::sendAssignSpool(const char* toolNumber) {
 #endif
 }
 
-bool ApplicationManager::publishToU1(const SpoolmanSyncedPayload& sync) {
-    // Snapmaker U1 direct-mode (Phase 1): POST scan result to extended firmware's
-    // /printer/filament_detect/set endpoint. Requires "Filament Detection: External" on the U1.
-    // Runs on the dispatch loop on every successful generic-UID Spoolman lookup, so this path
-    // must NOT block: short mutex wait + 30s reachability backoff after a transport failure.
-#ifndef NATIVE_TEST
-    auto& cfg = ConfigurationManager::getInstance();
-    if (!cfg.isU1Enabled()) return false;
-    if (sync.spoolman_id <= 0) return false;
-
-    uint32_t now = millis();
-    if (moonrakerBackoffUntilMs_ != 0 && (int32_t)(now - moonrakerBackoffUntilMs_) < 0) {
-        return false;
-    }
-
-    const char* moonrakerUrl = cfg.getMoonrakerURL();
-    if (!moonrakerUrl || moonrakerUrl[0] == '\0') return false;
-
-    uint8_t channel = cfg.getU1Channel();
-    if (channel > 3) return false;  // belt-and-braces; loader already clamps
-
-    extern SemaphoreHandle_t g_httpMutex;
-    if (g_httpMutex && xSemaphoreTake(g_httpMutex, pdMS_TO_TICKS(250)) != pdTRUE) {
-        Serial.println("ApplicationManager: HTTP mutex busy for publishToU1");
-        return false;
-    }
-
-    // Build the U1 extended-firmware schema. Optional fields are omitted when empty/zero
-    // so the firmware applies its own defaults rather than receiving "" / 0 sentinels.
-    StaticJsonDocument<512> body;
-    body["channel"] = channel;
-    JsonObject info = body.createNestedObject("info");
-
-    if (sync.manufacturer[0] != '\0') info["VENDOR"] = sync.manufacturer;
-
-    // material_name is e.g. "PLA" or "PLA Matte"; split on first space so the U1 can render
-    // "Matte" as a SUB_TYPE chip in Fluidd. Single-word names go to MAIN_TYPE only.
-    if (sync.material_name[0] != '\0') {
-        const char* mat = sync.material_name;
-        const char* space = strchr(mat, ' ');
-        if (space && space != mat) {
-            char main[16] = {0};
-            size_t mlen = (size_t)(space - mat);
-            if (mlen >= sizeof(main)) mlen = sizeof(main) - 1;
-            memcpy(main, mat, mlen);
-            info["MAIN_TYPE"] = main;
-            info["SUB_TYPE"] = space + 1;
-        } else {
-            info["MAIN_TYPE"] = mat;
-        }
-    }
-
-    if (sync.color_hex[0] != '\0') {
-        const char* h = (sync.color_hex[0] == '#') ? sync.color_hex + 1 : sync.color_hex;
-        unsigned int r = 0, g = 0, b = 0;
-        if (sscanf(h, "%02x%02x%02x", &r, &g, &b) == 3) {
-            info["RGB_1"] = (long)((r << 16) | (g << 8) | b);
-            info["ALPHA"] = 255;
-        }
-    }
-
-    // Spoolman exposes a single extruder/bed temp; the U1 schema wants min+max.
-    // Use the same value for both so the printer never under-shoots its hot-end target.
-    if (sync.extruder_temp > 0) {
-        info["HOTEND_MIN_TEMP"] = sync.extruder_temp;
-        info["HOTEND_MAX_TEMP"] = sync.extruder_temp;
-    }
-    if (sync.bed_temp > 0) info["BED_TEMP"] = sync.bed_temp;
-
-    // CARD_UID: parse spool_id hex string into byte array (e.g., "04A1B2C3" -> [4,161,178,195]).
-    JsonArray uidArr = info.createNestedArray("CARD_UID");
-    size_t hexLen = strlen(sync.spool_id);
-    for (size_t i = 0; i + 1 < hexLen; i += 2) {
-        char hex[3] = { sync.spool_id[i], sync.spool_id[i + 1], 0 };
-        uidArr.add((int)strtoul(hex, nullptr, 16));
-    }
-
-    String payload;
-    serializeJson(body, payload);
-
-    char url[192];
-    snprintf(url, sizeof(url), "%s/printer/filament_detect/set", moonrakerUrl);
-
-    WiFiClient client;
-    HTTPClient http;
-    http.setConnectTimeout(1000);
-    http.setTimeout(2000);
-    http.begin(client, url);
-    http.addHeader("Content-Type", "application/json");
-    int code = http.POST(payload);
-    http.end();
-
-    if (g_httpMutex) xSemaphoreGive(g_httpMutex);
-
-    Serial.printf("ApplicationManager: publishToU1 channel=%u spool=%d — HTTP %d\n",
-                  (unsigned)channel, sync.spoolman_id, code);
-
-    if (code < 0) {
-        // HTTPClient transport failure (connect refused, timeout, etc.) — back off so the
-        // next scan doesn't re-block the dispatch loop on the same unreachable host.
-        moonrakerBackoffUntilMs_ = millis() + MOONRAKER_BACKOFF_MS;
-        Serial.printf("ApplicationManager: U1/Moonraker unreachable — backing off %u ms\n",
-                      (unsigned)MOONRAKER_BACKOFF_MS);
-        return false;
-    }
-    moonrakerBackoffUntilMs_ = 0;  // server responded — clear any prior backoff
-    return code >= 200 && code < 300;
-#else
-    (void)sync;
-    return true;
-#endif
-}

--- a/src/ApplicationManager.h
+++ b/src/ApplicationManager.h
@@ -263,6 +263,11 @@ private:
     uint32_t dashboardRevertAt_ = 0;
     static constexpr uint32_t DASHBOARD_REVERT_DELAY_MS = 5000;
 
+    // Moonraker reachability backoff — skip publishToU1 after a transport failure
+    // so a misconfigured / offline U1 doesn't block the dispatch loop on every scan.
+    uint32_t moonrakerBackoffUntilMs_ = 0;
+    static constexpr uint32_t MOONRAKER_BACKOFF_MS = 30000;
+
     // Handlers
     void handlePrintStarted(const AppMessage& msg);
     void handlePrintEnded(const AppMessage& msg);
@@ -281,6 +286,10 @@ private:
     void handleTrayUpdate();
     void handleTrayAssign();
     bool sendAssignSpool(const char* toolNumber);
+    // Snapmaker U1 direct-mode (Phase 1 / fixed-channel): POST to extended firmware's
+    // /printer/filament_detect/set with the configured channel + filament info derived
+    // from the Spoolman sync result. No-op when U1 integration is disabled in config.
+    bool publishToU1(const SpoolmanSyncedPayload& sync);
     void finishPrint(float gramsUsed, bool canceled);
     void enqueueSpoolmanSync(const SpoolDetectedPayload& spool);
     void publishToHA(const char* topicSuffix, const char* payload, bool retained);

--- a/src/ApplicationManager.h
+++ b/src/ApplicationManager.h
@@ -263,11 +263,6 @@ private:
     uint32_t dashboardRevertAt_ = 0;
     static constexpr uint32_t DASHBOARD_REVERT_DELAY_MS = 5000;
 
-    // Moonraker reachability backoff — skip publishToU1 after a transport failure
-    // so a misconfigured / offline U1 doesn't block the dispatch loop on every scan.
-    uint32_t moonrakerBackoffUntilMs_ = 0;
-    static constexpr uint32_t MOONRAKER_BACKOFF_MS = 30000;
-
     // Handlers
     void handlePrintStarted(const AppMessage& msg);
     void handlePrintEnded(const AppMessage& msg);
@@ -286,10 +281,6 @@ private:
     void handleTrayUpdate();
     void handleTrayAssign();
     bool sendAssignSpool(const char* toolNumber);
-    // Snapmaker U1 direct-mode (Phase 1 / fixed-channel): POST to extended firmware's
-    // /printer/filament_detect/set with the configured channel + filament info derived
-    // from the Spoolman sync result. No-op when U1 integration is disabled in config.
-    bool publishToU1(const SpoolmanSyncedPayload& sync);
     void finishPrint(float gramsUsed, bool canceled);
     void enqueueSpoolmanSync(const SpoolDetectedPayload& spool);
     void publishToHA(const char* topicSuffix, const char* payload, bool retained);

--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -158,6 +158,30 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
           </section>
 
           <section>
+            <h2 class="section-title">Snapmaker U1 Integration</h2>
+            <div class="hint" style="margin-bottom:12px">Push scan results directly to a Snapmaker U1 toolchanger. Requires <a href="https://github.com/paxx12/SnapmakerU1-Extended-Firmware" target="_blank">paxx12 Extended Firmware</a> with <strong>Filament Detection: External</strong> set in <code>http://&lt;printer-ip&gt;/firmware-config/</code>. Set the Moonraker URL above to your U1's IP.</div>
+            <div class="toggle-row" style="margin-bottom:14px">
+              <span id="u1_enabled_label" class="toggle-label">Enable U1 Integration</span>
+              <label class="toggle-switch">
+                <input type="checkbox" id="u1_enabled" aria-labelledby="u1_enabled_label" />
+                <span class="toggle-track"></span>
+              </label>
+            </div>
+            <div id="u1_fields" style="display:none">
+              <div class="field">
+                <label for="u1_channel">Toolhead Channel</label>
+                <select id="u1_channel" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text);font-size:0.95em">
+                  <option value="0">Channel 0 (T0)</option>
+                  <option value="1">Channel 1 (T1)</option>
+                  <option value="2">Channel 2 (T2)</option>
+                  <option value="3">Channel 3 (T3)</option>
+                </select>
+                <div style="font-size:11px;color:#71717A;margin-top:4px">Each scanner posts to one channel. Use four scanners (one per toolhead) for a full U1 setup, or one scanner if you only load filament into one slot.</div>
+              </div>
+            </div>
+          </section>
+
+          <section>
             <h2 class="section-title">PrusaLink</h2>
             <div class="hint" style="margin-bottom:12px">Connect to a Prusa printer for automatic filament tracking. Get the API key from your printer's web interface.</div>
             <div class="toggle-row" style="margin-bottom:14px">
@@ -296,6 +320,10 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
       document.getElementById('bambu_dashboard').checked = !!cfg.bambu_dashboard;
       document.getElementById('wifi_keep_awake').checked = !!cfg.wifi_keep_awake;
       maybeSetValue('moonraker_url', cfg.moonraker_url);
+      // Snapmaker U1 integration
+      document.getElementById('u1_enabled').checked = !!cfg.u1_enabled;
+      if (cfg.u1_channel !== undefined) document.getElementById('u1_channel').value = cfg.u1_channel;
+      document.getElementById('u1_fields').style.display = cfg.u1_enabled ? '' : 'none';
       // Password placeholders
       if (cfg.wifi_pass_set) document.getElementById('wifi_pass').placeholder = '(set) Leave blank to keep';
       if (cfg.mqtt_pass_set) document.getElementById('mqtt_pass').placeholder = '(set) Leave blank to keep';
@@ -316,6 +344,22 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
     // Show/hide PrusaLink fields based on toggle
     document.getElementById('prusalink_on').addEventListener('change', function() {
       document.getElementById('prusalink_fields').style.display = this.checked ? '' : 'none';
+    });
+
+    // Show/hide U1 fields based on toggle
+    document.getElementById('u1_enabled').addEventListener('change', function() {
+      document.getElementById('u1_fields').style.display = this.checked ? '' : 'none';
+    });
+
+    // Auto-suggest hostname when U1 channel changes — only if user hasn't customized
+    // beyond the default ("spoolsense" or empty). Saves the "what should I name this scanner?" decision.
+    document.getElementById('u1_channel').addEventListener('change', function() {
+      var hostInput = document.getElementById('hostname');
+      var current = (hostInput.value || '').trim();
+      var defaults = ['', 'spoolsense', 'spoolsense-t0', 'spoolsense-t1', 'spoolsense-t2', 'spoolsense-t3'];
+      if (defaults.indexOf(current) >= 0) {
+        hostInput.value = 'spoolsense-t' + this.value;
+      }
     });
 
     function normalizeHostname(v) {
@@ -354,7 +398,9 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
         prusalink_url: document.getElementById('prusalink_url').value.trim(),
         prusalink_api_key: document.getElementById('prusalink_api_key').value,
         bambu_dashboard: document.getElementById('bambu_dashboard').checked ? 1 : 0,
-        wifi_keep_awake: document.getElementById('wifi_keep_awake').checked ? 1 : 0
+        wifi_keep_awake: document.getElementById('wifi_keep_awake').checked ? 1 : 0,
+        u1_enabled: document.getElementById('u1_enabled').checked ? 1 : 0,
+        u1_channel: parseInt(document.getElementById('u1_channel').value) || 0
       };
 
       fetch('/api/config', {

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -36,6 +36,8 @@ static const char* NVS_KEY_HOSTNAME      = "hostname";
 static const char* NVS_KEY_LOW_SPOOL     = "low_spool_g";
 static const char* NVS_KEY_BAMBU_DASH    = "bambu_dash";
 static const char* NVS_KEY_WIFI_AWAKE    = "wifi_awake";
+static const char* NVS_KEY_U1_ON         = "u1_on";
+static const char* NVS_KEY_U1_CHANNEL    = "u1_channel";
 
 // Sanitize hostname: enforce mDNS naming constraints (lowercase alphanum + hyphens,
 // no leading/trailing hyphens) and reject empty strings to avoid boot-time errors.
@@ -258,6 +260,15 @@ bool ConfigurationManager::loadFromNVS() {
         _wifiKeepAwake = prefs.getBool(NVS_KEY_WIFI_AWAKE, false);
         anyOverride = true;
     }
+    if (prefs.isKey(NVS_KEY_U1_ON)) {
+        _u1Enabled = prefs.getBool(NVS_KEY_U1_ON, false);
+        anyOverride = true;
+    }
+    if (prefs.isKey(NVS_KEY_U1_CHANNEL)) {
+        uint8_t ch = prefs.getUChar(NVS_KEY_U1_CHANNEL, 0);
+        _u1Channel = (ch <= 3) ? ch : 0;  // clamp invalid values from NVS
+        anyOverride = true;
+    }
 
     prefs.end();
     return anyOverride;
@@ -368,6 +379,14 @@ bool ConfigurationManager::isWifiKeepAwakeEnabled() const {
     return _wifiKeepAwake;
 }
 
+bool ConfigurationManager::isU1Enabled() const {
+    return _u1Enabled;
+}
+
+uint8_t ConfigurationManager::getU1Channel() const {
+    return _u1Channel;
+}
+
 void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     memset(&out, 0, sizeof(out));
     strncpy(out.wifi_ssid, _ssid, sizeof(out.wifi_ssid) - 1);
@@ -393,6 +412,8 @@ void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     out.low_spool_threshold_g = _lowSpoolThreshold;
     out.bambu_dashboard = _bambuDashboard ? 1 : 0;
     out.wifi_keep_awake = _wifiKeepAwake ? 1 : 0;
+    out.u1_enabled = _u1Enabled ? 1 : 0;
+    out.u1_channel = _u1Channel;
 }
 
 #ifndef NATIVE_TEST
@@ -438,6 +459,8 @@ bool ConfigurationManager::saveToNVS(const ConfigUpdate& update) {
     prefs.putUShort(NVS_KEY_LOW_SPOOL, update.low_spool_threshold_g);
     prefs.putBool(NVS_KEY_BAMBU_DASH, update.bambu_dashboard != 0);
     prefs.putBool(NVS_KEY_WIFI_AWAKE, update.wifi_keep_awake != 0);
+    prefs.putBool(NVS_KEY_U1_ON, update.u1_enabled != 0);
+    prefs.putUChar(NVS_KEY_U1_CHANNEL, (update.u1_channel <= 3) ? update.u1_channel : 0);
 
     // Invalidate Spoolman enrichment cache on config change to force re-fetch
     // (config change could invalidate cached spool lookups)

--- a/src/ConfigurationManager.h
+++ b/src/ConfigurationManager.h
@@ -41,6 +41,9 @@ struct ConfigUpdate {
     uint16_t low_spool_threshold_g;  // grams below which LED breathes (default 100)
     uint8_t bambu_dashboard;
     uint8_t wifi_keep_awake;  // disable WiFi modem sleep (better RSSI, more power)
+    // Snapmaker U1 direct-mode integration (extended firmware, Filament Detection: External)
+    uint8_t u1_enabled;       // 0 = off, 1 = post to /printer/filament_detect/set on scans
+    uint8_t u1_channel;       // 0..3 — toolhead this scanner is bound to
 };
 
 class ConfigurationManager {
@@ -94,6 +97,10 @@ public:
     // radio stays fully powered. Trades idle current for better RSSI/latency.
     bool isWifiKeepAwakeEnabled() const;
 
+    // Snapmaker U1 direct-mode (Phase 1 / fixed-channel)
+    bool isU1Enabled() const;
+    uint8_t getU1Channel() const;
+
     // Web config support
     void getCurrentConfig(ConfigUpdate& out) const;
     bool saveToNVS(const ConfigUpdate& update);
@@ -145,6 +152,10 @@ private:
     uint16_t _lowSpoolThreshold = 100;  // grams
     bool _bambuDashboard = false;
     bool _wifiKeepAwake = false;
+
+    // Snapmaker U1 direct-mode
+    bool _u1Enabled = false;
+    uint8_t _u1Channel = 0;
 
     bool _initialized = false;
 };

--- a/src/U1Manager.cpp
+++ b/src/U1Manager.cpp
@@ -6,7 +6,7 @@
 
 #ifndef NATIVE_TEST
   #include "ApplicationManager.h"  // SpoolDetectedPayload, SpoolmanSyncedPayload
-  #include "NFCTypes.h"             // CurrentSpoolState
+  #include "NFCTypes.h"             // CurrentSpoolState, TagKind
   #include "ConfigurationManager.h"
   #include <Arduino.h>
   #include <WiFi.h>
@@ -22,20 +22,6 @@
 extern SemaphoreHandle_t g_httpMutex;
 
 namespace {
-
-// Internal U1 wire-format struct — what we POST after all conversions.
-struct U1FilamentInfo {
-    char vendor[64] = {};
-    char main_type[24] = {};   // uppercase, e.g. "PLA", "PETG"
-    char sub_type[24] = {};    // e.g. "Matte", "CF", may be empty
-    int  rgb_1 = -1;            // -1 = no color sent
-    int  alpha = 255;
-    int  hotend_min_temp = 0;   // 0 = not sent
-    int  hotend_max_temp = 0;
-    int  bed_temp = 0;
-    uint8_t card_uid[8] = {};
-    uint8_t card_uid_len = 0;
-};
 
 // Per-material defaults for OpenSpool (no bed temp on tag) and any tag that's
 // missing temps. Matches common slicer defaults (Orca/PrusaSlicer/Cura).
@@ -169,10 +155,9 @@ U1FilamentInfo buildFromDetection(const SpoolDetectedPayload& p) {
     return info;
 }
 
-// Build U1 wire info from a Spoolman sync result (generic UID tag path) plus
-// the current NFC state for fallback fields the sync may not have populated.
-U1FilamentInfo buildFromSpoolmanSync(const SpoolmanSyncedPayload& s,
-                                      const CurrentSpoolState& state) {
+// Build U1 wire info from a Spoolman sync result. Used by the generic-UID-tag
+// path where the tag itself carries no rich data — Spoolman is the only source.
+U1FilamentInfo buildFromSpoolmanSync(const SpoolmanSyncedPayload& s) {
     U1FilamentInfo info;
 
     if (s.manufacturer[0] != '\0') {
@@ -193,14 +178,62 @@ U1FilamentInfo buildFromSpoolmanSync(const SpoolmanSyncedPayload& s,
     if (s.bed_temp > 0) info.bed_temp = s.bed_temp;
 
     packCardUid(s.spool_id, info.card_uid, sizeof(info.card_uid), info.card_uid_len);
-
-    // CurrentSpoolState fallback for any field Spoolman didn't return — covers
-    // the rare case where a generic UID tag exists in Spoolman but with sparse
-    // metadata (color or temps left blank in the Spoolman record).
-    (void)state;  // reserved for future fallback logic when state fields land
-
     applyMaterialDefaults(info);
     return info;
+}
+
+// Merge non-empty Spoolman fields onto a base U1FilamentInfo (POST 1's data for
+// smart-tag augment). Returns true if anything actually changed — caller uses
+// this to skip a redundant POST when Spoolman didn't add or correct anything.
+bool overlaySpoolmanFields(U1FilamentInfo& info, const SpoolmanSyncedPayload& s) {
+    bool changed = false;
+
+    if (s.manufacturer[0] != '\0' && strcmp(s.manufacturer, info.vendor) != 0) {
+        strncpy(info.vendor, s.manufacturer, sizeof(info.vendor) - 1);
+        info.vendor[sizeof(info.vendor) - 1] = '\0';
+        changed = true;
+    }
+
+    if (s.material_name[0] != '\0') {
+        char newMain[sizeof(info.main_type)] = {0};
+        char newSub[sizeof(info.sub_type)] = {0};
+        splitMaterialName(s.material_name, newMain, sizeof(newMain),
+                                              newSub, sizeof(newSub));
+        if (newMain[0] != '\0' && strcmp(newMain, info.main_type) != 0) {
+            strncpy(info.main_type, newMain, sizeof(info.main_type) - 1);
+            info.main_type[sizeof(info.main_type) - 1] = '\0';
+            changed = true;
+        }
+        if (newSub[0] != '\0' && strcmp(newSub, info.sub_type) != 0) {
+            strncpy(info.sub_type, newSub, sizeof(info.sub_type) - 1);
+            info.sub_type[sizeof(info.sub_type) - 1] = '\0';
+            changed = true;
+        }
+    }
+
+    if (s.color_hex[0] != '\0') {
+        int newRgb = hexColorToRgb1(s.color_hex);
+        if (newRgb >= 0 && newRgb != info.rgb_1) {
+            info.rgb_1 = newRgb;
+            info.alpha = 255;
+            changed = true;
+        }
+    }
+
+    if (s.extruder_temp > 0
+            && (s.extruder_temp != info.hotend_min_temp
+                || s.extruder_temp != info.hotend_max_temp)) {
+        info.hotend_min_temp = s.extruder_temp;
+        info.hotend_max_temp = s.extruder_temp;
+        changed = true;
+    }
+
+    if (s.bed_temp > 0 && s.bed_temp != info.bed_temp) {
+        info.bed_temp = s.bed_temp;
+        changed = true;
+    }
+
+    return changed;
 }
 
 // Returns true if every U1-required field has a meaningful value. Used to
@@ -303,18 +336,16 @@ void U1Manager::publishFromDetection(const SpoolDetectedPayload& payload) {
     }
     moonrakerBackoffUntilMs_ = 0;
 
-    // Register pending augment if POST 1 was incomplete and Spoolman is configured
-    // (otherwise there's no way the augment could supply anything new).
+    // Register pending augment if POST 1 was incomplete and Spoolman is configured.
+    // Cache the exact info we just sent — POST 2 will start from this and overlay
+    // any non-empty Spoolman fields, so on-tag data is never overwritten by gaps
+    // in the Spoolman record.
     if (cfg.isSpoolmanEnabled() && !isComplete(info)) {
         pendingAugment_.active = true;
         strncpy(pendingAugment_.uid, payload.spool_id, sizeof(pendingAugment_.uid) - 1);
         pendingAugment_.uid[sizeof(pendingAugment_.uid) - 1] = '\0';
         pendingAugment_.expiresAtMs = millis() + PENDING_AUGMENT_TTL_MS;
-        pendingAugment_.wantVendor       = (info.vendor[0] == '\0');
-        pendingAugment_.wantMainType     = (info.main_type[0] == '\0');
-        pendingAugment_.wantColor        = (info.rgb_1 < 0);
-        pendingAugment_.wantHotendTemps  = (info.hotend_min_temp == 0 || info.hotend_max_temp == 0);
-        pendingAugment_.wantBedTemp      = (info.bed_temp == 0);
+        pendingAugment_.postedInfo = info;
     } else {
         pendingAugment_.active = false;
     }
@@ -335,8 +366,16 @@ void U1Manager::publishFromSpoolmanSync(const SpoolmanSyncedPayload& sync,
     }
 
     if (sync.is_uid_lookup) {
-        // Generic UID tag (NFC+) — Spoolman is the only data source. Single POST.
-        U1FilamentInfo info = buildFromSpoolmanSync(sync, state);
+        // Generic UID tag (NFC+) — Spoolman is the only data source.
+        // Defense: if the user removed the tag during the lookup (or swapped to a
+        // different tag), skip the POST. Mirrors the writeback guard in the
+        // ApplicationManager generic-tag-writeback path.
+        if (!state.present
+                || state.kind != TagKind::GenericUidTag
+                || strcmp(state.spool_id, sync.spool_id) != 0) {
+            return;
+        }
+        U1FilamentInfo info = buildFromSpoolmanSync(sync);
         int code = postFilamentDetectSet(channel, info);
         Serial.printf("U1Manager: publishFromSpoolmanSync(UID) channel=%u spool=%d — HTTP %d\n",
                       (unsigned)channel, sync.spoolman_id, code);
@@ -348,14 +387,17 @@ void U1Manager::publishFromSpoolmanSync(const SpoolmanSyncedPayload& sync,
         return;
     }
 
-    // Smart-tag follow-up sync — only POST if a pending augment is active for
-    // this UID and Spoolman supplied at least one field that POST 1 was missing.
+    // Smart-tag follow-up sync — augment POST 1's data with anything Spoolman
+    // supplied that POST 1 didn't already have (or had with a different value).
     if (!pendingAugment_.active) return;
     // Bound the compare to the UID buffer size so a non-null-terminated producer
     // (defensive — both buffers are 17 bytes / 16 hex chars + null) can't make
     // strcmp walk off the end.
     if (strncmp(pendingAugment_.uid, sync.spool_id, sizeof(pendingAugment_.uid) - 1) != 0) {
-        pendingAugment_.active = false;
+        // Late sync for a previous (different) tag — ignore but DON'T clear the
+        // current pending augment. A user scanning two tags within ~3s could have
+        // an earlier tag's sync arrive first; clearing here would sabotage the
+        // augment for the tag they just scanned.
         return;
     }
     if ((int32_t)(now - pendingAugment_.expiresAtMs) >= 0) {
@@ -363,17 +405,14 @@ void U1Manager::publishFromSpoolmanSync(const SpoolmanSyncedPayload& sync,
         return;
     }
 
-    bool augments = false;
-    if (pendingAugment_.wantVendor && sync.manufacturer[0] != '\0')        augments = true;
-    if (pendingAugment_.wantColor && sync.color_hex[0] != '\0')             augments = true;
-    if (pendingAugment_.wantHotendTemps && sync.extruder_temp > 0)          augments = true;
-    if (pendingAugment_.wantBedTemp && sync.bed_temp > 0)                   augments = true;
-    if (pendingAugment_.wantMainType && sync.material_name[0] != '\0')     augments = true;
+    // Start from POST 1's wire info, overlay non-empty Spoolman fields. Skip the
+    // POST if nothing actually changed — Spoolman had no data POST 1 was missing.
+    U1FilamentInfo merged = pendingAugment_.postedInfo;
+    bool changed = overlaySpoolmanFields(merged, sync);
 
     pendingAugment_.active = false;  // single-shot regardless of outcome
-    if (!augments) return;
+    if (!changed) return;
 
-    U1FilamentInfo merged = buildFromSpoolmanSync(sync, state);
     int code = postFilamentDetectSet(channel, merged);
     Serial.printf("U1Manager: publishFromSpoolmanSync(augment) channel=%u spool=%d — HTTP %d\n",
                   (unsigned)channel, sync.spoolman_id, code);

--- a/src/U1Manager.cpp
+++ b/src/U1Manager.cpp
@@ -1,0 +1,394 @@
+// U1Manager.cpp — Snapmaker U1 direct-mode bridge implementation.
+// All HTTP plumbing, JSON shaping, per-material defaults, and pending-augment
+// state live here so ApplicationManager can stay focused on dispatch.
+
+#include "U1Manager.h"
+
+#ifndef NATIVE_TEST
+  #include "ApplicationManager.h"  // SpoolDetectedPayload, SpoolmanSyncedPayload
+  #include "NFCTypes.h"             // CurrentSpoolState
+  #include "ConfigurationManager.h"
+  #include <Arduino.h>
+  #include <WiFi.h>
+  #include <HTTPClient.h>
+  #include <ArduinoJson.h>
+  #include <freertos/FreeRTOS.h>
+  #include <freertos/semphr.h>
+  #include <cctype>
+  #include <cstring>
+  #include <cstdio>
+  #include <cstdlib>
+
+extern SemaphoreHandle_t g_httpMutex;
+
+namespace {
+
+// Internal U1 wire-format struct — what we POST after all conversions.
+struct U1FilamentInfo {
+    char vendor[64] = {};
+    char main_type[24] = {};   // uppercase, e.g. "PLA", "PETG"
+    char sub_type[24] = {};    // e.g. "Matte", "CF", may be empty
+    int  rgb_1 = -1;            // -1 = no color sent
+    int  alpha = 255;
+    int  hotend_min_temp = 0;   // 0 = not sent
+    int  hotend_max_temp = 0;
+    int  bed_temp = 0;
+    uint8_t card_uid[8] = {};
+    uint8_t card_uid_len = 0;
+};
+
+// Per-material defaults for OpenSpool (no bed temp on tag) and any tag that's
+// missing temps. Matches common slicer defaults (Orca/PrusaSlicer/Cura).
+// Only applied when MAIN_TYPE matches one of the firmware's recognized types.
+struct MaterialDefaults {
+    const char* main_type;  // uppercase
+    int hotend_min;
+    int hotend_max;
+    int bed_temp;
+};
+
+constexpr MaterialDefaults DEFAULTS[] = {
+    { "PLA",  200, 220, 60  },
+    { "PETG", 230, 250, 70  },
+    { "ABS",  240, 260, 100 },
+    { "ASA",  240, 260, 100 },
+    { "TPU",  220, 240, 50  },
+    { "PVA",  190, 210, 60  },
+    { "PC",   260, 290, 110 },
+    { "PA",   250, 280, 90  },  // Nylon
+};
+
+const MaterialDefaults* findDefaults(const char* mainType) {
+    if (!mainType || mainType[0] == '\0') return nullptr;
+    for (const auto& d : DEFAULTS) {
+        if (strcmp(d.main_type, mainType) == 0) return &d;
+    }
+    return nullptr;
+}
+
+// Split a material name into MAIN_TYPE (uppercase) + SUB_TYPE on first space
+// or hyphen. Examples:
+//   "PLA Matte"  -> "PLA"  + "Matte"
+//   "PETG-CF"    -> "PETG" + "CF"
+//   "PLA"        -> "PLA"  + ""
+//   "PA-CF Pro"  -> "PA"   + "CF Pro"
+void splitMaterialName(const char* src, char* main, size_t mainCap,
+                                          char* sub, size_t subCap) {
+    if (!src || src[0] == '\0') {
+        if (main && mainCap) main[0] = '\0';
+        if (sub && subCap) sub[0] = '\0';
+        return;
+    }
+    size_t i = 0;
+    while (src[i] && src[i] != ' ' && src[i] != '-' && i + 1 < mainCap) {
+        main[i] = (char)std::toupper((unsigned char)src[i]);
+        i++;
+    }
+    main[i] = '\0';
+    // Skip the separator
+    if (src[i] == ' ' || src[i] == '-') i++;
+    if (src[i] && sub && subCap > 0) {
+        strncpy(sub, src + i, subCap - 1);
+        sub[subCap - 1] = '\0';
+    } else if (sub && subCap) {
+        sub[0] = '\0';
+    }
+}
+
+// Pack the spool UID hex string ("04A1B2C3") into the byte array used by the
+// U1's CARD_UID field. Stops at non-hex or buffer end.
+void packCardUid(const char* hex, uint8_t* out, uint8_t cap, uint8_t& outLen) {
+    outLen = 0;
+    if (!hex) return;
+    size_t hexLen = strlen(hex);
+    for (size_t i = 0; i + 1 < hexLen && outLen < cap; i += 2) {
+        char buf[3] = { hex[i], hex[i + 1], 0 };
+        char* end = nullptr;
+        long byte = strtol(buf, &end, 16);
+        if (end != buf + 2) break;  // non-hex char
+        out[outLen++] = (uint8_t)byte;
+    }
+}
+
+// Convert RGBA bytes to RGB_1 integer (R<<16 | G<<8 | B). Returns -1 if all
+// channels are zero AND alpha is also zero — caller treats as "no color".
+int rgbaToRgb1(const uint8_t rgba[4]) {
+    if (rgba[0] == 0 && rgba[1] == 0 && rgba[2] == 0 && rgba[3] == 0) return -1;
+    return ((int)rgba[0] << 16) | ((int)rgba[1] << 8) | (int)rgba[2];
+}
+
+// Convert "#RRGGBB" or "RRGGBB" hex string to RGB_1 integer. Returns -1 on
+// parse failure or empty input.
+int hexColorToRgb1(const char* hex) {
+    if (!hex || hex[0] == '\0') return -1;
+    if (hex[0] == '#') hex++;
+    unsigned int r = 0, g = 0, b = 0;
+    if (sscanf(hex, "%02x%02x%02x", &r, &g, &b) != 3) return -1;
+    return (int)((r << 16) | (g << 8) | b);
+}
+
+// Apply firmware-recognized per-material defaults to any temp field that's
+// still zero. Only fires if the MAIN_TYPE is one of the U1's protocol-mapped
+// types — unrecognized types (PEEK, niche blends, etc.) leave zeros alone so
+// users see the gap and can set explicit values in Spoolman or on the tag.
+void applyMaterialDefaults(U1FilamentInfo& info) {
+    const MaterialDefaults* d = findDefaults(info.main_type);
+    if (!d) return;
+    if (info.hotend_min_temp == 0) info.hotend_min_temp = d->hotend_min;
+    if (info.hotend_max_temp == 0) info.hotend_max_temp = d->hotend_max;
+    if (info.bed_temp == 0) info.bed_temp = d->bed_temp;
+}
+
+// Build U1 wire info from a smart-tag detection payload.
+U1FilamentInfo buildFromDetection(const SpoolDetectedPayload& p) {
+    U1FilamentInfo info;
+    strncpy(info.vendor, p.manufacturer, sizeof(info.vendor) - 1);
+    splitMaterialName(p.material_name, info.main_type, sizeof(info.main_type),
+                                         info.sub_type, sizeof(info.sub_type));
+
+    // TigerTag carries aspect (Silk/Wood/Matt) separately when material_name
+    // is just the base type — promote aspect into SUB_TYPE if we don't have one.
+    if (info.sub_type[0] == '\0' && p.aspect[0] != '\0') {
+        strncpy(info.sub_type, p.aspect, sizeof(info.sub_type) - 1);
+    }
+
+    if (p.has_color) {
+        info.rgb_1 = rgbaToRgb1(p.primary_color);
+        info.alpha = p.primary_color[3] ? p.primary_color[3] : 255;
+    }
+
+    if (p.min_print_temp > 0) info.hotend_min_temp = p.min_print_temp;
+    if (p.max_print_temp > 0) info.hotend_max_temp = p.max_print_temp;
+    // U1 wants a single bed temp; prefer min, fall back to max — same convention
+    // the firmware's own OpenSpool parser uses for OpenSpool tags.
+    if (p.min_bed_temp > 0)      info.bed_temp = p.min_bed_temp;
+    else if (p.max_bed_temp > 0) info.bed_temp = p.max_bed_temp;
+
+    packCardUid(p.spool_id, info.card_uid, sizeof(info.card_uid), info.card_uid_len);
+    applyMaterialDefaults(info);
+    return info;
+}
+
+// Build U1 wire info from a Spoolman sync result (generic UID tag path) plus
+// the current NFC state for fallback fields the sync may not have populated.
+U1FilamentInfo buildFromSpoolmanSync(const SpoolmanSyncedPayload& s,
+                                      const CurrentSpoolState& state) {
+    U1FilamentInfo info;
+
+    if (s.manufacturer[0] != '\0') {
+        strncpy(info.vendor, s.manufacturer, sizeof(info.vendor) - 1);
+    }
+    splitMaterialName(s.material_name, info.main_type, sizeof(info.main_type),
+                                         info.sub_type, sizeof(info.sub_type));
+
+    if (s.color_hex[0] != '\0') {
+        info.rgb_1 = hexColorToRgb1(s.color_hex);
+        info.alpha = 255;
+    }
+
+    if (s.extruder_temp > 0) {
+        info.hotend_min_temp = s.extruder_temp;
+        info.hotend_max_temp = s.extruder_temp;  // single value -> use as both
+    }
+    if (s.bed_temp > 0) info.bed_temp = s.bed_temp;
+
+    packCardUid(s.spool_id, info.card_uid, sizeof(info.card_uid), info.card_uid_len);
+
+    // CurrentSpoolState fallback for any field Spoolman didn't return — covers
+    // the rare case where a generic UID tag exists in Spoolman but with sparse
+    // metadata (color or temps left blank in the Spoolman record).
+    (void)state;  // reserved for future fallback logic when state fields land
+
+    applyMaterialDefaults(info);
+    return info;
+}
+
+// Returns true if every U1-required field has a meaningful value. Used to
+// decide whether a pending-augment registration is worth keeping.
+bool isComplete(const U1FilamentInfo& info) {
+    return info.vendor[0] != '\0'
+        && info.main_type[0] != '\0'
+        && info.rgb_1 >= 0
+        && info.hotend_min_temp > 0
+        && info.hotend_max_temp > 0
+        && info.bed_temp > 0;
+}
+
+// Serialize and POST. Returns the HTTP response code, -1000 if Moonraker URL
+// unset, -1001 if the HTTP mutex was busy, or a negative HTTPC_ERROR_* code on
+// transport failure. Channel/enabled gating is the caller's responsibility.
+int postFilamentDetectSet(uint8_t channel, const U1FilamentInfo& info) {
+    auto& cfg = ConfigurationManager::getInstance();
+    const char* moonrakerUrl = cfg.getMoonrakerURL();
+    if (!moonrakerUrl || moonrakerUrl[0] == '\0') return -1000;
+
+    if (g_httpMutex && xSemaphoreTake(g_httpMutex, pdMS_TO_TICKS(250)) != pdTRUE) {
+        return -1001;
+    }
+
+    StaticJsonDocument<512> body;
+    body["channel"] = channel;
+    JsonObject infoObj = body.createNestedObject("info");
+
+    if (info.vendor[0] != '\0')   infoObj["VENDOR"] = info.vendor;
+    if (info.main_type[0] != '\0') infoObj["MAIN_TYPE"] = info.main_type;
+    if (info.sub_type[0] != '\0')  infoObj["SUB_TYPE"] = info.sub_type;
+    if (info.rgb_1 >= 0) {
+        infoObj["RGB_1"] = (long)info.rgb_1;
+        infoObj["ALPHA"] = info.alpha;
+    }
+    if (info.hotend_min_temp > 0) infoObj["HOTEND_MIN_TEMP"] = info.hotend_min_temp;
+    if (info.hotend_max_temp > 0) infoObj["HOTEND_MAX_TEMP"] = info.hotend_max_temp;
+    if (info.bed_temp > 0)         infoObj["BED_TEMP"] = info.bed_temp;
+    if (info.card_uid_len > 0) {
+        JsonArray uidArr = infoObj.createNestedArray("CARD_UID");
+        for (uint8_t i = 0; i < info.card_uid_len; i++) {
+            uidArr.add((int)info.card_uid[i]);
+        }
+    }
+
+    String payload;
+    serializeJson(body, payload);
+
+    char url[192];
+    snprintf(url, sizeof(url), "%s/printer/filament_detect/set", moonrakerUrl);
+
+    WiFiClient client;
+    HTTPClient http;
+    http.setConnectTimeout(1000);
+    http.setTimeout(2000);
+    http.begin(client, url);
+    http.addHeader("Content-Type", "application/json");
+    int code = http.POST(payload);
+    http.end();
+
+    if (g_httpMutex) xSemaphoreGive(g_httpMutex);
+    return code;
+}
+
+}  // namespace
+
+U1Manager& U1Manager::getInstance() {
+    static U1Manager instance;
+    return instance;
+}
+
+void U1Manager::publishFromDetection(const SpoolDetectedPayload& payload) {
+    auto& cfg = ConfigurationManager::getInstance();
+    if (!cfg.isU1Enabled()) return;
+
+    uint8_t channel = cfg.getU1Channel();
+    if (channel > 3) return;  // belt-and-braces; loader already clamps
+
+    uint32_t now = millis();
+    if (moonrakerBackoffUntilMs_ != 0 && (int32_t)(now - moonrakerBackoffUntilMs_) < 0) {
+        return;
+    }
+
+    U1FilamentInfo info = buildFromDetection(payload);
+    int code = postFilamentDetectSet(channel, info);
+
+    Serial.printf("U1Manager: publishFromDetection channel=%u uid=%s — HTTP %d\n",
+                  (unsigned)channel, payload.spool_id, code);
+
+    if (code == -1000 || code == -1001) {
+        // Config or contention issue — neither warrants a backoff window
+        return;
+    }
+    if (code < 0) {
+        moonrakerBackoffUntilMs_ = millis() + MOONRAKER_BACKOFF_MS;
+        Serial.printf("U1Manager: U1/Moonraker unreachable — backing off %u ms\n",
+                      (unsigned)MOONRAKER_BACKOFF_MS);
+        return;
+    }
+    moonrakerBackoffUntilMs_ = 0;
+
+    // Register pending augment if POST 1 was incomplete and Spoolman is configured
+    // (otherwise there's no way the augment could supply anything new).
+    if (cfg.isSpoolmanEnabled() && !isComplete(info)) {
+        pendingAugment_.active = true;
+        strncpy(pendingAugment_.uid, payload.spool_id, sizeof(pendingAugment_.uid) - 1);
+        pendingAugment_.uid[sizeof(pendingAugment_.uid) - 1] = '\0';
+        pendingAugment_.expiresAtMs = millis() + PENDING_AUGMENT_TTL_MS;
+        pendingAugment_.wantVendor       = (info.vendor[0] == '\0');
+        pendingAugment_.wantMainType     = (info.main_type[0] == '\0');
+        pendingAugment_.wantColor        = (info.rgb_1 < 0);
+        pendingAugment_.wantHotendTemps  = (info.hotend_min_temp == 0 || info.hotend_max_temp == 0);
+        pendingAugment_.wantBedTemp      = (info.bed_temp == 0);
+    } else {
+        pendingAugment_.active = false;
+    }
+}
+
+void U1Manager::publishFromSpoolmanSync(const SpoolmanSyncedPayload& sync,
+                                          const CurrentSpoolState& state) {
+    auto& cfg = ConfigurationManager::getInstance();
+    if (!cfg.isU1Enabled()) return;
+    if (!sync.success || sync.spoolman_id <= 0) return;
+
+    uint8_t channel = cfg.getU1Channel();
+    if (channel > 3) return;
+
+    uint32_t now = millis();
+    if (moonrakerBackoffUntilMs_ != 0 && (int32_t)(now - moonrakerBackoffUntilMs_) < 0) {
+        return;
+    }
+
+    if (sync.is_uid_lookup) {
+        // Generic UID tag (NFC+) — Spoolman is the only data source. Single POST.
+        U1FilamentInfo info = buildFromSpoolmanSync(sync, state);
+        int code = postFilamentDetectSet(channel, info);
+        Serial.printf("U1Manager: publishFromSpoolmanSync(UID) channel=%u spool=%d — HTTP %d\n",
+                      (unsigned)channel, sync.spoolman_id, code);
+        if (code < 0 && code != -1000 && code != -1001) {
+            moonrakerBackoffUntilMs_ = millis() + MOONRAKER_BACKOFF_MS;
+        } else if (code >= 0) {
+            moonrakerBackoffUntilMs_ = 0;
+        }
+        return;
+    }
+
+    // Smart-tag follow-up sync — only POST if a pending augment is active for
+    // this UID and Spoolman supplied at least one field that POST 1 was missing.
+    if (!pendingAugment_.active) return;
+    if (strcmp(pendingAugment_.uid, sync.spool_id) != 0) {
+        pendingAugment_.active = false;
+        return;
+    }
+    if ((int32_t)(now - pendingAugment_.expiresAtMs) >= 0) {
+        pendingAugment_.active = false;
+        return;
+    }
+
+    bool augments = false;
+    if (pendingAugment_.wantVendor && sync.manufacturer[0] != '\0')        augments = true;
+    if (pendingAugment_.wantColor && sync.color_hex[0] != '\0')             augments = true;
+    if (pendingAugment_.wantHotendTemps && sync.extruder_temp > 0)          augments = true;
+    if (pendingAugment_.wantBedTemp && sync.bed_temp > 0)                   augments = true;
+    if (pendingAugment_.wantMainType && sync.material_name[0] != '\0')     augments = true;
+
+    pendingAugment_.active = false;  // single-shot regardless of outcome
+    if (!augments) return;
+
+    U1FilamentInfo merged = buildFromSpoolmanSync(sync, state);
+    int code = postFilamentDetectSet(channel, merged);
+    Serial.printf("U1Manager: publishFromSpoolmanSync(augment) channel=%u spool=%d — HTTP %d\n",
+                  (unsigned)channel, sync.spoolman_id, code);
+    if (code < 0 && code != -1000 && code != -1001) {
+        moonrakerBackoffUntilMs_ = millis() + MOONRAKER_BACKOFF_MS;
+    } else if (code >= 0) {
+        moonrakerBackoffUntilMs_ = 0;
+    }
+}
+
+#else  // NATIVE_TEST
+
+U1Manager& U1Manager::getInstance() {
+    static U1Manager instance;
+    return instance;
+}
+void U1Manager::publishFromDetection(const SpoolDetectedPayload&) {}
+void U1Manager::publishFromSpoolmanSync(const SpoolmanSyncedPayload&,
+                                          const CurrentSpoolState&) {}
+
+#endif

--- a/src/U1Manager.cpp
+++ b/src/U1Manager.cpp
@@ -351,7 +351,10 @@ void U1Manager::publishFromSpoolmanSync(const SpoolmanSyncedPayload& sync,
     // Smart-tag follow-up sync — only POST if a pending augment is active for
     // this UID and Spoolman supplied at least one field that POST 1 was missing.
     if (!pendingAugment_.active) return;
-    if (strcmp(pendingAugment_.uid, sync.spool_id) != 0) {
+    // Bound the compare to the UID buffer size so a non-null-terminated producer
+    // (defensive — both buffers are 17 bytes / 16 hex chars + null) can't make
+    // strcmp walk off the end.
+    if (strncmp(pendingAugment_.uid, sync.spool_id, sizeof(pendingAugment_.uid) - 1) != 0) {
         pendingAugment_.active = false;
         return;
     }

--- a/src/U1Manager.h
+++ b/src/U1Manager.h
@@ -9,6 +9,22 @@ struct SpoolDetectedPayload;
 struct SpoolmanSyncedPayload;
 struct CurrentSpoolState;
 
+// U1's external filament-detection wire format. Built from on-tag data, then
+// possibly augmented from a Spoolman sync result; serialized into the JSON body
+// of POST /printer/filament_detect/set.
+struct U1FilamentInfo {
+    char vendor[64] = {};
+    char main_type[24] = {};   // uppercase, e.g. "PLA", "PETG"
+    char sub_type[24] = {};    // e.g. "Matte", "CF", may be empty
+    int  rgb_1 = -1;            // -1 = no color sent
+    int  alpha = 255;
+    int  hotend_min_temp = 0;   // 0 = not sent
+    int  hotend_max_temp = 0;
+    int  bed_temp = 0;
+    uint8_t card_uid[8] = {};
+    uint8_t card_uid_len = 0;
+};
+
 // U1Manager — Snapmaker U1 direct-mode bridge.
 //
 // Pushes scanner results to the U1's external filament-detection endpoint
@@ -40,10 +56,11 @@ public:
     void publishFromDetection(const SpoolDetectedPayload& payload);
 
     // Spoolman sync result path.
-    //  - For generic UID tags (is_uid_lookup): single POST using lookup result.
+    //  - For generic UID tags (is_uid_lookup): single POST using lookup
+    //    result; skipped if the reader no longer holds the same tag.
     //  - For smart tags (write update): if a pending augment was registered
     //    by publishFromDetection, merges Spoolman data over the prior POST
-    //    and re-publishes; otherwise no-op.
+    //    and re-publishes if Spoolman supplied something new; otherwise no-op.
     void publishFromSpoolmanSync(const SpoolmanSyncedPayload& sync,
                                   const CurrentSpoolState& state);
 
@@ -58,17 +75,14 @@ private:
     static constexpr uint32_t MOONRAKER_BACKOFF_MS = 30000;
 
     // Pending-augment tracking for smart tags that POSTed incomplete data and
-    // are waiting on a Spoolman sync to fill missing fields.
+    // are waiting on a Spoolman sync to fill missing fields. postedInfo holds
+    // the exact wire-format struct that POST 1 sent — POST 2 starts from this
+    // and overlays non-empty Spoolman fields, so on-tag data is never lost.
     struct PendingAugment {
         bool active = false;
         char uid[17] = {};
         uint32_t expiresAtMs = 0;
-        // What was missing in POST 1 — drives whether Spoolman data is worth a POST 2.
-        bool wantVendor = false;
-        bool wantMainType = false;
-        bool wantColor = false;
-        bool wantHotendTemps = false;
-        bool wantBedTemp = false;
+        U1FilamentInfo postedInfo;
     };
     PendingAugment pendingAugment_ = {};
     static constexpr uint32_t PENDING_AUGMENT_TTL_MS = 30000;

--- a/src/U1Manager.h
+++ b/src/U1Manager.h
@@ -1,0 +1,70 @@
+#ifndef U1_MANAGER_H
+#define U1_MANAGER_H
+
+#include <cstdint>
+
+// Forward declarations to keep this header lean — full definitions live in
+// ApplicationManager.h (payload types) and NFCTypes.h (CurrentSpoolState).
+struct SpoolDetectedPayload;
+struct SpoolmanSyncedPayload;
+struct CurrentSpoolState;
+
+// U1Manager — Snapmaker U1 direct-mode bridge.
+//
+// Pushes scanner results to the U1's external filament-detection endpoint
+// (paxx12 Extended Firmware with "Filament Detection: External" enabled).
+// Reads u1_enabled / u1_channel / moonraker_url from ConfigurationManager
+// each call; everything else is internal state.
+//
+// Two entry points cover the full integration:
+//   publishFromDetection()    — smart tags (OpenSpool, OPT, TigerTag, OT3D, Bambu)
+//   publishFromSpoolmanSync() — generic UID tags (NFC+) and smart-tag augment
+//
+// Both no-op when U1 integration is disabled in NVS, so callers can invoke
+// unconditionally without gating.
+class U1Manager {
+public:
+    static U1Manager& getInstance();
+
+    // Smart tag scan path. Builds U1 info from on-tag data + per-material
+    // defaults, POSTs to /printer/filament_detect/set, and (if anything is
+    // still missing and Spoolman is configured) registers a pending augment
+    // for publishFromSpoolmanSync to fill in later.
+    void publishFromDetection(const SpoolDetectedPayload& payload);
+
+    // Spoolman sync result path.
+    //  - For generic UID tags (is_uid_lookup): single POST using lookup result.
+    //  - For smart tags (write update): if a pending augment was registered
+    //    by publishFromDetection, merges Spoolman data over the prior POST
+    //    and re-publishes; otherwise no-op.
+    void publishFromSpoolmanSync(const SpoolmanSyncedPayload& sync,
+                                  const CurrentSpoolState& state);
+
+private:
+    U1Manager() = default;
+    U1Manager(const U1Manager&) = delete;
+    U1Manager& operator=(const U1Manager&) = delete;
+
+    // Reachability backoff — set after a transport failure so an offline U1
+    // doesn't block the dispatch loop on every subsequent scan.
+    uint32_t moonrakerBackoffUntilMs_ = 0;
+    static constexpr uint32_t MOONRAKER_BACKOFF_MS = 30000;
+
+    // Pending-augment tracking for smart tags that POSTed incomplete data and
+    // are waiting on a Spoolman sync to fill missing fields.
+    struct PendingAugment {
+        bool active = false;
+        char uid[17] = {};
+        uint32_t expiresAtMs = 0;
+        // What was missing in POST 1 — drives whether Spoolman data is worth a POST 2.
+        bool wantVendor = false;
+        bool wantMainType = false;
+        bool wantColor = false;
+        bool wantHotendTemps = false;
+        bool wantBedTemp = false;
+    };
+    PendingAugment pendingAugment_ = {};
+    static constexpr uint32_t PENDING_AUGMENT_TTL_MS = 30000;
+};
+
+#endif // U1_MANAGER_H

--- a/src/U1Manager.h
+++ b/src/U1Manager.h
@@ -22,6 +22,13 @@ struct CurrentSpoolState;
 //
 // Both no-op when U1 integration is disabled in NVS, so callers can invoke
 // unconditionally without gating.
+//
+// Threading: must be called only from the ApplicationManager dispatch loop
+// (handleSpoolDetected / handleSpoolmanSynced). Internal state
+// (moonrakerBackoffUntilMs_, pendingAugment_) is not mutex-protected — the
+// dispatch loop is single-threaded so no synchronization is needed in the
+// current design. Cross-thread invocation would require revisiting both
+// fields, not just adding atomics around millis() math.
 class U1Manager {
 public:
     static U1Manager& getInstance();

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -746,6 +746,8 @@ void WebServerManager::handleApiGetConfig() {
     doc["low_spool_threshold_g"] = cfg.low_spool_threshold_g;
     doc["bambu_dashboard"] = cfg.bambu_dashboard;
     doc["wifi_keep_awake"] = cfg.wifi_keep_awake;
+    doc["u1_enabled"] = cfg.u1_enabled;
+    doc["u1_channel"] = cfg.u1_channel;
     doc["tft_enabled"] = cfg.tft_enabled;
     doc["tft_driver"] = cfg.tft_driver;
     doc["ap_mode"] = _apMode;
@@ -805,6 +807,11 @@ void WebServerManager::handleApiPostConfig() {
     update.low_spool_threshold_g = doc["low_spool_threshold_g"] | (uint16_t)100;
     update.bambu_dashboard = doc["bambu_dashboard"] | 0;
     update.wifi_keep_awake = doc["wifi_keep_awake"] | 0;
+    update.u1_enabled = doc["u1_enabled"] | (uint8_t)0;
+    {
+        uint8_t ch = doc["u1_channel"] | (uint8_t)0;
+        update.u1_channel = (ch <= 3) ? ch : 0;  // clamp invalid client input
+    }
 
     if (update.wifi_ssid[0] == '\0') {
         sendError(400, "WiFi SSID is required");


### PR DESCRIPTION
## Summary

Release v1.7.5 — adds Snapmaker U1 direct-mode integration as the only user-visible change since v1.7.4.

## Changes since v1.7.4 on dev

- `0cf9099` feat(u1): direct-mode integration via /printer/filament_detect/set
- `39f21f0` refactor(u1): extract U1Manager + add smart-tag support, defaults, augment
- `968728a` fix(u1): bound UID compare + document single-threaded invariant
- `1c05c96` fix(u1): address CodeRabbit review — preserve on-tag data + tag-still-present + don't kill late augments
- `48459ba` Merge pull request #182: Snapmaker U1 direct-mode integration

## CHANGELOG

See `CHANGELOG.md` for the full entry. Single-feature release.

## Post-merge

After merge:
1. Push tag \`v1.7.5\` on the merge commit → triggers \`Build and Release Firmware\` workflow
2. Workflow builds 4 envs, creates GitHub Release, dispatches to spoolsense.org
3. spoolsense.org auto-updates web-flasher manifests + binaries (recently-validated dispatch path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Snapmaker U1 direct-mode integration with filament detection publishing via HTTP
  * Added U1 configuration UI with enable toggle and toolhead channel selection (T0–T3)
  * Implemented automatic hostname suggestion based on selected channel
  * Added support for temperature defaults and Spoolman sync with U1 integration

* **Documentation**
  * Updated changelog for version 1.7.5 release

* **Chores**
  * Bumped firmware version to 1.7.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->