### PR TITLE
bump: v1.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.7.7] - 2026-07-06
 
 ### Added
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ board_build.partitions = partitions.csv
 monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
-	-DFIRMWARE_VERSION=\"1.7.6\"
+	-DFIRMWARE_VERSION=\"1.7.7\"
 ; Exact pins (#216): caret ranges let fresh checkouts resolve newer libraries
 ; than tested builds — same commit, different binary. Bump pins deliberately,
 ; in their own commit, with all four envs built.


### PR DESCRIPTION
Version bump + changelog cut for v1.7.7. Contents: #203/#196 LED pin, #167 readback verify, memory phase-1 instrumentation, #218 churn fix + durable links, #212 PN5180 write reliability. Production step (main merge + tag) follows the morning soak readout per release checklist.