### PR TITLE
fix(#200): Bambu deduction blueprint — loop.index0 undefined in repeat action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Bambu deduction blueprint template error** — `tray_index` used `loop.index0`, which is only defined inside Jinja `{% for %}` blocks, not HA `repeat:` actions. Newer Home Assistant versions raise `UndefinedError: 'loop' is undefined` and the deduction never fires. Now uses `repeat.index - 1`. Re-import the blueprint after updating. (#200)
+
 ### Added
 
 - **Prusa MK4 / MMU3 HA blueprints** — two Home Assistant blueprints (`spoolsense_prusa_binding.yaml` + `spoolsense_prusa_lifecycle.yaml`) implementing per-slot Prusa spool tracking via HA orchestration. Default model is one scanner per slot (5 for MMU3). Pre-print material check uses bidirectional substring match; post-print deduction publishes per-tool grams via `cmd/deduct/<UID>` MQTT (reuses v1.6.14 path). Cancel proration by last-known progress %. PrusaLink local API has no slot-binding writes, so HA orchestration is the only path. Setup guide at [spoolsense.org/installation/prusa](https://spoolsense.org/installation/prusa/). Untested on real Prusa hardware. (#187, #195)

--- a/homeassistant/blueprints/spoolsense_bambu_deduction.yaml
+++ b/homeassistant/blueprints/spoolsense_bambu_deduction.yaml
@@ -69,7 +69,7 @@ actions:
       sequence:
         - variables:
             tray_entity: "{{ repeat.item }}"
-            tray_index: "{{ loop.index0 }}"
+            tray_index: "{{ repeat.index - 1 }}"
             ams_num: "{{ (tray_index | int // 4) + 1 }}"
             tray_in_ams: "{{ (tray_index | int % 4) + 1 }}"
             tray_attr_key: "AMS {{ ams_num }} Tray {{ tray_in_ams }}"


### PR DESCRIPTION
## Summary

The Bambu deduction blueprint's `tray_index` variable used `loop.index0`, which only exists inside Jinja `{% for %}` blocks. Inside an HA `repeat:` action the loop context is `repeat.*`, so newer Home Assistant versions raise `UndefinedError: 'loop' is undefined` and the deduction never fires. Reported with full trace in #200.

## Changes

- `spoolsense_bambu_deduction.yaml`: `tray_index: "{{ loop.index0 }}"` → `"{{ repeat.index - 1 }}"` (`repeat.index` is 1-based)
- CHANGELOG entry under Unreleased

## Not affected

- Dashboard blueprint's `loop.index0` is inside a real `{% for %}` block — valid
- Prusa lifecycle blueprint already used `repeat.index` correctly

## How to Test

- [ ] Re-import the deduction blueprint in HA after this lands on `main`
- [ ] Finish or cancel a Bambu print with tray usage; confirm the automation trace shows `tray_index` resolving 0..N and `cmd/deduct_tray` MQTT publishes fire

Fixes #200.