### PR TITLE
feat: memory phase 1 — heap + per-task stack HWM instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **Configurable status LED pin** — new optional `led_pin` setting on the config page (Hardware section). Empty means the board default; overrides are validated against per-board rules (strap pins, flash pins, input-only pins, PSRAM-reserved pins, NFC reader pins, and enabled-feature pins) at the NVS boundary and fall back to the default with a serial warning if invalid. (#203, closes #196)
+- **Heap and per-task stack instrumentation** — every FreeRTOS task now self-reports its stack high-water mark, logged with heap stats (free / min-ever / largest block) as `MEM:` lines every 60s on serial and the `/logs` web viewer. `/api/diagnostics` gains `min_free_bytes` and a per-task `stack_hwm_bytes` map. Baseline for the memory-recovery work: heap changes are validated against measured numbers from here on.
 - **Tag writes verified by readback** — TigerTag, OpenTag3D, and OpenSpool writes re-read the written pages and compare against the intended data after every reported success. A mismatch triggers one full-rewrite recovery, then fails loudly instead of reporting success on a corrupted write. Matters more now that the ACK fix is nibble-permissive: the 4-bit ACK carries no CRC, so a noise byte can read as success. (#167)
 
 ### Fixed

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -10,6 +10,7 @@
 #include "TagStateJson.h"
 #include "LEDManager.h"
 #include "LogBuffer.h"
+#include "MemoryDiagnostics.h"
 #include "SpoolmanManager.h"
 #include "TrayDashboardTypes.h"
 
@@ -366,6 +367,7 @@ void HomeAssistantManager::taskLoop() {
             break;
         }
 
+        MemoryDiagnostics::reportSelf(MemoryDiagnostics::Task::HA);
         uint32_t now = millis();
 
         // Main loop: reconnect if needed, drain publish queue, process MQTT

--- a/src/LCDManager.cpp
+++ b/src/LCDManager.cpp
@@ -1,4 +1,5 @@
 #include "LCDManager.h"
+#include "MemoryDiagnostics.h"
 #include <Arduino.h>
 #include <cstring>
 
@@ -114,6 +115,7 @@ void LCDManager::taskFunc(void* param) {
 void LCDManager::taskLoop() {
     while (true) {
         processQueue();
+        MemoryDiagnostics::reportSelf(MemoryDiagnostics::Task::LCD);
         vTaskDelay(pdMS_TO_TICKS(50));  // 20 Hz update rate (sufficient for human-readable display)
     }
 }

--- a/src/LEDManager.cpp
+++ b/src/LEDManager.cpp
@@ -10,6 +10,7 @@
 
 #ifndef NATIVE_TEST
 #include <Arduino.h>
+#include "MemoryDiagnostics.h"
 #endif
 
 #ifndef M_PI
@@ -310,6 +311,7 @@ void LEDManager::ledTaskLoop() {
 
         // Wait for setTarget/requestFlash notification OR 10ms tick for breathing animation
         ulTaskNotifyTake(pdTRUE, isBreathing ? pdMS_TO_TICKS(10) : portMAX_DELAY);
+        MemoryDiagnostics::reportSelf(MemoryDiagnostics::Task::LED);
 
         // Snapshot state from shared members (protected by mutex)
         xSemaphoreTake(_mutex, portMAX_DELAY);

--- a/src/MemoryDiagnostics.cpp
+++ b/src/MemoryDiagnostics.cpp
@@ -1,0 +1,79 @@
+#include "MemoryDiagnostics.h"
+#include "LogBuffer.h"
+#include <esp_heap_caps.h>
+
+static constexpr uint32_t kReportIntervalMs = 5000;
+
+static const char* const kTaskNames[MemoryDiagnostics::MAX_TRACKED] = {
+    "loopTask",
+    "NFCScanTask",
+    "SpoolmanSync",
+    "HATask",
+    "TFTTask",
+    "LCDTask",
+    "LEDTask",
+    "PrinterPoll",
+};
+
+namespace {
+struct Slot {
+    volatile uint32_t hwmBytes;
+    volatile uint32_t lastReportMs;  // 0 = never reported
+};
+}
+static Slot slots_[MemoryDiagnostics::MAX_TRACKED];
+
+void MemoryDiagnostics::reportSelf(Task t) {
+    size_t i = (size_t)t;
+    if (i >= MAX_TRACKED) {
+        return;
+    }
+    uint32_t now = millis();
+    if (slots_[i].lastReportMs != 0 && now - slots_[i].lastReportMs < kReportIntervalMs) {
+        return;
+    }
+    // ESP-IDF StackType_t is uint8_t, so the high-water mark is already in bytes
+    slots_[i].hwmBytes = (uint32_t)uxTaskGetStackHighWaterMark(nullptr);
+    slots_[i].lastReportMs = (now != 0) ? now : 1;
+}
+
+size_t MemoryDiagnostics::collect(TaskStackStat* out, size_t maxOut) {
+    size_t count = 0;
+    for (size_t i = 0; i < MAX_TRACKED && count < maxOut; i++) {
+        if (slots_[i].lastReportMs == 0) {
+            continue;
+        }
+        out[count].name = kTaskNames[i];
+        out[count].stackHighWaterBytes = slots_[i].hwmBytes;
+        count++;
+    }
+    return count;
+}
+
+void MemoryDiagnostics::logStats() {
+    // ESP.getFreeHeap() blends PSRAM into the totals on -S3 boards; the internal-only
+    // numbers are where task stacks, WiFi buffers, and TLS actually live
+    LogBuffer::getInstance().logPrintf("MEM: heap free=%u min=%u largest=%u | internal free=%u min=%u largest=%u\n",
+                                       (unsigned)ESP.getFreeHeap(),
+                                       (unsigned)ESP.getMinFreeHeap(),
+                                       (unsigned)ESP.getMaxAllocHeap(),
+                                       (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT),
+                                       (unsigned)heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT),
+                                       (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+
+    TaskStackStat stats[MAX_TRACKED];
+    size_t count = collect(stats, MAX_TRACKED);
+
+    char line[192];
+    line[0] = '\0';
+    size_t pos = 0;
+    for (size_t i = 0; i < count; i++) {
+        int written = snprintf(line + pos, sizeof(line) - pos, "%s=%u ",
+                               stats[i].name, (unsigned)stats[i].stackHighWaterBytes);
+        if (written < 0 || pos + (size_t)written >= sizeof(line)) {
+            break;
+        }
+        pos += (size_t)written;
+    }
+    LogBuffer::getInstance().logPrintf("MEM: stack-hwm %s\n", line);
+}

--- a/src/MemoryDiagnostics.h
+++ b/src/MemoryDiagnostics.h
@@ -1,0 +1,49 @@
+#ifndef MEMORY_DIAGNOSTICS_H
+#define MEMORY_DIAGNOSTICS_H
+
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+// Heap + per-task stack instrumentation. Each task reports its own high-water
+// mark via reportSelf() from inside its loop — a running task can never be a
+// stale handle, and the last report survives task stop (HA reconnect, TFT
+// freeForOTA), which is what a stack audit wants.
+//
+// Each slot is written only by its own task and read from the Arduino loop
+// task; 32-bit aligned writes are atomic on ESP32, so no locking is needed.
+class MemoryDiagnostics {
+public:
+    MemoryDiagnostics() = delete;
+
+    enum class Task : uint8_t {
+        Loop,
+        NFCScan,
+        SpoolmanSync,
+        HA,
+        TFT,
+        LCD,
+        LED,
+        PrinterPoll,
+        COUNT
+    };
+
+    static constexpr size_t MAX_TRACKED = (size_t)Task::COUNT;
+
+    struct TaskStackStat {
+        const char* name;
+        uint32_t stackHighWaterBytes;
+    };
+
+    // Call from inside the owning task's loop; rate-limited internally so the
+    // stack scan runs at most every 5s per task
+    static void reportSelf(Task t);
+
+    // Fills out[] with stats for tasks that have reported, returns count
+    static size_t collect(TaskStackStat* out, size_t maxOut);
+
+    // Log heap stats + per-task stack high-water marks to serial/LogBuffer
+    static void logStats();
+};
+
+#endif // MEMORY_DIAGNOSTICS_H

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -9,6 +9,7 @@
   #include "HardwareNFCConnection.h"
   #include "SpoolmanManager.h"
   #include "LogBuffer.h"
+  #include "MemoryDiagnostics.h"
   #include <Arduino.h>
 #else
   #include "platform/NativePlatform.h"
@@ -605,6 +606,7 @@ void NFCManager::scanLoop() {
     while (true) {
 #ifndef NATIVE_TEST
         esp_task_wdt_reset();
+        MemoryDiagnostics::reportSelf(MemoryDiagnostics::Task::NFCScan);
 #endif
         uint8_t uid[8];
         uint8_t uidLength = 0;

--- a/src/PrinterManager.cpp
+++ b/src/PrinterManager.cpp
@@ -5,6 +5,9 @@
 #include "NFCTypes.h"
 #include <Arduino.h>
 #include <cstring>
+#ifndef NATIVE_TEST
+#include "MemoryDiagnostics.h"
+#endif
 
 extern "C" {
 #include "openprinttag_lib.h"
@@ -63,6 +66,9 @@ void PrinterManager::pollingTaskFunc(void* param) {
 
     while (true) {
         self->poll();
+#ifndef NATIVE_TEST
+        MemoryDiagnostics::reportSelf(MemoryDiagnostics::Task::PrinterPoll);
+#endif
         vTaskDelay(pdMS_TO_TICKS(config.getPollIntervalMs()));
     }
 }

--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -1,6 +1,7 @@
 #include "SpoolmanManager.h"
 #include "ConfigurationManager.h"
 #include "ApplicationManager.h"
+#include "MemoryDiagnostics.h"
 #include <HTTPClient.h>
 #include <WiFiClient.h>
 #include <ArduinoJson.h>
@@ -1181,6 +1182,7 @@ void SpoolmanManager::taskLoop() {
     SpoolmanSyncRequest req;
     while (true) {
         if (xQueueReceive(syncQueue, &req, portMAX_DELAY) == pdTRUE) {
+            MemoryDiagnostics::reportSelf(MemoryDiagnostics::Task::SpoolmanSync);
             if (!isConfigured()) {
                 continue;
             }

--- a/src/TFTManager.cpp
+++ b/src/TFTManager.cpp
@@ -1,5 +1,6 @@
 #include "TFTManager.h"
 #include "ConfigurationManager.h"
+#include "MemoryDiagnostics.h"
 #include <Arduino.h>
 
 // TFT display controller for 240x240 ST7789 or GC9A01 (round). Manages sprite rendering to PSRAM
@@ -223,6 +224,7 @@ void TFTManager::taskFunc(void* param) {
 void TFTManager::taskLoop() {
     while (true) {
         processQueue();
+        MemoryDiagnostics::reportSelf(MemoryDiagnostics::Task::TFT);
         vTaskDelay(pdMS_TO_TICKS(20));  // 50 Hz update rate; allows other tasks to run between renders
     }
 }

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -9,6 +9,7 @@
 #include <HTTPClient.h>
 #include <WiFiClientSecure.h>
 
+#include "MemoryDiagnostics.h"
 #include "LandingHTML.h"
 #include "OpenPrintTagWriterHTML.h"
 #include "ReaderHTML.h"
@@ -640,7 +641,8 @@ void WebServerManager::handleApiSpoolmanPendingLink() {
 void WebServerManager::handleApiDiagnostics() {
     _server.sendHeader("Access-Control-Allow-Origin", "*");
 
-    StaticJsonDocument<1024> doc;
+    // 1536: task stack-hwm entries added on top of the original 1024 payload
+    StaticJsonDocument<1536> doc;
 
     // Device ID
     char deviceId[8];
@@ -708,7 +710,22 @@ void WebServerManager::handleApiDiagnostics() {
     memory["total_bytes"]     = totalHeap;
     memory["used_bytes"]      = totalHeap - freeHeap;
     memory["largest_block"]   = (uint32_t)ESP.getMaxAllocHeap();
+    memory["min_free_bytes"]  = (uint32_t)ESP.getMinFreeHeap();
+    memory["internal_free_bytes"]     = (uint32_t)heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    memory["internal_min_free_bytes"] = (uint32_t)heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    memory["internal_largest_block"]  = (uint32_t)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
     memory["uptime_s"]        = (uint32_t)(millis() / 1000);
+
+    JsonObject stacks = memory.createNestedObject("stack_hwm_bytes");
+    MemoryDiagnostics::TaskStackStat stats[MemoryDiagnostics::MAX_TRACKED];
+    size_t statCount = MemoryDiagnostics::collect(stats, MemoryDiagnostics::MAX_TRACKED);
+    for (size_t i = 0; i < statCount; i++) {
+        stacks[stats[i].name] = stats[i].stackHighWaterBytes;
+    }
+
+    if (doc.overflowed()) {
+        LogBuffer::getInstance().logPrintf("WebServer: diagnostics JSON truncated — grow doc capacity\n");
+    }
 
     String out;
     serializeJson(doc, out);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "NFCManager.h"
 #include "SpoolmanManager.h"
 #include "HomeAssistantManager.h"
+#include "MemoryDiagnostics.h"
 #include "DisplayI.h"
 #include "LCDManager.h"
 #include "TFTManager.h"
@@ -435,6 +436,14 @@ void loop() {
 
   // Fallback: retry NTP sync if boot-time attempt failed (non-blocking 30s interval)
   retryNTP();
+
+  // Heap + per-task stack high-water-mark baseline (60s interval, phase 1 memory work)
+  MemoryDiagnostics::reportSelf(MemoryDiagnostics::Task::Loop);
+  static unsigned long lastMemLog = 0;
+  if (millis() - lastMemLog >= 60000) {
+    lastMemLog = millis();
+    MemoryDiagnostics::logStats();
+  }
 
   // NFC scanning and other async work delegated to FreeRTOS tasks — 10ms soft delay prevents loop busywaiting
   delay(10);


### PR DESCRIPTION
## What

Baseline instrumentation for the memory-recovery milestone. Every persistent FreeRTOS task self-reports its stack high-water mark via `uxTaskGetStackHighWaterMark(NULL)` from inside its own loop (rate-limited to one scan per 5s per task) into single-writer volatile slots — a running task can never be a stale handle, and the last report survives task stop (HA reconnect, TFT `freeForOTA`).

- `MEM:` lines every 60s on serial and `/logs`: heap free / min-ever / largest block, **plus internal-RAM-only variants** (on PSRAM boards `ESP.getFreeHeap()` blends PSRAM into the totals; the internal numbers are where task stacks, WiFi, and TLS actually live), and per-task stack headroom
- `/api/diagnostics` gains `min_free_bytes`, `internal_free_bytes`, `internal_min_free_bytes`, `internal_largest_block`, and a `stack_hwm_bytes` map (doc capacity 1024→1536, `doc.overflowed()` guarded)

## Why self-report instead of handle registry / uxTaskGetSystemState

- Stored handles: stale-TCB dereference after HA stop or TFT OTA kill (caught in review)
- `xTaskGetHandle` lookup: TOCTOU between lookup and query (caught in review)
- `uxTaskGetSystemState`: not compiled into arduino-esp32's prebuilt IDF libs (`CONFIG_FREERTOS_USE_TRACE_FACILITY` unset — link error)

Self-reporting has no lifecycle race by construction.

## Validation

All 4 board envs build. Field-validated on an S3-DevKitC bench: all reporters live under real scan/sync/write load. The numbers have already paid rent — they flagged SpoolmanSync's stack floor (~1.7KB) before a canary panic later confirmed it (fix in the follow-up #218 branch), and identified `syncSpool`'s 2.4KB frame as a Phase 2/3 diet target.

Part of the memory-recovery plan; later phases (JSON streaming, String cleanup, measured stack trims) are validated against these numbers.