### PR TITLE
chore: exempt pending-release label from stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,4 +17,4 @@ jobs:
           stale-issue-label: "stale"
           days-before-stale: 60
           days-before-close: 14
-          exempt-issue-labels: "P1-critical,P2-high,blocked"
+          exempt-issue-labels: "P1-critical,P2-high,blocked,pending-release"


### PR DESCRIPTION
Issues whose fix is merged to dev but not yet released were getting stale-closed as not-planned (#167 was closed by the bot two days after its implementation merged). The `pending-release` label now exists and is exempted; tag issues at PR-merge time and the bot leaves them alone until the release closes them properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated issue-staleness handling to keep items with the `pending-release` label from being marked stale, alongside other exempt labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->