### PR TITLE
bump: v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [1.8.2] - 2026-07-10
 
 ### Improved
 
-- **PN532 tag reads are ~4× faster** — the reader was already receiving 16 bytes (4 pages) per radio exchange but keeping only 4; reads now harvest the full response, cutting round-trips 4× everywhere (classify read 10 → 3 exchanges, full OpenSpool payload 50 → 13, post-write verification the same). Most noticeable on single-core ESP32-C3 builds, where each library wait also stalls WiFi and the web UI. Radio traffic is unchanged — tags see the identical command sequence they always have. Extended payload reads are now also clamped to the tag variant's user memory, so a malformed payload length can no longer read lock/config pages into the payload tail. (#242)
+- **PN532 tag reads are ~4× faster** — the reader was already receiving 16 bytes (4 pages) per radio exchange but keeping only 4; reads now harvest the full response, cutting round-trips 4× everywhere (classify read 10 → 3 exchanges, full OpenSpool payload 50 → 13, post-write verification the same). Most noticeable on single-core ESP32-C3 builds, where each library wait also stalls WiFi and the web UI. Radio traffic is unchanged — tags see the identical command sequence they always have. Extended payload reads are now also clamped to the tag variant's user memory, so a malformed payload length can no longer read lock/config pages into the payload tail. (#242) _New — please report results: verified against the library source and CI, not yet timed on physical PN532 hardware._
 
 ## [1.8.1] - 2026-07-09
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ board_build.partitions = partitions.csv
 monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
-	-DFIRMWARE_VERSION=\"1.8.1\"
+	-DFIRMWARE_VERSION=\"1.8.2\"
 ; Exact pins (#216): caret ranges let fresh checkouts resolve newer libraries
 ; than tested builds — same commit, different binary. Bump pins deliberately,
 ; in their own commit, with all four envs built.


### PR DESCRIPTION
Version bump for v1.8.2: PN532 bulk reads (#242/#243). Changelog dated with a call-for-reports note (not yet timed on physical PN532 hardware).