### PR TITLE
bump: v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.8.1] - 2026-07-09
 
 ### Added
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ board_build.partitions = partitions.csv
 monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
-	-DFIRMWARE_VERSION=\"1.8.0\"
+	-DFIRMWARE_VERSION=\"1.8.1\"
 ; Exact pins (#216): caret ranges let fresh checkouts resolve newer libraries
 ; than tested builds — same commit, different binary. Bump pins deliberately,
 ; in their own commit, with all four envs built.


### PR DESCRIPTION
Version bump for v1.8.1: identity resolver (#224), link-without-write button, and Snapmaker U1 stage mode + motion-sensor auto-pick. Changelog dated, FIRMWARE_VERSION 1.8.0→1.8.1. Validated by a 14h stability soak on real hardware/network.