### PR TITLE
chore: exact-pin all lib_deps (#216)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,16 +17,19 @@ monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
 	-DFIRMWARE_VERSION=\"1.7.6\"
+; Exact pins (#216): caret ranges let fresh checkouts resolve newer libraries
+; than tested builds — same commit, different binary. Bump pins deliberately,
+; in their own commit, with all four envs built.
 lib_deps =
-	marcoschwartz/LiquidCrystal_I2C@^1.1.4
-	bblanchon/ArduinoJson@^7.0.0
-	densaugeo/base64@^1.4.0
-	knolleary/PubSubClient@^2.8
-	codewitch-honey-crisis/htcw_json@^0.2.5
-	adafruit/Adafruit NeoPixel
+	marcoschwartz/LiquidCrystal_I2C@1.1.4
+	bblanchon/ArduinoJson@7.4.3
+	densaugeo/base64@1.4.0
+	knolleary/PubSubClient@2.8
+	codewitch-honey-crisis/htcw_json@0.2.5
+	adafruit/Adafruit NeoPixel@1.15.4
 	adafruit/Adafruit PN532@1.3.4
-	chris--a/Keypad@^3.1.1
-	lovyan03/LovyanGFX@^1.1.16
+	chris--a/Keypad@3.1.1
+	lovyan03/LovyanGFX@1.2.19
 
 [env:esp32dev]
 board = esp32dev


### PR DESCRIPTION
Closes #216.

Caret ranges let fresh checkouts resolve newer libraries than tested builds — the same commit built against LovyanGFX 1.2.19 in one checkout and 1.2.24 in another (NeoPixel 1.15.4 vs 1.15.5), observed directly on 2026-07-05 with matching flash-size drift. A regression from a silent library bump would only reproduce on fresh checkouts and CI runners, and couldn't be bisected because the source never changed.

Pinned to the versions the home fleet's builds have actually shipped with (main checkout's resolved set). All four environments build from a clean `libdeps` with the pins.

**Bump procedure** (documented in the ini comment): change a pin in its own commit, build all four envs, changelog it.