### PR TITLE
Link an existing tag to a spool from the picker — no write required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **"Link tag (no write)" button** — selecting a spool in the Import-from-Spoolman picker now offers linking an already-written tag to that spool without rewriting it. The button arms the link window and guides the scan ("lift it off and set it back down" — links bind on fresh tag arrival), then confirms the link or reports expiry via a new pending-link status endpoint. Previously the link only armed as part of a tag write, and there was no feedback at all.
+
 ## [1.8.0] - 2026-07-06
 
 ### Security

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -427,7 +427,8 @@ function filterSpoolmanPicker(spools, query, fieldMap) {
     var color = (fil.color_hex || '').replace(/[^0-9a-fA-F]/g, '');
     var swatch = color ? '<span style="display:inline-block;width:14px;height:14px;border-radius:50%;background:#' + color + ';vertical-align:middle;margin-right:6px"></span>' : '';
     var remaining = spool.remaining_weight ? Math.round(spool.remaining_weight) + 'g' : '?';
-    var spoolId = spool.id;
+    var spoolId = Number(spool.id);
+    if (!isFinite(spoolId) || spoolId <= 0) return '';
     return '<div style="padding:8px 10px;border-bottom:1px solid var(--border);cursor:pointer" onclick="selectSpoolmanSpool(' + spoolId + ')">'
       + swatch + '#' + spoolId + ' ' + (vendor ? esc(vendor) + ' ' : '') + esc(fil.material || fil.name || '?') + ' \u2014 ' + remaining
       + '</div>';

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -438,6 +438,56 @@ function selectSpoolmanSpool(spoolId) {
   _selectedSpoolId = spoolId;
   var spool = _spoolmanPickerSpools.find(function(s) { return s.id === spoolId; });
   if (spool) fillFromSpoolman(spool, _spoolmanPickerFieldMap);
+  renderLinkOnlyBar(spoolId);
+}
+
+// "Link tag (no write)" — bind an already-written tag to the selected spool
+// without touching the tag. Arms the firmware pending link and reports the
+// outcome by polling: armed=false with time left means a sync consumed it.
+function renderLinkOnlyBar(spoolId) {
+  var results = document.getElementById('spoolmanPickerResults');
+  if (!results) return;
+  var bar = document.getElementById('linkOnlyBar');
+  if (!bar) {
+    bar = document.createElement('div');
+    bar.id = 'linkOnlyBar';
+    bar.style.cssText = 'margin-top:8px;padding:10px;border:1px solid var(--border);border-radius:8px;font-size:0.92em';
+    results.parentNode.insertBefore(bar, results.nextSibling);
+  }
+  bar.innerHTML = 'Spool #' + spoolId + ' selected \u2014 '
+    + '<button type="button" onclick="linkTagOnly(' + spoolId + ')" '
+    + 'style="padding:6px 12px;border-radius:8px;border:1px solid var(--accent);background:transparent;color:var(--accent);cursor:pointer">'
+    + 'Link tag (no write)</button>'
+    + '<div id="linkOnlyStatus" style="margin-top:6px;opacity:0.75"></div>';
+}
+
+async function linkTagOnly(spoolId) {
+  var status = document.getElementById('linkOnlyStatus');
+  try {
+    await api('/api/spoolman/pending-link', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({spool_id: spoolId})
+    });
+  } catch (e) {
+    if (status) status.textContent = 'Could not arm the link \u2014 is the scanner reachable?';
+    return;
+  }
+  _selectedSpoolId = -1;  // consumed by this flow — do not re-arm on Write Tag
+  var deadline = Date.now() + 125000;
+  while (Date.now() < deadline) {
+    var st = null;
+    try { st = await api('/api/spoolman/pending-link'); } catch (e) {}
+    if (st && st.armed === false) {
+      if (status) status.textContent = '\u2713 Tag linked to spool #' + spoolId + '.';
+      return;
+    }
+    var secs = st && st.remaining_ms ? Math.ceil(st.remaining_ms / 1000) : Math.ceil((deadline - Date.now()) / 1000);
+    if (status) status.textContent = 'Place the tag on the reader now (' + secs + 's). '
+      + 'If it\u2019s already sitting there, lift it off and set it back down.';
+    await sleep(1000);
+  }
+  if (status) status.textContent = 'Link window expired \u2014 select the spool and try again.';
 }
 
 function fillFromSpoolman(spool, fieldMap) {

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -445,6 +445,8 @@ function selectSpoolmanSpool(spoolId) {
 // without touching the tag. Arms the firmware pending link and reports the
 // outcome by polling: armed=false with time left means a sync consumed it.
 function renderLinkOnlyBar(spoolId) {
+  spoolId = Number(spoolId);
+  if (!isFinite(spoolId) || spoolId <= 0) return;
   var results = document.getElementById('spoolmanPickerResults');
   if (!results) return;
   var bar = document.getElementById('linkOnlyBar');
@@ -462,6 +464,8 @@ function renderLinkOnlyBar(spoolId) {
 }
 
 async function linkTagOnly(spoolId) {
+  spoolId = Number(spoolId);
+  if (!isFinite(spoolId) || spoolId <= 0) return;
   var status = document.getElementById('linkOnlyStatus');
   try {
     await api('/api/spoolman/pending-link', {
@@ -474,12 +478,18 @@ async function linkTagOnly(spoolId) {
     return;
   }
   _selectedSpoolId = -1;  // consumed by this flow — do not re-arm on Write Tag
-  var deadline = Date.now() + 125000;
+  var deadline = Date.now() + 135000;
   while (Date.now() < deadline) {
     var st = null;
     try { st = await api('/api/spoolman/pending-link'); } catch (e) {}
-    if (st && st.armed === false) {
-      if (status) status.textContent = '\u2713 Tag linked to spool #' + spoolId + '.';
+    if (st && st.state === 'consumed' && st.spool_id === spoolId) {
+      if (status) status.textContent = st.link_ok
+        ? ('\u2713 Tag ' + (st.uid || '') + ' linked to spool #' + spoolId + '.')
+        : ('\u2717 Link failed \u2014 Spoolman rejected the update. Try again.');
+      return;
+    }
+    if (st && (st.state === 'expired' || st.state === 'idle')) {
+      if (status) status.textContent = 'Link window expired \u2014 select the spool and try again.';
       return;
     }
     var secs = st && st.remaining_ms ? Math.ceil(st.remaining_ms / 1000) : Math.ceil((deadline - Date.now()) / 1000);

--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -1648,6 +1648,16 @@ int SpoolmanManager::findFilamentNoLock(int vendorId, const char* material,
     return streamFindFilament(vendorId, material, colorHex6, name ? name : "");
 }
 
+bool SpoolmanManager::getPendingLinkState(int32_t& outSpoolId, uint32_t& outRemainingMs) const {
+    int32_t id = pendingLinkSpoolId_.load();
+    if (id <= 0) return false;
+    uint32_t age = millis() - pendingLinkSetAt_.load();
+    if (age >= PENDING_LINK_TIMEOUT_MS) return false;
+    outSpoolId = id;
+    outRemainingMs = PENDING_LINK_TIMEOUT_MS - age;
+    return true;
+}
+
 int SpoolmanManager::findVendorNoLock(const char* name, char* outName, size_t outNameSize) {
     return streamFindVendorByName(name, outName, outNameSize);
 }

--- a/src/SpoolmanManager.cpp
+++ b/src/SpoolmanManager.cpp
@@ -1648,14 +1648,46 @@ int SpoolmanManager::findFilamentNoLock(int vendorId, const char* material,
     return streamFindFilament(vendorId, material, colorHex6, name ? name : "");
 }
 
-bool SpoolmanManager::getPendingLinkState(int32_t& outSpoolId, uint32_t& outRemainingMs) const {
+void SpoolmanManager::recordLinkResult(int32_t spoolId, bool ok, const char* uid) {
+    if (xSemaphoreTake(cacheMutex_, pdMS_TO_TICKS(100)) != pdTRUE) return;
+    lastLinkResult_.spoolId = spoolId;
+    lastLinkResult_.ok = ok;
+    lastLinkResult_.atMs = millis();
+    strncpy(lastLinkResult_.uid, uid ? uid : "", sizeof(lastLinkResult_.uid) - 1);
+    lastLinkResult_.uid[sizeof(lastLinkResult_.uid) - 1] = '\0';
+    xSemaphoreGive(cacheMutex_);
+}
+
+SpoolmanManager::PendingLinkStatus SpoolmanManager::getPendingLinkStatus() {
+    PendingLinkStatus st;
     int32_t id = pendingLinkSpoolId_.load();
-    if (id <= 0) return false;
-    uint32_t age = millis() - pendingLinkSetAt_.load();
-    if (age >= PENDING_LINK_TIMEOUT_MS) return false;
-    outSpoolId = id;
-    outRemainingMs = PENDING_LINK_TIMEOUT_MS - age;
-    return true;
+    if (id > 0) {
+        uint32_t age = millis() - pendingLinkSetAt_.load();
+        if (age < PENDING_LINK_TIMEOUT_MS) {
+            st.state = PendingLinkState::Armed;
+            st.spoolId = id;
+            st.remainingMs = PENDING_LINK_TIMEOUT_MS - age;
+        } else {
+            // Still stored but past the window — a sync would discard it
+            st.state = PendingLinkState::Expired;
+            st.spoolId = id;
+        }
+        return st;
+    }
+    // No armed link: report the most recent consumption if it's fresh enough
+    // for the UI's polling window to care about (2x the link window)
+    if (xSemaphoreTake(cacheMutex_, pdMS_TO_TICKS(100)) == pdTRUE) {
+        if (lastLinkResult_.spoolId > 0 &&
+            (millis() - lastLinkResult_.atMs) < (2 * PENDING_LINK_TIMEOUT_MS)) {
+            st.state = PendingLinkState::Consumed;
+            st.spoolId = lastLinkResult_.spoolId;
+            st.linkOk = lastLinkResult_.ok;
+            strncpy(st.uid, lastLinkResult_.uid, sizeof(st.uid) - 1);
+            st.uid[sizeof(st.uid) - 1] = '\0';
+        }
+        xSemaphoreGive(cacheMutex_);
+    }
+    return st;
 }
 
 int SpoolmanManager::findVendorNoLock(const char* name, char* outName, size_t outNameSize) {
@@ -1796,6 +1828,7 @@ bool SpoolmanManager::syncSpool(const SpoolmanSyncRequest& req, int& resolvedSpo
             } else {
                 Serial.printf("SpoolmanManager: Pending link PATCH failed (HTTP %d) for spool %d\n", patchCode, linkSpoolId);
             }
+            recordLinkResult(linkSpoolId, patchCode == 200, req.spool_id);
         } else {
             Serial.printf("SpoolmanManager: Pending link for spool %d expired (%ums old), discarding\n", linkSpoolId, age);
         }

--- a/src/SpoolmanManager.h
+++ b/src/SpoolmanManager.h
@@ -58,10 +58,19 @@ public:
     // Set before write flow starts; consumed on first tag sync within PENDING_LINK_TIMEOUT_MS.
     void setPendingLink(int32_t spoolId);
 
-    // Pending-link state for the web UI's link-only flow: returns true while a
-    // link is armed and unexpired, filling the target spool and remaining ms.
-    // Returns false once consumed by a sync or timed out.
-    bool getPendingLinkState(int32_t& outSpoolId, uint32_t& outRemainingMs) const;
+    // Pending-link state machine for the web UI's link-only flow. Distinguishes
+    // a link consumed by a sync (with the actual PATCH outcome and the tag that
+    // took it) from one that expired unconsumed — the UI must never claim
+    // "linked" on an expiry or a failed PATCH.
+    enum class PendingLinkState : uint8_t { Idle, Armed, Consumed, Expired };
+    struct PendingLinkStatus {
+        PendingLinkState state = PendingLinkState::Idle;
+        int32_t spoolId = -1;       // armed target, or consumed link's spool
+        uint32_t remainingMs = 0;   // Armed only
+        bool linkOk = false;        // Consumed only: did the nfc_id PATCH succeed
+        char uid[17] = {0};         // Consumed only: tag that took the link
+    };
+    PendingLinkStatus getPendingLinkStatus();
 
     // Streaming nfc_id → spool id lookup (no spool-count cap, archived spools
     // excluded). Does NOT take the HTTP mutex — the caller must already hold the
@@ -133,6 +142,17 @@ private:
 
     std::atomic<int32_t> pendingLinkSpoolId_{-1};
     std::atomic<uint32_t> pendingLinkSetAt_{0};
+
+    // Outcome of the most recent consumed link — written by the sync task,
+    // read by the web task; guarded by cacheMutex_ (multi-field consistency)
+    struct LinkResult {
+        int32_t spoolId = -1;
+        bool ok = false;
+        uint32_t atMs = 0;
+        char uid[17] = {0};
+    };
+    LinkResult lastLinkResult_;
+    void recordLinkResult(int32_t spoolId, bool ok, const char* uid);
 };
 
 #endif // SPOOLMAN_MANAGER_H

--- a/src/SpoolmanManager.h
+++ b/src/SpoolmanManager.h
@@ -58,6 +58,11 @@ public:
     // Set before write flow starts; consumed on first tag sync within PENDING_LINK_TIMEOUT_MS.
     void setPendingLink(int32_t spoolId);
 
+    // Pending-link state for the web UI's link-only flow: returns true while a
+    // link is armed and unexpired, filling the target spool and remaining ms.
+    // Returns false once consumed by a sync or timed out.
+    bool getPendingLinkState(int32_t& outSpoolId, uint32_t& outRemainingMs) const;
+
     // Streaming nfc_id → spool id lookup (no spool-count cap, archived spools
     // excluded). Does NOT take the HTTP mutex — the caller must already hold the
     // shared g_httpMutex. Returns id >= 0 on match, -1 not found, -2 lookup

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -595,14 +595,21 @@ void WebServerManager::handleApiSpoolmanLink() {
 
 void WebServerManager::handleApiSpoolmanPendingLink() {
     if (_server.method() == HTTP_GET) {
-        // Link-only flow polls this to show "linked" vs "expired": armed goes
-        // false the moment a sync consumes the link or the window lapses
-        int32_t spoolId = -1;
-        uint32_t remainingMs = 0;
-        bool armed = SpoolmanManager::getInstance().getPendingLinkState(spoolId, remainingMs);
-        char body[96];
-        snprintf(body, sizeof(body), "{\"armed\":%s,\"spool_id\":%ld,\"remaining_ms\":%lu}",
-                 armed ? "true" : "false", (long)spoolId, (unsigned long)remainingMs);
+        // Link-only flow polls this. States: armed (countdown), consumed
+        // (with the real PATCH outcome + the tag that took it), expired, idle.
+        auto st = SpoolmanManager::getInstance().getPendingLinkStatus();
+        const char* stateStr = "idle";
+        switch (st.state) {
+            case SpoolmanManager::PendingLinkState::Armed:    stateStr = "armed"; break;
+            case SpoolmanManager::PendingLinkState::Consumed: stateStr = "consumed"; break;
+            case SpoolmanManager::PendingLinkState::Expired:  stateStr = "expired"; break;
+            default: break;
+        }
+        char body[160];
+        snprintf(body, sizeof(body),
+                 "{\"state\":\"%s\",\"spool_id\":%ld,\"remaining_ms\":%lu,\"link_ok\":%s,\"uid\":\"%s\"}",
+                 stateStr, (long)st.spoolId, (unsigned long)st.remainingMs,
+                 st.linkOk ? "true" : "false", st.uid);
         _server.send(200, "application/json", body);
         return;
     }

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -139,6 +139,7 @@ bool WebServerManager::begin(bool apMode, uint16_t port) {
     _server.on("/api/spoolman/spools", HTTP_GET,  [this]() { handleApiSpoolmanSpools(); });
     _server.on("/api/spoolman/link",         HTTP_POST, [this]() { handleApiSpoolmanLink(); });
     _server.on("/api/spoolman/pending-link", HTTP_POST, [this]() { handleApiSpoolmanPendingLink(); });
+    _server.on("/api/spoolman/pending-link", HTTP_GET, [this]() { handleApiSpoolmanPendingLink(); });
     _server.on("/api/spoolman/find-vendor",     HTTP_GET,  [this]() { handleApiSpoolmanFindVendor(); });
     _server.on("/api/spoolman/find-filament",   HTTP_GET,  [this]() { handleApiSpoolmanFindFilament(); });
     _server.on("/api/spoolman/save-enrichment", HTTP_POST, [this]() { handleApiSpoolmanSaveEnrichment(); });
@@ -593,6 +594,18 @@ void WebServerManager::handleApiSpoolmanLink() {
 }
 
 void WebServerManager::handleApiSpoolmanPendingLink() {
+    if (_server.method() == HTTP_GET) {
+        // Link-only flow polls this to show "linked" vs "expired": armed goes
+        // false the moment a sync consumes the link or the window lapses
+        int32_t spoolId = -1;
+        uint32_t remainingMs = 0;
+        bool armed = SpoolmanManager::getInstance().getPendingLinkState(spoolId, remainingMs);
+        char body[96];
+        snprintf(body, sizeof(body), "{\"armed\":%s,\"spool_id\":%ld,\"remaining_ms\":%lu}",
+                 armed ? "true" : "false", (long)spoolId, (unsigned long)remainingMs);
+        _server.send(200, "application/json", body);
+        return;
+    }
 
     StaticJsonDocument<128> doc;
     if (deserializeJson(doc, _server.arg("plain"))) {


### PR DESCRIPTION
## Summary

Selecting a spool in the Import-from-Spoolman picker now shows a **"Link tag (no write)"** button. Before this, binding an already-written tag to a spool required going through a full tag write (the only path that armed the pending link) or hand-crafting an API call — and the UI gave zero feedback either way. This was a real user stumbling block: pick a spool, hold the tag, nothing happens.

Flow: the button arms the firmware's pending link and guides the scan — including the non-obvious *"if the tag is already on the reader, lift it off and set it back down"* (links bind on fresh tag arrival). A new `GET /api/spoolman/pending-link` reports a true state machine (`armed` with countdown / `consumed` with the actual nfc_id PATCH outcome and the tag that took it / `expired` / `idle`), so the UI confirms **"✓ Tag <uid> linked to spool #N"** only when the link genuinely succeeded, and reports Spoolman rejection or window expiry distinctly. The firmware records the consumption outcome (written by the sync task under the cache mutex) because the link is consumed before its PATCH result is known.

Hardening from review: expiry/failed-PATCH can no longer masquerade as success, and spool ids are coerced to finite numbers at both the picker render (the original injection point) and the link flow — a hostile Spoolman response can't break into the markup.

## Testing

All four environments build; native tests 18/18. Browser flow needs a bench pass when a board is next available (arm → countdown → lift-and-replace → confirmed link; plus the expiry and Spoolman-rejection paths) — flagged for the next bench session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Link tag (no write)” action in the spool picker to link an already-written tag to the selected spool without rewriting it.
  * Added live link status updates (armed, consumed/success, expired/failure) with confirmation feedback after arming.

* **Bug Fixes**
  * Prevented invalid spool entries from being selectable in the spool picker.
  * Improved user feedback when the link confirmation window expires or a confirmation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->