### PR TITLE
chore: add installer-impact checkbox to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,3 +12,4 @@ Steps to verify these changes work.
 - [ ] Compiles for both targets (`pio run -e esp32dev` and `pio run -e esp32s3zero`)
 - [ ] Avoid unnecessary heap allocations (runtime memory is limited)
 - [ ] User-facing config changes are in UserConfig.h only
+- [ ] Installer impact assessed — new NVS keys, Spoolman extra fields, boards, or release-asset changes need a matching spoolsense-installer issue


### PR DESCRIPTION
Adds one checklist line so PRs that introduce new NVS keys, Spoolman extra fields, boards, or release-asset changes get a matching spoolsense-installer issue at merge time instead of being discovered months later (the v1.3.0/v1.4.0 installer catch-up closed a season of these gaps — Happy Hare fields, 8 NVS keys, fields v2). Tracking pattern: SpoolSense/spoolsense-installer#38.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template with a new checklist item to confirm installer impact is reviewed.
  * Highlights changes that may require a matching installer issue, including new keys, extra fields, boards, or release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->