### PR TITLE
Release v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Improved
+
+- **PN532 tag reads are ~4× faster** — the reader was already receiving 16 bytes (4 pages) per radio exchange but keeping only 4; reads now harvest the full response, cutting round-trips 4× everywhere (classify read 10 → 3 exchanges, full OpenSpool payload 50 → 13, post-write verification the same). Most noticeable on single-core ESP32-C3 builds, where each library wait also stalls WiFi and the web UI. Radio traffic is unchanged — tags see the identical command sequence they always have. Extended payload reads are now also clamped to the tag variant's user memory, so a malformed payload length can no longer read lock/config pages into the payload tail. (#242)
+
 ## [1.8.1] - 2026-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [1.8.2] - 2026-07-10
 
 ### Improved
 
-- **PN532 tag reads are ~4× faster** — the reader was already receiving 16 bytes (4 pages) per radio exchange but keeping only 4; reads now harvest the full response, cutting round-trips 4× everywhere (classify read 10 → 3 exchanges, full OpenSpool payload 50 → 13, post-write verification the same). Most noticeable on single-core ESP32-C3 builds, where each library wait also stalls WiFi and the web UI. Radio traffic is unchanged — tags see the identical command sequence they always have. Extended payload reads are now also clamped to the tag variant's user memory, so a malformed payload length can no longer read lock/config pages into the payload tail. (#242)
+- **PN532 tag reads are ~4× faster** — the reader was already receiving 16 bytes (4 pages) per radio exchange but keeping only 4; reads now harvest the full response, cutting round-trips 4× everywhere (classify read 10 → 3 exchanges, full OpenSpool payload 50 → 13, post-write verification the same). Most noticeable on single-core ESP32-C3 builds, where each library wait also stalls WiFi and the web UI. Radio traffic is unchanged — tags see the identical command sequence they always have. Extended payload reads are now also clamped to the tag variant's user memory, so a malformed payload length can no longer read lock/config pages into the payload tail. (#242) _New — please report results: verified against the library source and CI, not yet timed on physical PN532 hardware._
 
 ## [1.8.1] - 2026-07-09
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ board_build.partitions = partitions.csv
 monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
-	-DFIRMWARE_VERSION=\"1.8.1\"
+	-DFIRMWARE_VERSION=\"1.8.2\"
 ; Exact pins (#216): caret ranges let fresh checkouts resolve newer libraries
 ; than tested builds — same commit, different binary. Bump pins deliberately,
 ; in their own commit, with all four envs built.

--- a/src/HardwareNFCConnectionPN532.cpp
+++ b/src/HardwareNFCConnectionPN532.cpp
@@ -143,12 +143,18 @@ uint16_t HardwareNFCConnectionPN532::readISO14443Pages(
     uint16_t totalBytes = (uint16_t)pageCount * 4;
     if (totalBytes > bufferSize) return 0;
 
+    // The NTAG READ command behind mifareultralight_ReadPage always returns
+    // 16 bytes (4 pages); the library keeps 4 and leaves the whole response in
+    // its file-scope packet buffer (frame: [7]=status, [8..23]=data), which
+    // this file already scrapes for ATQA/SAK. Harvesting all 16 bytes per
+    // round-trip cuts radio exchanges 4x — a 10-page classify read costs 3
+    // exchanges instead of 10, a 50-page NDEF read 13 instead of 50 (#242).
     uint16_t bytesRead = 0;
-    for (uint8_t i = 0; i < pageCount; i++) {
-        uint8_t page = startPage + i;
+    for (uint16_t i = 0; i < pageCount; i += 4) {
+        uint8_t page = startPage + (uint8_t)i;
         uint8_t pageBuf[4];
 
-        // Per-page retry: tag may lose activation on RF noise; reactivate and retry once
+        // Per-chunk retry: tag may lose activation on RF noise; reactivate and retry once
         if (!pn532_->mifareultralight_ReadPage(page, pageBuf)) {
             if (!reactivateTag()) return 0;  // reactivateTag also verifies tag hasn't changed
             if (!pn532_->mifareultralight_ReadPage(page, pageBuf)) {
@@ -156,8 +162,13 @@ uint16_t HardwareNFCConnectionPN532::readISO14443Pages(
             }
         }
 
-        memcpy(buffer + (i * 4), pageBuf, 4);
-        bytesRead += 4;
+        // Copy up to 4 pages from the response frame, bounded by the caller's
+        // request — never past it, so a READ that straddles the tag's last
+        // page can't leak roll-over data into the result
+        uint16_t chunkBytes = (uint16_t)(pageCount - i) * 4;
+        if (chunkBytes > 16) chunkBytes = 16;
+        memcpy(buffer + (i * 4), pn532_packetbuffer + 8, chunkBytes);
+        bytesRead += chunkBytes;
     }
 
     return bytesRead;

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -286,7 +286,7 @@ static NdefRecord findNdefMediaRecord(const uint8_t* pageData, uint16_t bytesRea
 // Read NDEF payload bytes, doing an extended page read if the initial 40-byte read
 // didn't contain the full payload. Returns bytes copied into outBuf.
 uint16_t NFCManager::readNdefPayload(const NdefRecord& rec, const uint8_t* pageData, uint16_t bytesRead,
-                                      uint8_t* outBuf, uint16_t outBufSize) {
+                                      uint8_t* outBuf, uint16_t outBufSize, uint16_t maxPages) {
     if (!rec.found || rec.payloadLen == 0) return 0;
 
     uint16_t available = (rec.payloadOffset < bytesRead) ? bytesRead - rec.payloadOffset : 0;
@@ -301,6 +301,15 @@ uint16_t NFCManager::readNdefPayload(const NdefRecord& rec, const uint8_t* pageD
     uint8_t startPage = 4 + (rec.payloadOffset / 4);
     uint16_t pagesNeeded = (uint16_t)((rec.payloadLen + 3) / 4) + 1;
     if (pagesNeeded > 50) pagesNeeded = 50;
+    // Never request past the tag's last usable page: NTAG READ rolls over to
+    // page 0 beyond the end, which would silently corrupt the tail of an
+    // over-asked payload (garbage payloadLen on a malformed tag)
+    if (maxPages > 0) {
+        if (startPage >= maxPages) return 0;
+        if ((uint16_t)startPage + pagesNeeded > maxPages) {
+            pagesNeeded = maxPages - startPage;
+        }
+    }
 
     uint8_t extBuf[256] = {0};
     uint16_t extRead = connection_->readISO14443Pages(startPage, (uint8_t)pagesNeeded, extBuf, sizeof(extBuf));
@@ -351,7 +360,8 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
             if (rec.mimeLen == strlen(ot3dMime) && memcmp(rec.mimeType, ot3dMime, rec.mimeLen) == 0) {
                 uint8_t payload[OT3D_EXTENDED_MIN];
                 SCAN_PHASE(22);
-                uint16_t payloadBytes = readNdefPayload(rec, pageData, bytesRead, payload, sizeof(payload));
+                uint16_t payloadBytes = readNdefPayload(rec, pageData, bytesRead, payload, sizeof(payload),
+                                                        ntagUsablePages(scan.variant));
                 if (payloadBytes >= OT3D_CORE_SIZE) {
                     opentag3d_result_t res = opentag3d_decode(payload, payloadBytes, &ot3dData);
                     if (res == OT3D_OK || res == OT3D_VERSION_WARNING) {
@@ -372,7 +382,8 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
                 if (rec.mimeLen == strlen(jsonMime) && memcmp(rec.mimeType, jsonMime, rec.mimeLen) == 0) {
                     uint8_t payload[256];
                     SCAN_PHASE(23);
-                    uint16_t payloadBytes = readNdefPayload(rec, pageData, bytesRead, payload, sizeof(payload));
+                    uint16_t payloadBytes = readNdefPayload(rec, pageData, bytesRead, payload, sizeof(payload),
+                                                            ntagUsablePages(scan.variant));
                     if (payloadBytes > 0 && parseOpenSpool(payload, payloadBytes, openSpoolData)) {
                         isOpenSpool = true;
                     }

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -361,7 +361,7 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
                 uint8_t payload[OT3D_EXTENDED_MIN];
                 SCAN_PHASE(22);
                 uint16_t payloadBytes = readNdefPayload(rec, pageData, bytesRead, payload, sizeof(payload),
-                                                        ntagUsablePages(scan.variant));
+                                                        ntagUserMemoryEnd(scan.variant));
                 if (payloadBytes >= OT3D_CORE_SIZE) {
                     opentag3d_result_t res = opentag3d_decode(payload, payloadBytes, &ot3dData);
                     if (res == OT3D_OK || res == OT3D_VERSION_WARNING) {
@@ -383,7 +383,7 @@ void NFCManager::readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength
                     uint8_t payload[256];
                     SCAN_PHASE(23);
                     uint16_t payloadBytes = readNdefPayload(rec, pageData, bytesRead, payload, sizeof(payload),
-                                                            ntagUsablePages(scan.variant));
+                                                            ntagUserMemoryEnd(scan.variant));
                     if (payloadBytes > 0 && parseOpenSpool(payload, payloadBytes, openSpoolData)) {
                         isOpenSpool = true;
                     }

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -127,7 +127,7 @@ private:
     bool readAndParseTag(uint8_t* uid, uint8_t uid_length);
     void readAndProcessISO14443Tag(const uint8_t* uid, uint8_t uidLength, const TagScanResult& scan);
     uint16_t readNdefPayload(const struct NdefRecord& rec, const uint8_t* pageData, uint16_t bytesRead,
-                              uint8_t* outBuf, uint16_t outBufSize);
+                              uint8_t* outBuf, uint16_t outBufSize, uint16_t maxPages = 0);
     bool formatNewSpool();
     TagScanResult classifyTag(const uint8_t* uid, uint8_t uid_length);
     void sendOpenPrintTagMessage(bool suppress_spoolman_sync = false);

--- a/src/NFCTypes.h
+++ b/src/NFCTypes.h
@@ -32,6 +32,20 @@ inline uint16_t ntagUsablePages(NtagVariant v) {
     }
 }
 
+// Exclusive end of USER memory (first dynamic-lock/config page). Differs from
+// ntagUsablePages, which counts every page on the die — payload reads must
+// stop here or a malformed length pulls lock/config bytes into the payload.
+inline uint16_t ntagUserMemoryEnd(NtagVariant v) {
+    switch (v) {
+        case NtagVariant::NTAG213:          return 40;   // user 4-39
+        case NtagVariant::NTAG215:          return 130;  // user 4-129
+        case NtagVariant::NTAG216:          return 226;  // user 4-225
+        case NtagVariant::UltralightEV1_48: return 16;   // user 4-15
+        case NtagVariant::UltralightEV1_128:return 36;   // user 4-35
+        default:                            return 0;    // unknown — no clamp
+    }
+}
+
 inline const char* ntagVariantName(NtagVariant v) {
     switch (v) {
         case NtagVariant::NTAG213:          return "NTAG213";


### PR DESCRIPTION
v1.8.2 — PN532 read performance:

**PN532 tag reads are ~4× faster.** The reader was already receiving 16 bytes per radio exchange but keeping only 4; reads now harvest the full response — classify read 10 → 3 exchanges, full OpenSpool payload 50 → 13, post-write verification the same. Radio traffic is byte-identical (tags see the same command sequence they always have), so there's no tag-compatibility surface. Extended payload reads are additionally clamped to the tag variant's user memory so a malformed payload length can't read lock/config pages into the payload tail. Biggest felt improvement on single-core ESP32-C3 builds. (#242, #243)

Community-reported (Discord: PN532 scans slower than dedicated raw-comms readers), root-caused against the Adafruit library source. Verified via CI and code review; changelog carries a call-for-reports note pending physical PN532 timing.