### PR TITLE
feat(#187): Prusa MK4/MMU3 HA blueprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Prusa MK4 / MMU3 HA blueprints** — two Home Assistant blueprints (`spoolsense_prusa_binding.yaml` + `spoolsense_prusa_lifecycle.yaml`) implementing per-slot Prusa spool tracking via HA orchestration. Default model is one scanner per slot (5 for MMU3). Pre-print material check uses bidirectional substring match; post-print deduction publishes per-tool grams via `cmd/deduct/<UID>` MQTT (reuses v1.6.14 path). Cancel proration by last-known progress %. PrusaLink local API has no slot-binding writes, so HA orchestration is the only path. Setup guide at [spoolsense.org/installation/prusa](https://spoolsense.org/installation/prusa/). Untested on real Prusa hardware. (#187, #195)
+
+---
+
 ## [1.7.5] - 2026-04-29
 
 ### Added

--- a/homeassistant/blueprints/spoolsense_prusa_binding.yaml
+++ b/homeassistant/blueprints/spoolsense_prusa_binding.yaml
@@ -65,8 +65,7 @@ actions:
   - variables:
       uid: "{{ trigger.to_state.attributes.uid | default('') }}"
       spoolman_id: "{{ trigger.to_state.attributes.spoolman_id | default(-1) }}"
-      material_raw: "{{ trigger.to_state.attributes.material_type | default('') }}"
-      material: "{{ material_raw.split(' ')[-1] | upper if material_raw else '' }}"
+      material: "{{ trigger.to_state.attributes.material_type | default('') | upper }}"
       color: "{{ trigger.to_state.attributes.color | default('') }}"
       label: !input slot_label
       notify: !input notify_on_bind

--- a/homeassistant/blueprints/spoolsense_prusa_binding.yaml
+++ b/homeassistant/blueprints/spoolsense_prusa_binding.yaml
@@ -1,0 +1,94 @@
+blueprint:
+  name: "SpoolSense → Prusa Slot Binding"
+  description: >
+    Bind a SpoolSense scanner to a single Prusa MMU3 slot (or the single MK4 extruder).
+    When the configured scanner publishes a spool present event, the spool's UID,
+    Spoolman ID, and material are written to a slot helper that the SpoolSense → Prusa
+    Lifecycle blueprint reads from on print start and finish.
+
+    Default model: one scanner per slot. Install this blueprint once per slot you want
+    to track (1× for MK4, 5× for MMU3), each instance configured with one scanner's
+    spool sensor and one slot helper.
+
+    Hard caveats:
+    - There is no printer-side signal for "spool was loaded into slot N." If the user
+      scans one spool but physically loads a different one, the system has no way to
+      detect the discrepancy.
+    - PrusaLink local API has no write endpoint for slot/material binding. The Prusa
+      LCD will not reflect the scanned spool.
+  domain: automation
+  input:
+    spoolsense_sensor:
+      name: SpoolSense Spool Sensor
+      description: >
+        The spool sensor entity from the scanner mounted at this slot
+        (e.g., sensor.spoolsense_4d9620_spool).
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    slot_helper:
+      name: Slot Helper
+      description: >
+        The input_text helper for this slot (e.g., input_text.prusa_slot_2).
+        Must allow at least 100 characters. Stores compact JSON:
+        {"uid":"...","sid":N,"mat":"...","color":"..."}.
+      selector:
+        entity:
+          filter:
+            - domain: input_text
+    slot_label:
+      name: Slot Label (optional)
+      description: >
+        Human-readable label for notifications (e.g., "MMU3 Slot 2", "MK4").
+        Used only in the optional notification.
+      default: ""
+      selector:
+        text: {}
+    notify_on_bind:
+      name: Notify on Bind
+      description: >
+        Send an HA notification when a spool is bound to this slot.
+      default: false
+      selector:
+        boolean: {}
+
+mode: single
+max_exceeded: silent
+
+triggers:
+  - trigger: state
+    entity_id: !input spoolsense_sensor
+    to: "present"
+
+actions:
+  - variables:
+      uid: "{{ trigger.to_state.attributes.uid | default('') }}"
+      spoolman_id: "{{ trigger.to_state.attributes.spoolman_id | default(-1) }}"
+      material_raw: "{{ trigger.to_state.attributes.material_type | default('') }}"
+      material: "{{ material_raw.split(' ')[-1] | upper if material_raw else '' }}"
+      color: "{{ trigger.to_state.attributes.color | default('') }}"
+      label: !input slot_label
+      notify: !input notify_on_bind
+
+  - condition: template
+    value_template: "{{ uid != '' }}"
+
+  - action: input_text.set_value
+    target:
+      entity_id: !input slot_helper
+    data:
+      value: >
+        {"uid":"{{ uid }}","sid":{{ spoolman_id }},"mat":"{{ material }}","color":"{{ color }}"}
+
+  - if:
+      - condition: template
+        value_template: "{{ notify }}"
+    then:
+      - action: persistent_notification.create
+        data:
+          title: "SpoolSense → Prusa"
+          message: >
+            Bound {{ material if material else 'spool' }}{% if label %} to {{ label }}{% endif %}
+            (UID {{ uid }}{% if spoolman_id|int(-1) >= 0 %}, Spoolman #{{ spoolman_id }}{% endif %}).
+          notification_id: "spoolsense_prusa_bind_{{ uid }}"

--- a/homeassistant/blueprints/spoolsense_prusa_lifecycle.yaml
+++ b/homeassistant/blueprints/spoolsense_prusa_lifecycle.yaml
@@ -132,6 +132,14 @@ actions:
       scanner_id: !input scanner_device_id
       action_choice: !input mismatch_action
       pause_btn: !input pause_button
+
+  - action: homeassistant.update_entity
+    target:
+      entity_id: "{{ meta_sensor }}"
+  - delay:
+      seconds: 3
+
+  - variables:
       meta: "{{ state_attr(meta_sensor, 'meta') | default({}, true) }}"
       gcode_types_array: "{{ meta.get('filament_type per tool', []) }}"
       gcode_type_single: "{{ meta.get('filament_type', '') }}"
@@ -155,14 +163,16 @@ actions:
               mismatches: >
                 {% set ns = namespace(out=[]) %}
                 {% for gcode_type in types_list %}
-                  {% set gtype = (gcode_type | string).split(' ')[-1] | upper %}
+                  {% set gtype = (gcode_type | string) | upper %}
                   {% if loop.index0 < slots | length %}
                     {% set helper_state = states(slots[loop.index0]) %}
                     {% if helper_state and helper_state not in ['unknown','unavailable',''] %}
                       {% set bound = helper_state | from_json(default={}) %}
                       {% set bound_mat = (bound.mat | default('') | upper) %}
-                      {% if bound_mat and gtype and bound_mat != gtype %}
-                        {% set ns.out = ns.out + [{'tool': loop.index0, 'gcode': gtype, 'bound': bound_mat}] %}
+                      {% if bound_mat and gtype %}
+                        {% if (gtype not in bound_mat) and (bound_mat not in gtype) %}
+                          {% set ns.out = ns.out + [{'tool': loop.index0, 'gcode': gtype, 'bound': bound_mat}] %}
+                        {% endif %}
                       {% endif %}
                     {% endif %}
                   {% endif %}

--- a/homeassistant/blueprints/spoolsense_prusa_lifecycle.yaml
+++ b/homeassistant/blueprints/spoolsense_prusa_lifecycle.yaml
@@ -1,0 +1,272 @@
+blueprint:
+  name: "SpoolSense → Prusa Print Lifecycle"
+  description: >
+    Pre-print material check + post-print Spoolman deduction for Prusa printers
+    (MK4 single extruder or MMU3 multi-color). One instance per printer; covers
+    all configured slots.
+
+    On state → printing: compares the gcode's per-tool material strings against
+    the spool bound to each slot. On mismatch, sends an HA notification (and
+    optionally pauses the print).
+
+    On state → finished: reads slicer-estimated grams used per tool from gcode
+    metadata and publishes deductions to the SpoolSense scanner via MQTT
+    (cmd/deduct/<UID>). Scanner handles Spoolman PATCH and writable-tag NVS
+    deferral.
+
+    On state → stopped (canceled): prorates the deduction by the last known
+    progress %. If the progress sensor is unavailable at cancel time,
+    deduction defaults to 0g.
+
+    Hard caveats:
+    - Deduction is the slicer's pre-print estimate, not measured usage.
+      Drift accumulates over many prints.
+    - PrusaLink reports nothing about which spool is physically loaded in
+      which slot. Bindings are user-asserted.
+    - Material mismatch checking is string-based and not bulletproof. Default
+      mismatch action is "notify only" — opt into "pause" only after you've
+      validated your slicer profiles match Spoolman material names.
+
+    Required prereq: a REST sensor in configuration.yaml polling
+    /api/v1/job and exposing file.meta as an attribute. See setup doc.
+  domain: automation
+  input:
+    prusa_state_sensor:
+      name: PrusaLink State Sensor
+      description: >
+        The PrusaLink integration's printer state sensor
+        (e.g., sensor.prusa_mk4_printer). Lowercase states like "printing",
+        "finished", "stopped".
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    prusa_progress_sensor:
+      name: PrusaLink Progress Sensor
+      description: >
+        The PrusaLink integration's job progress sensor
+        (e.g., sensor.prusa_mk4_progress). Used for cancel proration.
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    prusa_job_meta_sensor:
+      name: Prusa Job Meta REST Sensor
+      description: >
+        Your manually-configured REST sensor that polls /api/v1/job and
+        exposes file.meta as an attribute. The HA prusalink integration
+        does not expose this on its own. See setup doc for the YAML.
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    slot_helpers:
+      name: Slot Helpers (in slot order)
+      description: >
+        Select the slot helpers in physical slot order. Position 0 is
+        slot 0, position 1 is slot 1, etc. For MK4 select just the single
+        slot helper. For MMU3 select all 5 in order.
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - domain: input_text
+    scanner_device_id:
+      name: SpoolSense Scanner Device ID
+      description: >
+        Any one of your scanner device IDs (e.g., 4d9620). Used as the
+        MQTT topic prefix for cmd/deduct messages. The deduction message
+        carries the spool UID, so the scanner resolves the spool itself —
+        the scanner ID just routes the message.
+      selector:
+        text: {}
+    mismatch_action:
+      name: Material Mismatch Action
+      description: >
+        What to do when the gcode's expected material doesn't match the
+        spool bound to that slot. "Notify only" is recommended unless your
+        slicer profiles and Spoolman material names are perfectly aligned —
+        false positives will pause good prints.
+      default: notify
+      selector:
+        select:
+          options:
+            - label: "Notify only (recommended)"
+              value: notify
+            - label: "Notify + pause the print"
+              value: notify_pause
+    pause_button:
+      name: PrusaLink Pause Button (optional)
+      description: >
+        Required only if Mismatch Action is "Notify + pause". Select the
+        PrusaLink integration's Pause button entity for this printer
+        (e.g., button.prusa_mk4_pause_job).
+      default: ""
+      selector:
+        entity:
+          filter:
+            - domain: button
+
+mode: single
+max_exceeded: silent
+
+triggers:
+  - trigger: state
+    entity_id: !input prusa_state_sensor
+    to: "printing"
+    id: pre_check
+  - trigger: state
+    entity_id: !input prusa_state_sensor
+    to: "finished"
+    id: deduct_full
+  - trigger: state
+    entity_id: !input prusa_state_sensor
+    to: "stopped"
+    id: deduct_prorated
+
+actions:
+  - variables:
+      meta_sensor: !input prusa_job_meta_sensor
+      progress_sensor: !input prusa_progress_sensor
+      slots: !input slot_helpers
+      scanner_id: !input scanner_device_id
+      action_choice: !input mismatch_action
+      pause_btn: !input pause_button
+      meta: "{{ state_attr(meta_sensor, 'meta') | default({}, true) }}"
+      gcode_types_array: "{{ meta.get('filament_type per tool', []) }}"
+      gcode_type_single: "{{ meta.get('filament_type', '') }}"
+      gcode_grams_array: "{{ meta.get('filament used [g] per tool', []) }}"
+      gcode_grams_single: "{{ meta.get('filament used [g]', 0) | float(0) }}"
+
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: pre_check
+        sequence:
+          - variables:
+              types_list: >
+                {% if gcode_types_array %}
+                  {{ gcode_types_array }}
+                {% elif gcode_type_single %}
+                  {{ [gcode_type_single] }}
+                {% else %}
+                  {{ [] }}
+                {% endif %}
+              mismatches: >
+                {% set ns = namespace(out=[]) %}
+                {% for gcode_type in types_list %}
+                  {% set gtype = (gcode_type | string).split(' ')[-1] | upper %}
+                  {% if loop.index0 < slots | length %}
+                    {% set helper_state = states(slots[loop.index0]) %}
+                    {% if helper_state and helper_state not in ['unknown','unavailable',''] %}
+                      {% set bound = helper_state | from_json(default={}) %}
+                      {% set bound_mat = (bound.mat | default('') | upper) %}
+                      {% if bound_mat and gtype and bound_mat != gtype %}
+                        {% set ns.out = ns.out + [{'tool': loop.index0, 'gcode': gtype, 'bound': bound_mat}] %}
+                      {% endif %}
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+                {{ ns.out }}
+          - if:
+              - condition: template
+                value_template: "{{ mismatches | length > 0 }}"
+            then:
+              - action: persistent_notification.create
+                data:
+                  title: "SpoolSense → Prusa: material mismatch"
+                  message: >
+                    {% for m in mismatches %}
+                    Tool {{ m.tool }}: gcode wants {{ m.gcode }}, slot has {{ m.bound }}.
+                    {% endfor %}
+                  notification_id: "spoolsense_prusa_mismatch"
+              - if:
+                  - condition: template
+                    value_template: "{{ action_choice == 'notify_pause' and pause_btn != '' }}"
+                then:
+                  - action: button.press
+                    target:
+                      entity_id: "{{ pause_btn }}"
+
+      - conditions:
+          - condition: trigger
+            id: deduct_full
+        sequence:
+          - variables:
+              grams_list: >
+                {% if gcode_grams_array %}
+                  {{ gcode_grams_array }}
+                {% else %}
+                  {{ [gcode_grams_single] }}
+                {% endif %}
+              factor: 1.0
+          - repeat:
+              for_each: "{{ grams_list }}"
+              sequence:
+                - variables:
+                    tool_index: "{{ repeat.index | int - 1 }}"
+                    grams_used: "{{ (repeat.item | float(0)) * factor }}"
+                - condition: template
+                  value_template: "{{ grams_used > 0 and tool_index < slots | length }}"
+                - variables:
+                    helper_state: "{{ states(slots[tool_index]) }}"
+                - condition: template
+                  value_template: "{{ helper_state not in ['unknown','unavailable',''] }}"
+                - variables:
+                    bound: "{{ helper_state | from_json(default={}) }}"
+                    uid: "{{ bound.uid | default('') }}"
+                - condition: template
+                  value_template: "{{ uid != '' }}"
+                - action: mqtt.publish
+                  data:
+                    topic: "spoolsense/{{ scanner_id }}/cmd/deduct/{{ uid }}"
+                    payload: '{"deduct_g": {{ grams_used | round(2) }}}'
+
+      - conditions:
+          - condition: trigger
+            id: deduct_prorated
+        sequence:
+          - variables:
+              progress_raw: "{{ states(progress_sensor) }}"
+              progress_pct: >
+                {% set v = progress_raw | float(-1) %}
+                {{ v if v >= 0 else 0 }}
+              factor: "{{ (progress_pct | float(0)) / 100.0 }}"
+              grams_list: >
+                {% if gcode_grams_array %}
+                  {{ gcode_grams_array }}
+                {% else %}
+                  {{ [gcode_grams_single] }}
+                {% endif %}
+          - action: persistent_notification.create
+            data:
+              title: "SpoolSense → Prusa: print canceled"
+              message: >
+                Print canceled at {{ progress_pct | round(1) }}% progress.
+                Deducting prorated estimate. Adjust Spoolman manually if needed.
+              notification_id: "spoolsense_prusa_cancel"
+          - if:
+              - condition: template
+                value_template: "{{ factor | float(0) > 0 }}"
+            then:
+              - repeat:
+                  for_each: "{{ grams_list }}"
+                  sequence:
+                    - variables:
+                        tool_index: "{{ repeat.index | int - 1 }}"
+                        grams_used: "{{ (repeat.item | float(0)) * (factor | float(0)) }}"
+                    - condition: template
+                      value_template: "{{ grams_used > 0 and tool_index < slots | length }}"
+                    - variables:
+                        helper_state: "{{ states(slots[tool_index]) }}"
+                    - condition: template
+                      value_template: "{{ helper_state not in ['unknown','unavailable',''] }}"
+                    - variables:
+                        bound: "{{ helper_state | from_json(default={}) }}"
+                        uid: "{{ bound.uid | default('') }}"
+                    - condition: template
+                      value_template: "{{ uid != '' }}"
+                    - action: mqtt.publish
+                      data:
+                        topic: "spoolsense/{{ scanner_id }}/cmd/deduct/{{ uid }}"
+                        payload: '{"deduct_g": {{ grams_used | round(2) }}}'


### PR DESCRIPTION
## Summary

Adds two Home Assistant blueprints implementing per-slot Prusa spool tracking through HA orchestration. Closes the design phase of #187.

PrusaLink's local API has no slot-binding write endpoints, so per-slot tracking has to live in HA (verified against hexdocs prusa_link + Prusa-Link-Web OpenAPI spec). This is the realistic path for HA-using Prusa MK4/MMU3 users — no firmware changes needed, deduction reuses the existing `cmd/deduct/<UID>` MQTT path that already handles writable-tag NVS deferral and Spoolman direct PATCH.

## Changes

- `homeassistant/blueprints/spoolsense_prusa_binding.yaml` — per-slot scanner-to-helper binding. 1 instance for MK4, 5 for MMU3.
- `homeassistant/blueprints/spoolsense_prusa_lifecycle.yaml` — single-instance per printer; pre-print material mismatch check + post-print prorated Spoolman deduction.

Setup doc + caveats live at `~/Code/spoolsense.org/docs/installation/prusa.md` (separate, will land direct-to-main on the docs site per usual flow).

## Locked design decisions

1. Cancel handling: prorate by last-known progress %, fallback 0g if unavailable
2. Mismatch action: user-selectable input (`notify` default, `notify_pause` opt-in)
3. Single combined lifecycle blueprint (pre-check + deduction)
4. MK4 + MMU3 ship together — slot count is just config
5. Default model: 1 scanner per slot (Discord user explicitly said multi-scanner — see #187)

## Static verification (via cocoindex against firmware)

- ✅ Topic shape `spoolsense/<id>/cmd/deduct/<UID>` matches `HomeAssistantManager::handleCommand` parser at src/HomeAssistantManager.cpp:794
- ✅ Payload key `deduct_g` matches `deductDoc["deduct_g"]` at src/HomeAssistantManager.cpp:863
- ✅ Spool sensor attributes read by binding blueprint (`uid`, `material_type`, `spoolman_id`, `color`) all confirmed as real keys in `TagStateJson::buildTagStateJson` at src/TagStateJson.h:31-47

## Hard caveats called out in setup doc

- **Slicer estimate, not measured usage.** Bambu reports actual; PrusaLink does not. ~1g drift per clean print, more on aborts/stringing.
- **No printer-side load detection.** Bindings are user-asserted via the scan workflow. Physical mismatches go undetected.
- **Cancel proration is best-effort.** If the progress sensor is unavailable at the moment of `stopped`, deduction is 0g.
- **Prusa LCD will not reflect bound spools.** No write API; this is a Prusa-side limit.

## Validation status

**Untested on real Prusa hardware** (none in dev environment). Validation gaps that need a Prusa user:
- `meta["filament used [g] per tool"]` population on current MMU3 firmware
- Per-tool array indexing vs MMU3 physical slot order
- REST sensor digest auth on current PrusaLink firmware
- Cancel proration end-to-end on a `stopped` print

Material name normalization uses the same `last-token-upper` pattern as the Bambu blueprint. This works for `"PRUSAMENT PLA"` → `"PLA"` but does the wrong thing for TigerTag-style names like `"PLA Sandstorm Orange"` → `"ORANGE"`. Inherits Bambu's behavior; happy to refine in a follow-up if it turns out to be a real problem in practice.

## How to Test

- [ ] Import binding blueprint, instantiate once, scan a tagged spool, confirm `input_text.prusa_slot_0` gets compact JSON `{"uid":"...","sid":N,"mat":"...","color":"..."}`
- [ ] Import lifecycle blueprint, set up REST sensor per setup doc, start a print, confirm pre-check fires
- [ ] On `printing` state with a known-mismatch binding, confirm HA notification lists the wrong slot
- [ ] On `finished`, confirm `cmd/deduct/<UID>` MQTT message published per slot with `deduct_g` > 0
- [ ] On `stopped` mid-print, confirm prorated deduction = estimate × progress%

## Checklist

- [ ] Tested on real Prusa MK4 hardware
- [ ] Tested on real Prusa MMU3 hardware
- [ ] Setup doc on spoolsense.org cross-referenced (will land separately, direct-to-main)

Closes design phase of #187 — implementation lands here. Real-hardware validation is a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prusa MK4 / MMU3 Home Assistant blueprints for spool tracking
  * Enabled per-slot material validation with mismatch notifications
  * Added MQTT-based post-print spool deductions by tool
  * Implemented print cancellation deduction adjustments

* **Documentation**
  * Added setup documentation for new Prusa blueprints with hardware compatibility notes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpoolSense/spoolsense_scanner/pull/195)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->