### PR TITLE
fix: debounce tag removal — require 3 consecutive missed detects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- **Tag present/removed flapping with stationary tags** — a single failed read (RF hiccup, marginal coupling) immediately declared the tag removed, and the next 50ms poll re-detected it. Every subscriber flapped with it: MQTT `present`, the HA sensor, displays. Removal is now debounced behind 3 consecutive misses (~150ms). Reported by two users (serial log flapping every ~5s; HA sensor "hopping").
 - **WiFi association failures on ESP32-C3 (SuperMini / SuperMini Plus)** — station init now clears stale association state and sets mode + sleep configuration before `WiFi.begin()`. Boards that previously fell back to AP mode on every boot connect normally. Connect window extended from 15s to 30s, and the WiFi status code is logged during the wait and on failure so unsuccessful connects are diagnosable from serial.
 - **Bambu deduction blueprint template error** — `tray_index` used `loop.index0`, which is only defined inside Jinja `{% for %}` blocks, not HA `repeat:` actions. Newer Home Assistant versions raise `UndefinedError: 'loop' is undefined` and the deduction never fires. Now uses `repeat.index - 1`. Re-import the blueprint after updating. (#200)
 

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -615,6 +615,7 @@ void NFCManager::scanLoop() {
         }
 
         if (connection_->detectTag(uid, &uidLength)) {
+            absentMisses_ = 0;
             if (!lastSeenValid || memcmp(uid, lastSeenUid, uidLength) != 0) {
                 char uidHex[17]; uidHex[0] = '\0';
                 for (uint8_t i = 0; i < uidLength; i++) snprintf(uidHex + i*2, 3, "%02X", uid[i]);
@@ -627,8 +628,16 @@ void NFCManager::scanLoop() {
                 handleNewTag(uid, uidLength);
             }
             processWriteQueue();
-        } else {
+        } else if (!lastSeenValid) {
+            // Nothing was present — no debounce needed, keep state cleared
             handleTagAbsent();
+        } else if (++absentMisses_ >= TAG_ABSENT_MISS_THRESHOLD) {
+            // Debounce removal: single failed reads happen with stationary tags
+            // (RF hiccups, marginal coupling). Only declare the tag gone after
+            // several consecutive misses, or present/removed flaps every few
+            // seconds and every subscriber (MQTT, HA, displays) flaps with it.
+            handleTagAbsent();
+            absentMisses_ = 0;
         }
 
         vTaskDelay(pdMS_TO_TICKS(50));

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -162,6 +162,8 @@ private:
     bool lastSeenValid = false;
     unsigned long lastSeenMs = 0;            // millis() when last tag was detected
     static constexpr unsigned long SCAN_COOLDOWN_MS = 3000;  // suppress re-reads within 3s
+    uint8_t absentMisses_ = 0;               // consecutive failed detects while a tag was present
+    static constexpr uint8_t TAG_ABSENT_MISS_THRESHOLD = 3;  // ~150ms at 50ms poll before declaring removal
 
     // Recent spools history (RAM only, most recent first)
     RecentSpoolEntry recentSpools[MAX_RECENT_SPOOLS];


### PR DESCRIPTION
## Summary

A single failed `detectTag()` immediately fired `handleTagAbsent()`, so a stationary tag with occasional RF hiccups flapped present/removed every few seconds — MQTT `present`, the HA sensor, and displays all flapped with it. Two user reports: serial log cycling detect/remove every ~5s with a stationary tag at 5mm, and an HA sensor "hopping between present and not".

## Changes

- Removal now requires 3 consecutive missed detects (~150ms at the 50ms poll) before `handleTagAbsent()` fires
- When nothing was present to begin with, the absent path runs undebounced as before
- Counter lives entirely in the scan task — single writer, single reader, no locking needed

## Verification

- Local reviewer pass: no new bugs; its overflow concern doesn't apply (counter resets via the `lastSeenValid` transition), pre-existing `lastSeenValid` read pattern unchanged
- esp32dev builds green

## How to Test

- [ ] Stationary tag on reader for 10+ minutes: no `Tag removed` events in `/logs`
- [ ] Actually removing the tag still reports removal promptly (within ~200ms)
- [ ] HA `sensor.spoolsense_*_spool` stays `present` with a resting tag