### PR TITLE
feat(#185): save tag_format to Spoolman extras on enrichment save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **Spoolman links on the reader page** — every Spoolman ID shown after a scan is now a link that opens that spool's page in Spoolman's web UI (new tab). Also fixes the OpenSpool reader view's existing link, which used a hash route that landed on Spoolman's home page instead of the spool. (#179)
 - **Prusa MK4 / MMU3 HA blueprints** — two Home Assistant blueprints (`spoolsense_prusa_binding.yaml` + `spoolsense_prusa_lifecycle.yaml`) implementing per-slot Prusa spool tracking via HA orchestration. Default model is one scanner per slot (5 for MMU3). Pre-print material check uses bidirectional substring match; post-print deduction publishes per-tool grams via `cmd/deduct/<UID>` MQTT (reuses v1.6.14 path). Cancel proration by last-known progress %. PrusaLink local API has no slot-binding writes, so HA orchestration is the only path. Setup guide at [spoolsense.org/installation/prusa](https://spoolsense.org/installation/prusa/). Untested on real Prusa hardware. (#187, #195)
 
+### Added (writer pages)
+
+- **`tag_format` saved to Spoolman extras on enrichment save** — the TigerTag, OpenTag3D, and OpenSpool writer pages now record the tag's format (`tigertag`, `opentag3d`, `openspool`) in the spool's `Tag Format` extra field, matching what auto-sync already writes. Spool updates merge with existing extras so middleware-managed fields (like Happy Hare's MMU Gate) are preserved. (#185)
+
 ### Fixed
 
 - **Tag present/removed flapping with stationary tags** — a single failed read (RF hiccup, marginal coupling) immediately declared the tag removed, and the next 50ms poll re-detected it. Every subscriber flapped with it: MQTT `present`, the HA sensor, displays. Removal is now debounced behind 3 consecutive misses (~150ms). Reported by two users (serial log flapping every ~5s; HA sensor "hopping").

--- a/src/OpenSpoolWriterHTML.h
+++ b/src/OpenSpoolWriterHTML.h
@@ -294,6 +294,7 @@ const char OPENSPOOL_WRITER_HTML[] PROGMEM = R"rawliteral(
         },
         afterSuccess: function(uid) {
           return saveEnrichmentToSpoolman(uid, {
+            tagFormat: 'openspool',
             enrichmentFieldIds: ENRICHMENT_FIELDS,
             getFields: function() {
               var nozzleMin = parseInt(document.getElementById('min_temp').value) || 0;

--- a/src/OpenTag3DWriterHTML.h
+++ b/src/OpenTag3DWriterHTML.h
@@ -522,6 +522,7 @@ const char OPENTAG3D_WRITER_HTML[] PROGMEM = R"rawliteral(
         },
         afterSuccess: function(uid) {
           return saveEnrichmentToSpoolman(uid, {
+            tagFormat: 'opentag3d',
             enrichmentFieldIds: ENRICHMENT_FIELDS,
             getFields: function() {
               var nozzleMin = parseInt(document.getElementById('min_print_temp_c').value) || 0;

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -784,7 +784,8 @@ async function saveEnrichmentToSpoolman(uid, config) {
         diameter_mm: fields.diameterMm || 1.75,
         density: fields.density || 0,
         vendor_id: vendorId,
-        filament_id: filamentId
+        filament_id: filamentId,
+        tag_format: config.tagFormat || ''
       })
     });
     var result = await resp.json();

--- a/src/TigerTagWriterHTML.h
+++ b/src/TigerTagWriterHTML.h
@@ -570,6 +570,7 @@ const char TIGERTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
         },
         afterSuccess: function(uid) {
           return saveEnrichmentToSpoolman(uid, {
+            tagFormat: 'tigertag',
             enrichmentFieldIds: ENRICHMENT_FIELDS,
             getFields: function() {
               var nozzleMin = parseInt(document.getElementById('nozzle_min').value) || 0;

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -412,13 +412,14 @@ void WebServerManager::handleApiRegisterUid() {
     snprintf(quotedUid, sizeof(quotedUid), "\"%s\"", uid);
 
     float existingInitialWeight = 0.0f;
-    int spoolId = enrichFindSpoolByUid(client, http, baseUrl, quotedUid, existingInitialWeight);
+    String linkExtraJson;
+    int spoolId = enrichFindSpoolByUid(client, http, baseUrl, quotedUid, existingInitialWeight, linkExtraJson);
 
     if (spoolId > 0) {
         // Spool exists — update it instead of creating a duplicate
         Serial.printf("register-uid: found existing spool %d, updating\n", spoolId);
         float effInitial = initialWeight > 0 ? initialWeight : existingInitialWeight;
-        if (!enrichUpdateSpool(client, http, baseUrl, spoolId, filamentId, remainingWeight, effInitial)) {
+        if (!enrichUpdateSpool(client, http, baseUrl, spoolId, filamentId, remainingWeight, effInitial, "", "")) {
             xSemaphoreGive(g_httpMutex);
             sendError(500, "Failed to update existing spool");
             return;
@@ -1983,7 +1984,8 @@ int WebServerManager::enrichFindOrCreateFilament(WiFiClient& client, HTTPClient&
 
 // Fetch all spools and match nfc_id client-side — Spoolman's extra_field filter is unreliable
 int WebServerManager::enrichFindSpoolByUid(WiFiClient& client, HTTPClient& http,
-                                            const char* baseUrl, const char* quotedUid, float& outInitialWeight) {
+                                            const char* baseUrl, const char* quotedUid, float& outInitialWeight,
+                                            String& outExtraJson) {
     char url[256];
     snprintf(url, sizeof(url), "%s/api/v1/spool?limit=200", baseUrl);
     http.begin(client, url);
@@ -1991,6 +1993,7 @@ int WebServerManager::enrichFindSpoolByUid(WiFiClient& client, HTTPClient& http,
     int code = http.GET();
     int spoolId = -1;
     outInitialWeight = 0.0f;
+    outExtraJson = "";
     if (code == 200) {
         String response = http.getString();
         DynamicJsonDocument sDoc(16384);
@@ -2002,6 +2005,9 @@ int WebServerManager::enrichFindSpoolByUid(WiFiClient& client, HTTPClient& http,
                 if (arr[i]["archived"] | false) continue;
                 spoolId = arr[i]["id"] | -1;
                 outInitialWeight = arr[i]["initial_weight"] | 0.0f;
+                // Capture existing extras — Spoolman PATCH replaces the whole
+                // extra map, so any update that touches extras must merge
+                serializeJson(arr[i]["extra"], outExtraJson);
                 break;
             }
         }
@@ -2012,10 +2018,25 @@ int WebServerManager::enrichFindSpoolByUid(WiFiClient& client, HTTPClient& http,
 
 // PATCH existing spool — Spoolman uses used_weight (not remaining_weight) for weight tracking
 bool WebServerManager::enrichUpdateSpool(WiFiClient& client, HTTPClient& http, const char* baseUrl,
-                                           int spoolId, int filamentId, float remainingG, float existingInitialWeight) {
+                                           int spoolId, int filamentId, float remainingG, float existingInitialWeight,
+                                           const char* existingExtraJson, const char* tagFormat) {
     char url[256];
-    StaticJsonDocument<256> patch;
+    StaticJsonDocument<512> patch;
     patch["filament_id"] = filamentId;
+
+    // Only touch extras when writing tag_format. Spoolman PATCH replaces the
+    // entire extra map, so the existing extras (nfc_id, middleware fields like
+    // MMU Gate) must be carried over or they get wiped.
+    StaticJsonDocument<384> existingExtra;
+    if (tagFormat[0] != '\0') {
+        if (existingExtraJson[0] != '\0') {
+            deserializeJson(existingExtra, existingExtraJson);
+        }
+        char fmtJson[20];
+        snprintf(fmtJson, sizeof(fmtJson), "\"%s\"", tagFormat);
+        existingExtra["tag_format"] = fmtJson;
+        patch["extra"] = existingExtra;
+    }
     if (remainingG > 0) {
         float initialW = existingInitialWeight > 0 ? existingInitialWeight : 1000.0f;
         float usedW = initialW - remainingG;
@@ -2035,7 +2056,8 @@ bool WebServerManager::enrichUpdateSpool(WiFiClient& client, HTTPClient& http, c
 }
 
 int WebServerManager::enrichCreateSpool(WiFiClient& client, HTTPClient& http, const char* baseUrl,
-                                          int filamentId, float remainingG, const char* quotedUid) {
+                                          int filamentId, float remainingG, const char* quotedUid,
+                                          const char* tagFormat) {
     char url[256];
     StaticJsonDocument<512> sBody;
     sBody["filament_id"] = filamentId;
@@ -2048,6 +2070,11 @@ int WebServerManager::enrichCreateSpool(WiFiClient& client, HTTPClient& http, co
     }
     JsonObject extra = sBody.createNestedObject("extra");
     extra["nfc_id"] = quotedUid;
+    char fmtJson[20];
+    if (tagFormat[0] != '\0') {
+        snprintf(fmtJson, sizeof(fmtJson), "\"%s\"", tagFormat);
+        extra["tag_format"] = fmtJson;
+    }
     String sJson;
     serializeJson(sBody, sJson);
     snprintf(url, sizeof(url), "%s/api/v1/spool", baseUrl);
@@ -2093,6 +2120,21 @@ void WebServerManager::handleApiSpoolmanSaveEnrichment() {
     int   confirmedVendorId   = doc["vendor_id"]   | -1;
     int   confirmedFilamentId = doc["filament_id"] | -1;
 
+    // tag_format: lowercase alnum + underscore, canonical values from
+    // tagKindToMqttFormat (openprinttag, tigertag, opentag3d, openspool, ...)
+    char tagFormat[16] = "";
+    {
+        const char* tf = doc["tag_format"] | "";
+        size_t n = 0;
+        for (; tf[n] != '\0' && n < sizeof(tagFormat) - 1; n++) {
+            char c = tf[n];
+            bool ok = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
+            if (!ok) { n = 0; break; }
+            tagFormat[n] = c;
+        }
+        tagFormat[n] = '\0';
+    }
+
     if (uid[0] == '\0') {
         _server.send(400, "application/json", "{\"error\":\"uid required\"}");
         return;
@@ -2119,16 +2161,18 @@ void WebServerManager::handleApiSpoolmanSaveEnrichment() {
     char quotedUid[130];
     snprintf(quotedUid, sizeof(quotedUid), "\"%s\"", uid);
     float existingInitialWeight = 0.0f;
-    int spoolId = enrichFindSpoolByUid(client, http, baseUrl, quotedUid, existingInitialWeight);
+    String existingExtraJson;
+    int spoolId = enrichFindSpoolByUid(client, http, baseUrl, quotedUid, existingInitialWeight, existingExtraJson);
 
     if (spoolId > 0) {
-        if (!enrichUpdateSpool(client, http, baseUrl, spoolId, filamentId, remainingG, existingInitialWeight)) {
+        if (!enrichUpdateSpool(client, http, baseUrl, spoolId, filamentId, remainingG, existingInitialWeight,
+                               existingExtraJson.c_str(), tagFormat)) {
             xSemaphoreGive(g_httpMutex);
             _server.send(500, "application/json", "{\"error\":\"spool update failed\"}");
             return;
         }
     } else {
-        spoolId = enrichCreateSpool(client, http, baseUrl, filamentId, remainingG, quotedUid);
+        spoolId = enrichCreateSpool(client, http, baseUrl, filamentId, remainingG, quotedUid, tagFormat);
     }
 
     StaticJsonDocument<128> result;

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -2026,16 +2026,25 @@ bool WebServerManager::enrichUpdateSpool(WiFiClient& client, HTTPClient& http, c
 
     // Only touch extras when writing tag_format. Spoolman PATCH replaces the
     // entire extra map, so the existing extras (nfc_id, middleware fields like
-    // MMU Gate) must be carried over or they get wiped.
-    StaticJsonDocument<384> existingExtra;
+    // MMU Gate) must be carried over or they get wiped. If the existing extras
+    // fail to parse (or overflow the buffer), skip the extras portion entirely
+    // rather than PATCHing a partial map — losing tag_format is harmless,
+    // wiping nfc_id is not.
+    StaticJsonDocument<768> existingExtra;
     if (tagFormat[0] != '\0') {
+        DeserializationError extraErr = DeserializationError::Ok;
         if (existingExtraJson[0] != '\0') {
-            deserializeJson(existingExtra, existingExtraJson);
+            extraErr = deserializeJson(existingExtra, existingExtraJson);
         }
-        char fmtJson[20];
-        snprintf(fmtJson, sizeof(fmtJson), "\"%s\"", tagFormat);
-        existingExtra["tag_format"] = fmtJson;
-        patch["extra"] = existingExtra;
+        if (extraErr == DeserializationError::Ok) {
+            char fmtJson[20];
+            snprintf(fmtJson, sizeof(fmtJson), "\"%s\"", tagFormat);
+            existingExtra["tag_format"] = fmtJson;
+            patch["extra"] = existingExtra;
+        } else {
+            Serial.printf("WebServer: existing extras unparseable (%s) — skipping tag_format write\n",
+                          extraErr.c_str());
+        }
     }
     if (remainingG > 0) {
         float initialW = existingInitialWeight > 0 ? existingInitialWeight : 1000.0f;

--- a/src/WebServerManager.h
+++ b/src/WebServerManager.h
@@ -105,11 +105,12 @@ private:
                                     const char* material, const char* colorHex, int vendorId,
                                     float density, float diameter, int bedTemp, int nozzleTemp, int confirmedId);
     int enrichFindSpoolByUid(WiFiClient& client, HTTPClient& http, const char* baseUrl,
-                              const char* quotedUid, float& outInitialWeight);
+                              const char* quotedUid, float& outInitialWeight, String& outExtraJson);
     bool enrichUpdateSpool(WiFiClient& client, HTTPClient& http, const char* baseUrl,
-                            int spoolId, int filamentId, float remainingG, float existingInitialWeight);
+                            int spoolId, int filamentId, float remainingG, float existingInitialWeight,
+                            const char* existingExtraJson, const char* tagFormat);
     int enrichCreateSpool(WiFiClient& client, HTTPClient& http, const char* baseUrl,
-                           int filamentId, float remainingG, const char* quotedUid);
+                           int filamentId, float remainingG, const char* quotedUid, const char* tagFormat);
 
     void sendError(int code, const char* msg);
 #endif


### PR DESCRIPTION
## Summary

Writer pages (TigerTag, OpenTag3D, OpenSpool) now send the tag's format with the save-enrichment POST, and the handler writes it to the spool's `Tag Format` extra — same canonical lowercase strings the auto-sync path already uses. Closes the writer-page gap in #185.

## The important part: extras merge

Spoolman's PATCH replaces the **entire** extra map. Updating an existing spool now captures its current extras in `enrichFindSpoolByUid` and merges `tag_format` into them. Without the merge, writing tag_format would have wiped `nfc_id` and middleware-managed extras (Happy Hare's MMU Gate, printer name). Flows that don't write tag_format leave extras untouched entirely — the register-uid path passes empty and behaves exactly as before.

## Changes

- `SharedJS.h`: `tag_format` in the save-enrichment POST body
- 3 writer pages: pass their format string (`tigertag`, `opentag3d`, `openspool`)
- `WebServerManager`: parse + sanitize (lowercase alnum + underscore, 15 chars), thread through `enrichUpdateSpool` (with extras merge) and `enrichCreateSpool`
- `enrichFindSpoolByUid`: also returns the found spool's serialized extras

## Verification

- Local reviewer pass: no bugs found (walked all call sites including the unchanged register-uid path)
- esp32dev builds green

## How to Test

- [ ] Write a TigerTag via the writer page with enrichment data; confirm the spool's `Tag Format` extra shows `tigertag` in Spoolman
- [ ] Repeat on a spool that already has `nfc_id` + a manually-set extra; confirm both survive the update
- [ ] NFC+ register-uid flow: confirm extras unchanged

Closes #185.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Writer page saves now preserve existing spool details when updating enrichment data.
  * Tag format is now saved with TigerTag, OpenTag3D, and OpenSpool writes, helping spool records reflect the correct format.
  * Enrichment updates now keep middleware-managed fields intact instead of overwriting them.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->