### PR TITLE
chore: explicit CodeRabbit base branches (main, dev)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,7 +13,8 @@ reviews:
     enabled: true
     drafts: false
     base_branches:
-      - ".*"
+      - "main"
+      - "dev"
 
   instructions: |
     This is an ESP32 Arduino firmware project (C++17) using PlatformIO.


### PR DESCRIPTION
## Summary

CodeRabbit skipped PR #206 with "auto reviews are disabled on base/target branches other than the default branch" and reported "Configuration used: defaults" — it never loaded this repo's `.coderabbit.yaml`, whose `".*"` regex should already match dev. Replacing the regex with explicit branch names is self-documenting and immune to regex-handling changes on their side.

## Changes

- `.coderabbit.yaml`: `auto_review.base_branches` from `[".*"]` to `["main", "dev"]`

## How to Test

Next PR targeting `dev` should get an automatic CodeRabbit review instead of a skip notice.