### PR TITLE
test+ci: version the native test suite and add PR build/test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev]
+
+jobs:
+  native-tests:
+    name: Native tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run native test suite
+        run: make -C test/native test
+
+  firmware:
+    name: Build ${{ matrix.env }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [esp32dev, esp32s3zero, esp32c3, esp32s3devkitc]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Provide UserConfig
+        run: cp include/UserConfig.example.h include/UserConfig.h
+      - name: Build
+        run: pio run -e ${{ matrix.env }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
           path: |
             ~/.platformio
             ~/.cache/pip
-          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+          key: pio-${{ runner.os }}-py3.11-pio6.1.19-${{ hashFiles('platformio.ini') }}
       - name: Install PlatformIO
-        run: pip install platformio
+        run: pip install platformio==6.1.19
       - name: Provide UserConfig
         run: cp include/UserConfig.example.h include/UserConfig.h
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 .vscode/
 include/UserConfig.h
 serial.log
-test/
+# test build artifacts (sources are tracked)
+test/native/*.o
+test/native/test_printer_manager
+test/native/*.dSYM/
+test/build/
 tools/
 esp32-planning.md
 docs/*-preview.html

--- a/include/UserConfig.example.h
+++ b/include/UserConfig.example.h
@@ -34,7 +34,8 @@
 /* Optional hardware features */
 #define ENABLE_LCD 0
 #define ENABLE_STATUS_LED 1  // Always available on S3-Zero (onboard LED), optional on WROOM (external wiring)
-#define ENABLE_KEYPAD 0      // 3x4 matrix keypad — wiring per BoardPins.h
+#define ENABLE_KEYPAD 0
+#define ENABLE_BAMBU_DASHBOARD 0      // 3x4 matrix keypad — wiring per BoardPins.h
                              // Note: Using LCD + keypad together on S3 is not recommended due to limited GPIO.
                              //       For LCD + keypad builds, use the WROOM board.
 

--- a/include/platform/NativePlatform.h
+++ b/include/platform/NativePlatform.h
@@ -132,6 +132,11 @@ inline BaseType_t xTaskCreatePinnedToCore(
     (void)priority; (void)handle; (void)core;
     return pdPASS;
 }
+inline BaseType_t xTaskCreate(
+    void (*taskFunc)(void*), const char* name, uint32_t stackSize,
+    void* param, UBaseType_t priority, TaskHandle_t* handle) {
+    return xTaskCreatePinnedToCore(taskFunc, name, stackSize, param, priority, handle, 0);
+}
 
 // FreeRTOS queue peek
 inline BaseType_t xQueuePeek(QueueHandle_t queue, void* item, TickType_t wait) {

--- a/test/integration/mock_prusalink.py
+++ b/test/integration/mock_prusalink.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Mock PrusaLink HTTP server for integration testing SpoolSense scanner.
+
+Simulates /api/v1/status and /api/v1/job endpoints.
+Control state via command-line args or HTTP POST to /mock/state.
+
+Usage:
+    python3 mock_prusalink.py                    # starts idle
+    python3 mock_prusalink.py --port 8080
+
+Then from another terminal:
+    curl -X POST http://localhost:8080/mock/state -d '{"state":"printing","job_id":42,"filament_g":9.18}'
+    curl -X POST http://localhost:8080/mock/state -d '{"state":"finished"}'
+    curl -X POST http://localhost:8080/mock/state -d '{"state":"idle"}'
+"""
+
+import json
+import argparse
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+
+class MockState:
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.printer_state = "IDLE"
+        self.job_id = None
+        self.job_state = ""
+        self.progress = 0.0
+        self.filament_g = 0.0
+        self.filament_type = "PLA"
+        self.nozzle_temp = 0
+        self.bed_temp = 0
+        self.material_name = ""
+        self.download_ref = ""
+        # Per-tool (XL)
+        self.filament_per_tool = []
+        self.filament_type_per_tool = []
+
+    def set_printing(self, job_id: int, filament_g: float = 0,
+                     filament_type: str = "PLA", nozzle_temp: int = 215,
+                     bed_temp: int = 60, progress: float = 0.0):
+        self.printer_state = "PRINTING"
+        self.job_id = job_id
+        self.job_state = "PRINTING"
+        self.progress = progress
+        self.filament_g = filament_g
+        self.filament_type = filament_type
+        self.nozzle_temp = nozzle_temp
+        self.bed_temp = bed_temp
+
+    def set_progress(self, progress: float):
+        self.progress = progress
+
+    def set_finished(self):
+        self.job_state = "FINISHED"
+        self.progress = 100.0
+
+    def set_stopped(self):
+        self.job_state = "STOPPED"
+
+    def set_idle(self):
+        self.reset()
+
+    def status_response(self) -> dict:
+        resp = {
+            "printer": {
+                "state": self.printer_state,
+                "temp_nozzle": self.nozzle_temp if self.job_id else 22.0,
+                "target_nozzle": self.nozzle_temp if self.job_id else 0,
+                "temp_bed": self.bed_temp if self.job_id else 22.0,
+                "target_bed": self.bed_temp if self.job_id else 0,
+            }
+        }
+        if self.job_id is not None:
+            resp["job"] = {
+                "id": self.job_id,
+                "progress": self.progress,
+            }
+        return resp
+
+    def job_response(self) -> dict | None:
+        if self.job_id is None:
+            return None
+
+        meta = {}
+        if self.filament_g > 0:
+            meta["filament used [g]"] = self.filament_g
+        if self.filament_type:
+            meta["filament_type"] = self.filament_type
+        if self.nozzle_temp:
+            meta["temperature"] = self.nozzle_temp
+        if self.bed_temp:
+            meta["bed_temperature"] = self.bed_temp
+        if self.material_name:
+            meta["material_name"] = self.material_name
+        if self.filament_per_tool:
+            meta["filament used [g] per tool"] = self.filament_per_tool
+        if self.filament_type_per_tool:
+            meta["filament_type per tool"] = self.filament_type_per_tool
+
+        resp = {
+            "state": self.job_state,
+            "progress": self.progress,
+            "file": {
+                "name": "test_print.gcode",
+                "meta": meta,
+            }
+        }
+        if self.download_ref:
+            resp["file"]["refs"] = {"download": self.download_ref}
+        return resp
+
+
+mock = MockState()
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        # Quieter logging
+        pass
+
+    def _send_json(self, code: int, data: dict):
+        body = json.dumps(data).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        # Check API key
+        api_key = self.headers.get("X-Api-Key", "")
+        if not api_key:
+            self.send_error(401, "Missing X-Api-Key")
+            return
+
+        if self.path == "/api/v1/status":
+            self._send_json(200, mock.status_response())
+
+        elif self.path == "/api/v1/job":
+            resp = mock.job_response()
+            if resp is None:
+                self.send_response(204)
+                self.end_headers()
+            else:
+                self._send_json(200, resp)
+
+        elif self.path.startswith("/api/v1/job/"):
+            try:
+                requested_id = int(self.path.rsplit("/", 1)[1])
+            except ValueError:
+                self.send_error(400, "Invalid job id")
+                return
+            resp = mock.job_response()
+            if resp is None or requested_id != mock.job_id:
+                self.send_error(404)
+            else:
+                self._send_json(200, resp)
+
+        elif self.path == "/api/v1/info":
+            self._send_json(200, {
+                "mmu": False,
+                "name": "MockPrusa",
+                "nozzle_diameter": 0.4,
+                "serial": "MOCK123456",
+            })
+
+        elif self.path == "/mock/state":
+            self._send_json(200, {
+                "printer_state": mock.printer_state,
+                "job_id": mock.job_id,
+                "job_state": mock.job_state,
+                "progress": mock.progress,
+            })
+
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        if self.path == "/mock/state":
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length)) if length > 0 else {}
+
+            state = body.get("state", "idle")
+            if state == "printing":
+                mock.set_printing(
+                    job_id=body.get("job_id", 1),
+                    filament_g=body.get("filament_g", 0),
+                    filament_type=body.get("filament_type", "PLA"),
+                    nozzle_temp=body.get("nozzle_temp", 215),
+                    bed_temp=body.get("bed_temp", 60),
+                    progress=body.get("progress", 0.0),
+                )
+            elif state == "progress":
+                mock.set_progress(body.get("progress", 0.0))
+            elif state == "finished":
+                mock.set_finished()
+            elif state == "stopped":
+                mock.set_stopped()
+            elif state == "idle":
+                mock.set_idle()
+
+            # XL per-tool
+            if "filament_per_tool" in body:
+                mock.filament_per_tool = body["filament_per_tool"]
+            if "filament_type_per_tool" in body:
+                mock.filament_type_per_tool = body["filament_type_per_tool"]
+
+            print(f"[mock] State → {mock.printer_state} job={mock.job_id} "
+                  f"job_state={mock.job_state} progress={mock.progress}% "
+                  f"filament={mock.filament_g}g")
+
+            self._send_json(200, {"ok": True})
+
+        elif self.path == "/mock/reset":
+            mock.reset()
+            print("[mock] Reset to idle")
+            self._send_json(200, {"ok": True})
+
+        else:
+            self.send_error(404)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mock PrusaLink server")
+    parser.add_argument("--port", type=int, default=8080)
+    args = parser.parse_args()
+
+    server = HTTPServer(("0.0.0.0", args.port), Handler)
+    print(f"Mock PrusaLink running on http://0.0.0.0:{args.port}")
+    print(f"Control: POST http://localhost:{args.port}/mock/state")
+    print(f"  {'{'}\"state\":\"printing\",\"job_id\":42,\"filament_g\":9.18{'}'}")
+    print(f"  {'{'}\"state\":\"finished\"{'}'}")
+    print(f"  {'{'}\"state\":\"idle\"{'}'}")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down")
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_filament_mismatch.py
+++ b/test/integration/test_filament_mismatch.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Filament mismatch warning test.
+
+Starts a print that expects ABS (240C nozzle) while the NFC tag has PLA loaded.
+Verifies the scanner logs a FILAMENT MISMATCH warning.
+
+Usage:
+    python3 test_filament_mismatch.py --mock-host localhost --mock-port 8080
+"""
+
+import argparse
+import time
+import requests
+
+
+def set_mock_state(base_url: str, state: dict):
+    r = requests.post(f"{base_url}/mock/state", json=state)
+    r.raise_for_status()
+    print(f"  Mock → {state.get('state', '?')}")
+
+
+def wait(seconds: int, reason: str):
+    print(f"  Waiting {seconds}s — {reason}")
+    time.sleep(seconds)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mock-host", default="localhost")
+    parser.add_argument("--mock-port", type=int, default=8080)
+    args = parser.parse_args()
+
+    mock_url = f"http://{args.mock_host}:{args.mock_port}"
+
+    print("=" * 60)
+    print("SpoolSense PrusaLink Test: Filament Mismatch Warning")
+    print("=" * 60)
+
+    requests.post(f"{mock_url}/mock/reset")
+
+    # Start print expecting ABS at 240C — but tag should have PLA loaded
+    print("\n[1/3] Starting print expecting ABS (240C nozzle, 100C bed)...")
+    set_mock_state(mock_url, {
+        "state": "printing",
+        "job_id": 77,
+        "filament_g": 15.0,
+        "filament_type": "ABS",
+        "nozzle_temp": 240,
+        "bed_temp": 100,
+    })
+    wait(15, "Scanner should detect mismatch if tag has PLA")
+
+    print("\n[2/3] Check serial output for:")
+    print("  PrinterManager: FILAMENT MISMATCH — gcode expects 'ABS', tag has 'PLA'")
+    print("  EVENT: PrinterWarning type=filament_mismatch expected=ABS actual=PLA")
+    print("  (LCD should show 'WRONG FILAMENT!' / 'ABS!=PLA WRONG!')")
+    print("  (LED should flash yellow 3x)")
+
+    # Also test temp warning — if tag has max_print_temp < 240
+    print("\n[3/3] Temperature check:")
+    print("  If tag has max_print_temp=220 and gcode needs 240C:")
+    print("  PrinterManager: TEMP WARNING — gcode 240C exceeds tag max 220C")
+
+    # Let it finish
+    set_mock_state(mock_url, {"state": "finished"})
+    wait(5, "Cleanup")
+    requests.post(f"{mock_url}/mock/reset")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_print_canceled.py
+++ b/test/integration/test_print_canceled.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Print cancellation test — verifies partial filament deduction.
+
+Usage:
+    python3 test_print_canceled.py --mock-host localhost --mock-port 8080
+"""
+
+import argparse
+import json
+import time
+import sys
+import requests
+
+
+def set_mock_state(base_url: str, state: dict):
+    r = requests.post(f"{base_url}/mock/state", json=state)
+    r.raise_for_status()
+    print(f"  Mock → {state.get('state', '?')}")
+
+
+def wait(seconds: int, reason: str):
+    print(f"  Waiting {seconds}s — {reason}")
+    time.sleep(seconds)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mock-host", default="localhost")
+    parser.add_argument("--mock-port", type=int, default=8080)
+    args = parser.parse_args()
+
+    mock_url = f"http://{args.mock_host}:{args.mock_port}"
+
+    print("=" * 60)
+    print("SpoolSense PrusaLink Test: Print Canceled at 30%")
+    print("=" * 60)
+
+    # Reset
+    requests.post(f"{mock_url}/mock/reset")
+
+    # Start print
+    print("\n[1/4] Starting print (job_id=99, filament=20.0g)...")
+    set_mock_state(mock_url, {
+        "state": "printing",
+        "job_id": 99,
+        "filament_g": 20.0,
+        "filament_type": "PETG",
+        "nozzle_temp": 240,
+        "bed_temp": 85,
+    })
+    wait(15, "Scanner detects print start")
+
+    # Progress to 30%
+    print("\n[2/4] Progress to 30%...")
+    set_mock_state(mock_url, {"state": "progress", "progress": 30.0})
+    wait(12, "Scanner updates progress")
+
+    # Stop
+    print("\n[3/4] Canceling print...")
+    set_mock_state(mock_url, {"state": "stopped"})
+    wait(15, "Scanner should deduct 30% of 20g = 6.0g")
+
+    # Verify
+    print("\n[4/4] Verification")
+    print("  Expected: ~6.0g deducted (30% of 20g)")
+    print("  Check serial output for:")
+    print("    PrinterManager: Job 99 canceled — 6.00g used")
+
+    requests.post(f"{mock_url}/mock/reset")
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_print_e2e.py
+++ b/test/integration/test_print_e2e.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+End-to-end print lifecycle test.
+
+Prerequisites:
+  1. mock_prusalink.py running on port 8080
+  2. Scanner configured with PrusaLink URL = http://<your-ip>:8080
+  3. Scanner has an NFC tag on the reader with known remaining weight
+
+This script drives the mock through a complete print cycle and verifies
+the scanner deducts filament from the NFC tag.
+
+Usage:
+    python3 test_print_e2e.py --mock-host localhost --mock-port 8080
+"""
+
+import argparse
+import json
+import time
+import sys
+import requests
+
+
+def set_mock_state(base_url: str, state: dict):
+    r = requests.post(f"{base_url}/mock/state", json=state)
+    r.raise_for_status()
+    print(f"  Mock → {state.get('state', '?')}")
+
+
+def get_mock_state(base_url: str) -> dict:
+    r = requests.get(f"{base_url}/mock/state")
+    r.raise_for_status()
+    return r.json()
+
+
+def wait(seconds: int, reason: str):
+    print(f"  Waiting {seconds}s — {reason}")
+    for i in range(seconds):
+        time.sleep(1)
+        print(f"    {i+1}/{seconds}s", end="\r")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mock-host", default="localhost")
+    parser.add_argument("--mock-port", type=int, default=8080)
+    parser.add_argument("--scanner-host", default=None,
+                        help="Scanner IP for API checks (optional)")
+    args = parser.parse_args()
+
+    mock_url = f"http://{args.mock_host}:{args.mock_port}"
+
+    print("=" * 60)
+    print("SpoolSense PrusaLink Integration Test: Print E2E")
+    print("=" * 60)
+
+    # --- Phase 1: Verify mock is running ---
+    print("\n[1/6] Verifying mock server...")
+    try:
+        state = get_mock_state(mock_url)
+        print(f"  Mock state: {state['printer_state']}")
+    except Exception as e:
+        print(f"  FAIL: Cannot reach mock at {mock_url}: {e}")
+        sys.exit(1)
+
+    # --- Phase 2: Reset to idle ---
+    print("\n[2/6] Resetting mock to idle...")
+    requests.post(f"{mock_url}/mock/reset")
+
+    if args.scanner_host:
+        print(f"  Checking scanner at {args.scanner_host}...")
+        try:
+            r = requests.get(f"http://{args.scanner_host}/api/status", timeout=5)
+            status = r.json()
+            print(f"  Scanner status: tag={status.get('tag_present', '?')}")
+        except Exception as e:
+            print(f"  Warning: Cannot reach scanner: {e}")
+
+    # --- Phase 3: Start a print ---
+    print("\n[3/6] Starting print (job_id=42, filament=9.18g PLA)...")
+    set_mock_state(mock_url, {
+        "state": "printing",
+        "job_id": 42,
+        "filament_g": 9.18,
+        "filament_type": "PLA",
+        "nozzle_temp": 215,
+        "bed_temp": 60,
+    })
+
+    wait(15, "Scanner should detect PRINTING state and send PRINT_STARTED")
+
+    # --- Phase 4: Progress updates ---
+    print("\n[4/6] Simulating print progress...")
+    for pct in [25, 50, 75, 100]:
+        set_mock_state(mock_url, {"state": "progress", "progress": float(pct)})
+        wait(3, f"Progress → {pct}%")
+
+    # --- Phase 5: Print finishes ---
+    print("\n[5/6] Print finishing...")
+    set_mock_state(mock_url, {"state": "finished"})
+
+    wait(15, "Scanner should detect FINISHED and deduct 9.18g from tag")
+
+    # --- Phase 6: Verify ---
+    print("\n[6/6] Verification...")
+
+    if args.scanner_host:
+        try:
+            r = requests.get(f"http://{args.scanner_host}/api/status", timeout=5)
+            status = r.json()
+            remaining = status.get("grams_remaining")
+            if remaining is not None:
+                print(f"  Tag remaining: {remaining}g")
+                print("  (Check serial output for PRINT_ENDED + REMOVE_WEIGHT log)")
+            else:
+                print("  Could not read remaining weight from scanner API")
+        except Exception as e:
+            print(f"  Could not verify via scanner API: {e}")
+    else:
+        print("  No --scanner-host provided. Check scanner serial output for:")
+        print("    PrinterManager: Tracking job 42 (filament: 9.18g)")
+        print("    PrinterManager: Job 42 finished — 9.18g used")
+        print("    EVENT: PrintEnded - job_id=42, filament=9.18g, canceled=false")
+
+    # Cleanup
+    requests.post(f"{mock_url}/mock/reset")
+
+    print("\n" + "=" * 60)
+    print("Test complete. Verify deduction in scanner serial output.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/test_xl_multitool.py
+++ b/test/integration/test_xl_multitool.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+XL multi-tool print test.
+
+Simulates a 3-tool XL print with per-tool filament data.
+Verifies the scanner logs per-tool usage and publishes to HA.
+
+Usage:
+    python3 test_xl_multitool.py --mock-host localhost --mock-port 8080
+"""
+
+import argparse
+import time
+import requests
+
+
+def set_mock_state(base_url: str, state: dict):
+    r = requests.post(f"{base_url}/mock/state", json=state)
+    r.raise_for_status()
+    print(f"  Mock → {state.get('state', '?')}")
+
+
+def wait(seconds: int, reason: str):
+    print(f"  Waiting {seconds}s — {reason}")
+    time.sleep(seconds)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mock-host", default="localhost")
+    parser.add_argument("--mock-port", type=int, default=8080)
+    args = parser.parse_args()
+
+    mock_url = f"http://{args.mock_host}:{args.mock_port}"
+
+    print("=" * 60)
+    print("SpoolSense PrusaLink Test: XL Multi-Tool Print")
+    print("=" * 60)
+
+    requests.post(f"{mock_url}/mock/reset")
+
+    # Start 3-tool print with per-tool filament data
+    print("\n[1/3] Starting 3-tool print...")
+    set_mock_state(mock_url, {
+        "state": "printing",
+        "job_id": 200,
+        "filament_g": 45.0,  # total
+        "filament_type": "PLA",
+        "nozzle_temp": 215,
+        "bed_temp": 60,
+        "filament_per_tool": [15.0, 20.0, 10.0],
+        "filament_type_per_tool": ["PLA", "PETG", "PLA"],
+    })
+    wait(15, "Scanner detects multi-tool print")
+
+    print("  Expected serial output:")
+    print("    PrusaLink: Multi-tool job detected (3 tools)")
+    print("      Tool 0: 15.00g PLA")
+    print("      Tool 1: 20.00g PETG")
+    print("      Tool 2: 10.00g PLA")
+
+    # Finish print
+    print("\n[2/3] Finishing print...")
+    set_mock_state(mock_url, {"state": "progress", "progress": 100.0})
+    wait(5, "Progress to 100%")
+    set_mock_state(mock_url, {"state": "finished"})
+    wait(15, "Scanner deducts total 45g")
+
+    print("\n[3/3] Verification")
+    print("  Expected serial output:")
+    print("    EVENT: PrintEnded - job_id=200, filament=45.00g, canceled=false, tools=3")
+    print("      Tool 0: 15.00g")
+    print("      Tool 1: 20.00g")
+    print("      Tool 2: 10.00g")
+    print("")
+    print("  Expected HA MQTT payload (printer/state):")
+    print('    {"state":"idle","last_job_id":200,"filament_used_g":45.0,')
+    print('     "tool_count":3,"per_tool":[15.0,20.0,10.0]}')
+
+    requests.post(f"{mock_url}/mock/reset")
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/native/Arduino.h
+++ b/test/native/Arduino.h
@@ -1,0 +1,4 @@
+// Shim: production sources include <Arduino.h>; native tests resolve it here
+// via -I. and get the canonical NativePlatform stubs instead.
+#pragma once
+#include "platform/NativePlatform.h"

--- a/test/native/Makefile
+++ b/test/native/Makefile
@@ -1,0 +1,29 @@
+CXX = g++
+CC = gcc
+CXXFLAGS = -std=c++17 -Wall -Wextra -DNATIVE_TEST -I../../src -I../../include -I. \
+           -I../../lib/openprinttag -I../../lib/opentag3d -I../../lib/tigertag -I../../lib/bambutag
+CFLAGS = -std=c11 -DNATIVE_TEST -I../../lib/openprinttag
+
+OPT_OBJS = openprinttag_lib.o cbor_native.o
+
+.PHONY: all clean test
+
+all: test_printer_manager
+
+openprinttag_lib.o: ../../lib/openprinttag/openprinttag_lib.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+cbor_native.o: ../../lib/openprinttag/cbor_native.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+test_printer_manager: test_printer_manager.cpp native_stubs.cpp MockPrinterStrategy.h test_helpers.h ../../src/IPrinterStrategy.h $(OPT_OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ test_printer_manager.cpp native_stubs.cpp $(OPT_OBJS)
+
+test: test_printer_manager
+	@echo ""
+	@echo "=== Running PrinterManager tests ==="
+	@./test_printer_manager
+	@echo ""
+
+clean:
+	rm -f test_printer_manager *.o

--- a/test/native/MessageCapture.h
+++ b/test/native/MessageCapture.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "ApplicationManager.h"
+#include <vector>
+
+/// Captures AppMessages sent via ApplicationManager::sendMessage() during tests.
+/// In native test mode, sendMessage calls are intercepted here instead of going
+/// through the FreeRTOS queue.
+struct MessageCapture {
+    static std::vector<AppMessage> messages;
+
+    static void reset() { messages.clear(); }
+    static int count() { return static_cast<int>(messages.size()); }
+
+    static const AppMessage* findFirst(AppMessageType type) {
+        for (auto& m : messages) {
+            if (m.type == type) return &m;
+        }
+        return nullptr;
+    }
+
+    static int countOf(AppMessageType type) {
+        int n = 0;
+        for (auto& m : messages) {
+            if (m.type == type) n++;
+        }
+        return n;
+    }
+};
+
+std::vector<AppMessage> MessageCapture::messages;
+
+// In native test mode, ApplicationManager::sendMessage pushes to capture vector
+// This is linked in lieu of the real ApplicationManager
+namespace {
+    struct FakeApplicationManager {
+        static FakeApplicationManager& getInstance() {
+            static FakeApplicationManager inst;
+            return inst;
+        }
+        bool sendMessage(const AppMessage& msg, uint32_t = 0) {
+            MessageCapture::messages.push_back(msg);
+            return true;
+        }
+    };
+}

--- a/test/native/MockPrinterStrategy.h
+++ b/test/native/MockPrinterStrategy.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "IPrinterStrategy.h"
+#include <cstring>
+
+/// Mock printer strategy for unit testing PrinterManager.
+/// Test code sets state directly, then calls PrinterManager::poll().
+class MockPrinterStrategy : public IPrinterStrategy {
+public:
+    void update() override { updateCalled_++; }
+
+    bool hasActiveJob() const override { return hasJob_; }
+    int getJobId() const override { return jobId_; }
+    float getProgress() const override { return progress_; }
+    float getTotalFilamentGrams() const override { return totalFilamentG_; }
+    const char* getJobState() const override { return jobState_; }
+    bool isConnected() const override { return connected_; }
+
+    const char* getExpectedFilamentType() const override { return expectedFilamentType_; }
+    float getExpectedNozzleTemp() const override { return expectedNozzleTemp_; }
+    float getExpectedBedTemp() const override { return expectedBedTemp_; }
+
+    float fetchDeferredFilament(int expectedJobId) override {
+        deferredCalled_++;
+        if (expectedJobId == deferredJobId_ && deferredFilamentG_ > 0.0f) {
+            return deferredFilamentG_;
+        }
+        return 0.0f;
+    }
+
+    // --- Test controls ---
+
+    void setIdle() {
+        connected_ = true;
+        hasJob_ = false;
+        jobId_ = -1;
+        progress_ = 0.0f;
+        totalFilamentG_ = 0.0f;
+        jobState_[0] = '\0';
+    }
+
+    void setPrinting(int jobId, float filamentG, float progress = 0.0f) {
+        connected_ = true;
+        hasJob_ = true;
+        jobId_ = jobId;
+        totalFilamentG_ = filamentG;
+        progress_ = progress;
+        strncpy(jobState_, "PRINTING", sizeof(jobState_));
+    }
+
+    void setFinished(float progress = 100.0f) {
+        strncpy(jobState_, "FINISHED", sizeof(jobState_));
+        progress_ = progress;
+    }
+
+    void setStopped(float progress) {
+        strncpy(jobState_, "STOPPED", sizeof(jobState_));
+        progress_ = progress;
+    }
+
+    void setDisconnected() {
+        connected_ = false;
+    }
+
+    void clearJob() {
+        hasJob_ = false;
+    }
+
+    void setExpectedFilament(const char* type, float nozzleTemp = 0, float bedTemp = 0) {
+        strncpy(expectedFilamentType_, type, sizeof(expectedFilamentType_) - 1);
+        expectedNozzleTemp_ = nozzleTemp;
+        expectedBedTemp_ = bedTemp;
+    }
+
+    void setDeferredFilament(int jobId, float grams) {
+        deferredJobId_ = jobId;
+        deferredFilamentG_ = grams;
+    }
+
+    void setPerToolData(int count, const float* grams) {
+        toolCount_ = (count > MAX_TOOLS) ? MAX_TOOLS : count;
+        for (int i = 0; i < toolCount_; i++) {
+            filamentPerTool_[i] = grams[i];
+        }
+    }
+
+    int getToolCount() const override { return toolCount_; }
+    float getFilamentForTool(int idx) const override {
+        return (idx >= 0 && idx < toolCount_) ? filamentPerTool_[idx] : 0.0f;
+    }
+
+    int updateCalled_ = 0;
+    int deferredCalled_ = 0;
+
+    // All fields public for test access
+    bool connected_ = false;
+    bool hasJob_ = false;
+    int jobId_ = -1;
+    float progress_ = 0.0f;
+    float totalFilamentG_ = 0.0f;
+    char jobState_[16] = {0};
+    char expectedFilamentType_[32] = {0};
+    float expectedNozzleTemp_ = 0.0f;
+    float expectedBedTemp_ = 0.0f;
+    int deferredJobId_ = -1;
+    float deferredFilamentG_ = 0.0f;
+    int toolCount_ = 0;
+    float filamentPerTool_[MAX_TOOLS] = {0};
+};

--- a/test/native/freertos/FreeRTOS.h
+++ b/test/native/freertos/FreeRTOS.h
@@ -1,0 +1,4 @@
+// Shim: production headers include <freertos/*.h>; native tests resolve them
+// here via -I. and get the canonical NativePlatform stubs instead.
+#pragma once
+#include "platform/NativePlatform.h"

--- a/test/native/freertos/queue.h
+++ b/test/native/freertos/queue.h
@@ -1,0 +1,4 @@
+// Shim: production headers include <freertos/*.h>; native tests resolve them
+// here via -I. and get the canonical NativePlatform stubs instead.
+#pragma once
+#include "platform/NativePlatform.h"

--- a/test/native/freertos/semphr.h
+++ b/test/native/freertos/semphr.h
@@ -1,0 +1,4 @@
+// Shim: production headers include <freertos/*.h>; native tests resolve them
+// here via -I. and get the canonical NativePlatform stubs instead.
+#pragma once
+#include "platform/NativePlatform.h"

--- a/test/native/freertos/task.h
+++ b/test/native/freertos/task.h
@@ -1,0 +1,4 @@
+// Shim: production headers include <freertos/*.h>; native tests resolve them
+// here via -I. and get the canonical NativePlatform stubs instead.
+#pragma once
+#include "platform/NativePlatform.h"

--- a/test/native/native_stubs.cpp
+++ b/test/native/native_stubs.cpp
@@ -1,0 +1,3 @@
+// Definitions for NativePlatform extern stubs — link once per test binary
+#include "platform/NativePlatform.h"
+SerialStub Serial;

--- a/test/native/test_helpers.h
+++ b/test/native/test_helpers.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+static int _tests_run = 0;
+static int _tests_passed = 0;
+static int _tests_failed = 0;
+
+#define TEST_ASSERT(cond) do { \
+    if (!(cond)) { \
+        printf("  FAIL: %s (line %d)\n", #cond, __LINE__); \
+        return false; \
+    } \
+} while(0)
+
+#define TEST_ASSERT_EQ(a, b) do { \
+    if ((a) != (b)) { \
+        printf("  FAIL: %s != %s (line %d)\n", #a, #b, __LINE__); \
+        return false; \
+    } \
+} while(0)
+
+#define TEST_ASSERT_STR_EQ(a, b) do { \
+    if (strcmp((a), (b)) != 0) { \
+        printf("  FAIL: \"%s\" != \"%s\" (line %d)\n", (a), (b), __LINE__); \
+        return false; \
+    } \
+} while(0)
+
+#define TEST_ASSERT_FLOAT_NEAR(a, b, tol) do { \
+    float _diff = (a) - (b); \
+    if (_diff < 0) _diff = -_diff; \
+    if (_diff > (tol)) { \
+        printf("  FAIL: %f !~ %f (tol=%f, line %d)\n", (double)(a), (double)(b), (double)(tol), __LINE__); \
+        return false; \
+    } \
+} while(0)
+
+#define RUN_TEST(func) do { \
+    _tests_run++; \
+    printf("  %s... ", #func); \
+    if (func()) { \
+        _tests_passed++; \
+        printf("PASS\n"); \
+    } else { \
+        _tests_failed++; \
+    } \
+} while(0)
+
+static inline void print_test_summary() {
+    printf("\n%d tests, %d passed, %d failed\n", _tests_run, _tests_passed, _tests_failed);
+}

--- a/test/native/test_printer_manager.cpp
+++ b/test/native/test_printer_manager.cpp
@@ -14,6 +14,13 @@
 // Define header guards BEFORE including production code — stubs replace real headers.
 // When PrinterManager.cpp includes ConfigurationManager.h, the guard is already set,
 // so the real header is skipped and the stub below is used instead.
+//
+// KNOWN LIMITATION: the stubbed contracts (AppMessage, AppMessageType, the manager
+// APIs below) are local copies. If the production versions drift, this test still
+// compiles against the copies and can false-pass. When changing AppMessage or the
+// ApplicationManager/NFCManager surfaces PrinterManager uses, update these stubs
+// in the same commit. (Real types with no heavy deps — NFCTypes.h — are included
+// directly instead of copied.)
 #define CONFIGURATION_MANAGER_H
 #define APPLICATION_MANAGER_H
 #define NFC_MANAGER_H

--- a/test/native/test_printer_manager.cpp
+++ b/test/native/test_printer_manager.cpp
@@ -1,0 +1,439 @@
+// Native unit tests for PrinterManager state machine.
+// Tests the IDLE→TRACKING state machine, filament deduction, job lifecycle,
+// grace periods, and deferred filament lookup.
+//
+// Build: make test_printer_manager
+// Run:   ./test_printer_manager
+
+#define NATIVE_TEST 1
+
+#include "test_helpers.h"
+#include "platform/NativePlatform.h"
+#include "MockPrinterStrategy.h"
+
+// Define header guards BEFORE including production code — stubs replace real headers.
+// When PrinterManager.cpp includes ConfigurationManager.h, the guard is already set,
+// so the real header is skipped and the stub below is used instead.
+#define CONFIGURATION_MANAGER_H
+#define APPLICATION_MANAGER_H
+#define NFC_MANAGER_H
+
+// Real type definitions PrinterManager.cpp pulls in directly (data-only header)
+#include "NFCTypes.h"
+
+// Minimal stubs for headers PrinterManager includes
+namespace ConfigStub {
+    static uint32_t pollIntervalMs = 10000;
+}
+
+// --- Stub ConfigurationManager ---
+class ConfigurationManager {
+public:
+    static ConfigurationManager& getInstance() { static ConfigurationManager inst; return inst; }
+    uint32_t getPollIntervalMs() const { return ConfigStub::pollIntervalMs; }
+    bool isPrusaLinkEnabled() const { return true; }
+    const char* getPrusaLinkURL() const { return "http://test"; }
+    const char* getPrusaLinkAPIKey() const { return "key"; }
+};
+
+// --- Capture messages ---
+#include <vector>
+
+enum class AppMessageType {
+    PRINT_STARTED,
+    PRINT_ENDED,
+    SPOOL_DETECTED,
+    SPOOL_UPDATED,
+    BLANK_TAG_DETECTED,
+    GENERIC_TAG_DETECTED,
+    SPOOLMAN_SYNCED,
+    TAG_REMOVED,
+    HA_WRITE_TAG,
+    HA_UPDATE_REMAINING,
+    PRINTER_WARNING,
+};
+
+struct PrinterWarningPayload {
+    char warning_type[24];
+    char expected[32];
+    char actual[32];
+    float gcode_temp;
+    int16_t tag_max_temp;
+};
+
+struct AppMessage {
+    AppMessageType type;
+    union {
+        struct { int job_id; } printStarted;
+        struct {
+            int job_id;
+            float filament_used_grams;
+            bool canceled;
+            int tool_count;
+            float filament_per_tool[IPrinterStrategy::MAX_TOOLS];
+        } printEnded;
+        PrinterWarningPayload printerWarning;
+    } payload;
+};
+
+static std::vector<AppMessageType> capturedTypes;
+static std::vector<float> capturedFilament;
+static std::vector<bool> capturedCanceled;
+static std::vector<int> capturedJobIds;
+static std::vector<int> capturedToolCounts;
+static std::vector<std::vector<float>> capturedPerTool;
+
+// --- Stub NFCManager (CurrentSpoolState comes from the real NFCTypes.h) ---
+class NFCManager {
+public:
+    static NFCManager& getInstance() { static NFCManager inst; return inst; }
+    bool getCurrentSpoolState(CurrentSpoolState& out) {
+        out.present = false;
+        out.tag_data_valid = false;
+        return false;
+    }
+};
+
+class ApplicationManager {
+public:
+    static ApplicationManager& getInstance() { static ApplicationManager inst; return inst; }
+    bool sendMessage(const AppMessage& msg, uint32_t = 0) {
+        capturedTypes.push_back(msg.type);
+        if (msg.type == AppMessageType::PRINT_STARTED) {
+            capturedJobIds.push_back(msg.payload.printStarted.job_id);
+        }
+        if (msg.type == AppMessageType::PRINT_ENDED) {
+            capturedFilament.push_back(msg.payload.printEnded.filament_used_grams);
+            capturedCanceled.push_back(msg.payload.printEnded.canceled);
+            capturedJobIds.push_back(msg.payload.printEnded.job_id);
+            capturedToolCounts.push_back(msg.payload.printEnded.tool_count);
+            std::vector<float> tools;
+            for (int i = 0; i < msg.payload.printEnded.tool_count; i++) {
+                tools.push_back(msg.payload.printEnded.filament_per_tool[i]);
+            }
+            capturedPerTool.push_back(tools);
+        }
+        return true;
+    }
+    void publishToHA(const char*, const char*, bool) {}
+};
+
+// Include the REAL production PrinterManager — stubs above satisfy its dependencies.
+// This ensures tests exercise actual production logic, not a drifting copy.
+#include "../../src/PrinterManager.h"
+#include "../../src/PrinterManager.cpp"
+
+// =========================================================================
+// Test helpers
+// =========================================================================
+
+static MockPrinterStrategy mock;
+static PrinterManager& pm = PrinterManager::getInstance();
+
+static void reset() {
+    capturedTypes.clear();
+    capturedFilament.clear();
+    capturedCanceled.clear();
+    capturedJobIds.clear();
+    capturedToolCounts.clear();
+    capturedPerTool.clear();
+    mock = MockPrinterStrategy();
+    pm.begin();
+    pm.setStrategy(&mock);
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+bool test_idle_no_job() {
+    reset();
+    mock.setIdle();
+    pm.poll();
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::IDLE);
+    TEST_ASSERT_EQ(capturedTypes.size(), 0u);
+    return true;
+}
+
+bool test_detect_print_start() {
+    reset();
+    mock.setPrinting(42, 9.18f);
+    pm.poll();
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::TRACKING);
+    TEST_ASSERT_EQ(capturedTypes.size(), 1u);
+    TEST_ASSERT_EQ(capturedTypes[0], AppMessageType::PRINT_STARTED);
+    TEST_ASSERT_EQ(capturedJobIds[0], 42);
+    return true;
+}
+
+bool test_print_finished_100_percent() {
+    reset();
+    mock.setPrinting(42, 9.18f);
+    pm.poll();  // detect start
+
+    mock.setFinished(100.0f);
+    pm.poll();  // detect finish
+
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::IDLE);
+    TEST_ASSERT_EQ(capturedTypes.size(), 2u);
+    TEST_ASSERT_EQ(capturedTypes[1], AppMessageType::PRINT_ENDED);
+    TEST_ASSERT_FLOAT_NEAR(capturedFilament[0], 9.18f, 0.01f);
+    TEST_ASSERT_EQ(capturedCanceled[0], false);
+    return true;
+}
+
+bool test_print_canceled_at_30_percent() {
+    reset();
+    mock.setPrinting(42, 9.18f, 30.0f);
+    pm.poll();  // detect start
+
+    mock.setStopped(30.0f);
+    pm.poll();  // detect stop
+
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::IDLE);
+    TEST_ASSERT_FLOAT_NEAR(capturedFilament[0], 9.18f * 0.30f, 0.01f);
+    TEST_ASSERT_EQ(capturedCanceled[0], true);
+    return true;
+}
+
+bool test_job_disappeared_under_95_is_canceled() {
+    reset();
+    mock.setPrinting(42, 9.18f, 0.0f);
+    pm.poll();  // start → TRACKING, lastProgress=0
+
+    mock.setPrinting(42, 9.18f, 50.0f);
+    pm.poll();  // update progress to 50%
+
+    mock.clearJob();
+    pm.poll();  // grace 1
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::TRACKING);
+
+    pm.poll();  // grace 2 → disappeared
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::IDLE);
+    TEST_ASSERT_EQ(capturedCanceled[0], true);
+    TEST_ASSERT_FLOAT_NEAR(capturedFilament[0], 9.18f * 0.50f, 0.01f);
+    return true;
+}
+
+bool test_job_disappeared_at_95_treated_as_finished() {
+    reset();
+    mock.setPrinting(42, 9.18f, 0.0f);
+    pm.poll();  // start
+
+    mock.setPrinting(42, 9.18f, 96.0f);
+    pm.poll();  // update progress to 96%
+
+    mock.clearJob();
+    pm.poll();  // grace 1
+    pm.poll();  // grace 2 → disappeared, 96% >= 95% → treated as finished
+
+    TEST_ASSERT_EQ(capturedCanceled[0], false);  // treated as finished
+    TEST_ASSERT_FLOAT_NEAR(capturedFilament[0], 9.18f, 0.01f);  // 100%
+    return true;
+}
+
+bool test_disconnect_during_tracking() {
+    reset();
+    mock.setPrinting(42, 9.18f, 60.0f);
+    pm.poll();
+
+    mock.setDisconnected();
+    pm.poll();  // grace 1
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::TRACKING);
+
+    pm.poll();  // grace 2 → disappeared
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::IDLE);
+    TEST_ASSERT_EQ(capturedTypes.size(), 2u);  // START + END
+    return true;
+}
+
+bool test_job_replaced() {
+    reset();
+    mock.setPrinting(42, 9.18f, 50.0f);
+    pm.poll();  // start job 42
+
+    mock.setPrinting(99, 15.0f, 0.0f);  // new job
+    pm.poll();  // should end 42, start 99
+
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::TRACKING);
+    TEST_ASSERT_EQ(capturedTypes.size(), 3u);  // START(42) + END(42) + START(99)
+    TEST_ASSERT_EQ(capturedTypes[0], AppMessageType::PRINT_STARTED);
+    TEST_ASSERT_EQ(capturedTypes[1], AppMessageType::PRINT_ENDED);
+    TEST_ASSERT_EQ(capturedTypes[2], AppMessageType::PRINT_STARTED);
+    TEST_ASSERT_EQ(capturedJobIds[0], 42);  // first start
+    TEST_ASSERT_EQ(capturedJobIds[1], 42);  // end of 42
+    TEST_ASSERT_EQ(capturedJobIds[2], 99);  // start of 99
+    return true;
+}
+
+bool test_deferred_filament_on_finish() {
+    reset();
+    mock.setPrinting(42, 0.0f);  // no filament metadata initially
+    pm.poll();
+
+    mock.setDeferredFilament(42, 9.18f);
+    mock.setFinished(100.0f);
+    pm.poll();
+
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::IDLE);
+    TEST_ASSERT_FLOAT_NEAR(capturedFilament[0], 9.18f, 0.01f);
+    TEST_ASSERT_EQ(mock.deferredCalled_, 1);
+    return true;
+}
+
+bool test_deferred_not_called_on_replace() {
+    reset();
+    mock.setPrinting(42, 0.0f);
+    pm.poll();
+
+    mock.setDeferredFilament(42, 9.18f);
+    mock.setPrinting(99, 15.0f);  // replace, not finish
+    pm.poll();
+
+    // Deferred should NOT be called for replaced jobs
+    TEST_ASSERT_EQ(mock.deferredCalled_, 0);
+    return true;
+}
+
+bool test_update_called_each_poll() {
+    reset();
+    mock.setIdle();
+    pm.poll();
+    pm.poll();
+    pm.poll();
+    TEST_ASSERT_EQ(mock.updateCalled_, 3);
+    return true;
+}
+
+bool test_filament_updates_during_tracking() {
+    reset();
+    mock.setPrinting(42, 0.0f);  // no metadata yet
+    pm.poll();
+
+    mock.setPrinting(42, 9.18f, 50.0f);  // metadata arrives
+    pm.poll();
+
+    mock.setFinished(100.0f);
+    pm.poll();
+
+    TEST_ASSERT_FLOAT_NEAR(capturedFilament[0], 9.18f, 0.01f);
+    return true;
+}
+
+bool test_zero_filament_no_deferred() {
+    reset();
+    mock.setPrinting(42, 0.0f);
+    pm.poll();
+
+    // No deferred data set
+    mock.setFinished(100.0f);
+    pm.poll();
+
+    TEST_ASSERT_FLOAT_NEAR(capturedFilament[0], 0.0f, 0.01f);
+    return true;
+}
+
+bool test_single_tool_has_zero_tool_count() {
+    reset();
+    mock.setPrinting(42, 9.18f);
+    pm.poll();
+
+    mock.setFinished(100.0f);
+    pm.poll();
+
+    TEST_ASSERT_EQ(capturedToolCounts[0], 0);
+    TEST_ASSERT_EQ(capturedPerTool[0].size(), 0u);
+    return true;
+}
+
+bool test_multi_tool_per_tool_data() {
+    reset();
+    float perTool[] = {15.0f, 20.0f, 10.0f};
+    mock.setPrinting(200, 45.0f);
+    mock.setPerToolData(3, perTool);
+    pm.poll();  // start → caches per-tool data
+
+    mock.setFinished(100.0f);
+    pm.poll();  // finish → emits cached per-tool in PRINT_ENDED
+
+    TEST_ASSERT_EQ(capturedToolCounts[0], 3);
+    TEST_ASSERT_FLOAT_NEAR(capturedFilament[0], 45.0f, 0.01f);
+    TEST_ASSERT_FLOAT_NEAR(capturedPerTool[0][0], 15.0f, 0.01f);
+    TEST_ASSERT_FLOAT_NEAR(capturedPerTool[0][1], 20.0f, 0.01f);
+    TEST_ASSERT_FLOAT_NEAR(capturedPerTool[0][2], 10.0f, 0.01f);
+    return true;
+}
+
+bool test_multi_tool_cached_on_job_replaced() {
+    reset();
+    float perTool1[] = {10.0f, 5.0f};
+    mock.setPrinting(100, 15.0f);
+    mock.setPerToolData(2, perTool1);
+    pm.poll();  // start job 100, cache [10, 5]
+
+    // Replace with new job that has different per-tool data
+    float perTool2[] = {30.0f};
+    mock.setPrinting(200, 30.0f);
+    mock.setPerToolData(1, perTool2);
+    pm.poll();  // should end 100 with cached [10, 5], start 200
+
+    // PRINT_ENDED for job 100 should use cached data, not new job's
+    TEST_ASSERT_EQ(capturedToolCounts[0], 2);
+    TEST_ASSERT_FLOAT_NEAR(capturedPerTool[0][0], 0.0f, 0.01f);  // 0% progress on job 100
+    TEST_ASSERT_FLOAT_NEAR(capturedPerTool[0][1], 0.0f, 0.01f);
+    return true;
+}
+
+bool test_no_strategy_does_nothing() {
+    reset();
+    pm.setStrategy(nullptr);
+    pm.poll();
+    TEST_ASSERT_EQ(capturedTypes.size(), 0u);
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::IDLE);
+    return true;
+}
+
+bool test_paused_starts_tracking() {
+    reset();
+    mock.connected_ = true;
+    mock.hasJob_ = true;
+    mock.jobId_ = 55;
+    mock.progress_ = 10.0f;
+    mock.totalFilamentG_ = 5.0f;
+    strncpy(mock.jobState_, "PAUSED", sizeof(mock.jobState_));
+    mock.updateCalled_ = 0;
+
+    pm.poll();
+    TEST_ASSERT_EQ(pm.getState(), PrinterState::TRACKING);
+    TEST_ASSERT_EQ(capturedTypes[0], AppMessageType::PRINT_STARTED);
+    return true;
+}
+
+// =========================================================================
+
+int main() {
+    printf("PrinterManager tests\n");
+    printf("====================\n\n");
+
+    RUN_TEST(test_idle_no_job);
+    RUN_TEST(test_detect_print_start);
+    RUN_TEST(test_print_finished_100_percent);
+    RUN_TEST(test_print_canceled_at_30_percent);
+    RUN_TEST(test_job_disappeared_under_95_is_canceled);
+    RUN_TEST(test_job_disappeared_at_95_treated_as_finished);
+    RUN_TEST(test_disconnect_during_tracking);
+    RUN_TEST(test_job_replaced);
+    RUN_TEST(test_deferred_filament_on_finish);
+    RUN_TEST(test_deferred_not_called_on_replace);
+    RUN_TEST(test_update_called_each_poll);
+    RUN_TEST(test_filament_updates_during_tracking);
+    RUN_TEST(test_zero_filament_no_deferred);
+    RUN_TEST(test_single_tool_has_zero_tool_count);
+    RUN_TEST(test_multi_tool_per_tool_data);
+    RUN_TEST(test_multi_tool_cached_on_job_replaced);
+    RUN_TEST(test_no_strategy_does_nothing);
+    RUN_TEST(test_paused_starts_tracking);
+
+    print_test_summary();
+    return _tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## What

Closes the two top process risks from the codebase assessment: the test suite wasn't in version control, and no CI ran on PRs (builds only happened at release-tag time).

**Test suite into git.** `test/` was blanket-gitignored — the native harness existed on exactly one machine, next to orphaned binaries whose sources were gone. Now tracked: the native PrinterManager suite (**18 tests, all passing, compiling the real `PrinterManager.cpp`**, not a reimplementation — the #36 approach) and the Python integration suite (mock PrusaLink; e2e / cancel / mismatch / XL multitool).

**Drift repairs** (the suite had rotted against production changes):
- `freertos/` + `Arduino.h` shim headers in `test/native/` resolve production includes to the canonical `include/platform/NativePlatform.h` stub; the diverged test-local copy is deleted
- `NFC_MANAGER_H` guard preemption + real `NFCTypes.h` (PrinterManager.cpp gained an NFCManager dependency after the test was written)
- Missing `xTaskCreate` stub added to the canonical platform
- OpenPrintTag C library now built from `lib/` sources instead of stale committed `.o` files
- `Serial` stub definition lives in `native_stubs.cpp`

**PR CI.** Every PR to dev/main now: builds all four board environments (esp32dev / esp32s3zero / esp32c3 / esp32s3devkitc, cached PlatformIO, `UserConfig.h` from the example) and runs the native suite. `UserConfig.example.h` gained the missing `ENABLE_BAMBU_DASHBOARD` define so example-based builds match.

## Notes

- `.gitignore`: `test/` blanket ignore replaced with build-artifact patterns (`*.o`, binaries, `*.dSYM/`, `test/build/`)
- Integration tests are tracked but not yet wired into CI (they need a longer harness bring-up — follow-up)
- This PR's own CI run is the workflow's first live execution