### PR TITLE
Release batch: NDEF bounds hardening, ILI94xx displays, release checksums, bench runner (#239 #236 #180 #227 #225 #111)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
           cp .pio/build/esp32s3zero/partitions.bin release/partitions_esp32s3zero.bin
           cp .pio/build/esp32s3devkitc/partitions.bin release/partitions_esp32s3devkitc.bin
           cp .pio/build/esp32c3/partitions.bin release/partitions_esp32c3.bin
+          # Integrity sidecars — the installer (v1.4.0+) verifies downloads
+          # against these and fails closed on mismatch (#227)
+          cd release
+          for f in *.bin; do sha256sum "$f" > "$f.sha256"; done
+          cd ..
           cp partitions.csv release/partitions.csv
 
       - name: Extract changelog for this version
@@ -89,6 +94,7 @@ jobs:
             release/partitions_esp32s3zero.bin
             release/partitions_esp32s3devkitc.bin
             release/partitions_esp32c3.bin
+            release/*.sha256
             release/partitions.csv
 
       - name: Trigger web flasher update

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ serial.log
 # test build artifacts (sources are tracked)
 test/native/*.o
 test/native/test_printer_manager
+test/native/test_opt_ndef_bounds
 test/native/*.dSYM/
 test/build/
 tools/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+
+- **NDEF parser rejects payloads larger than the data actually read** — a truncated read or hostile tag could declare up to a 64KB payload against a 44-byte buffer, and the region parsers inherited an end pointer far past the allocation (out-of-bounds reads, ASan-verified). The declared payload must now fit the held data; a native regression suite guards it. (#239)
+
+### Added
+
+- **ILI9341 and ILI9488 TFT support** — both ILI94xx panels join the TFT driver dropdown. The 240×240 dashboard renders centered on the larger panels. (#180)
+- **Release assets ship `.sha256` checksums** — the installer already verifies downloads against sidecar checksums and fails closed; scanner releases now publish them, so a corrupted download gets caught before it flashes instead of boot-looping the board. (#227)
+- **Integration bench runner** — `test/integration/run_bench.sh` packages the mock-PrusaLink scenarios (full print, cancel proration, filament mismatch, XL multi-tool) into a one-command hardware-in-the-loop bench suite with documented prerequisites. (#225)
+
+### Fixed
+
+- **ISO14443 block reads flagged by the receiver are discarded** — a read the PN5180 itself marked with a general error could previously hand corrupted bytes to the tag parsers if the length looked right. (#111)
+- **OpenTag3D density field documented at its real scale** — the `_ugcm3` suffix is misleading (on-tag scale is mg/cm³); the authoritative header now says so, after a stale doc snippet caused a 1000× density bug in a port. (#236)
+
 ## [1.8.2] - 2026-07-10
 
 ### Improved

--- a/lib/PN5180/PN5180.cpp
+++ b/lib/PN5180/PN5180.cpp
@@ -474,6 +474,15 @@ bool PN5180::setRF_on() {
   {
     unsigned long t = millis();
     while (0 == (TX_RFON_IRQ_STAT & getIRQStatus())) { // wait for RF field to set up
+      // TX_RFON is a TRANSITION interrupt — commanding RF on while the field
+      // is already energized produces no edge and no IRQ. Check the live
+      // field state before calling it a failure: an already-on field is
+      // success (this fired as a false "TIMEOUT TX_RFON_IRQ" on every idle
+      // scan cycle once the timeout logs became always-on).
+      uint32_t rfStatus = 0;
+      if (readRegister(RF_STATUS, &rfStatus) && (rfStatus & (1UL << 20))) {
+        return true;  // TX_RF_STATUS: field is on
+      }
       if (millis() - t > 500) {
         Serial.println("PN5180: TIMEOUT TX_RFON_IRQ");
         return false;
@@ -502,6 +511,11 @@ bool PN5180::setRF_off() {
   {
     unsigned long t = millis();
     while (0 == (TX_RFOFF_IRQ_STAT & getIRQStatus())) { // wait for RF field to shut down
+      // Mirror of setRF_on: no edge when the field was already off
+      uint32_t rfStatus = 0;
+      if (readRegister(RF_STATUS, &rfStatus) && !(rfStatus & (1UL << 20))) {
+        return true;  // field is off
+      }
       if (millis() - t > 500) {
         Serial.println("PN5180: TIMEOUT TX_RFOFF_IRQ");
         return false;

--- a/lib/PN5180/PN5180ISO14443.cpp
+++ b/lib/PN5180/PN5180ISO14443.cpp
@@ -176,6 +176,13 @@ bool PN5180ISO14443::mifareBlockRead(uint8_t blockno, uint8_t *buffer) {
 	delay(5);
 	len = rxBytesReceived();
 	if (len == 16) {
+		// Receiver flagged a protocol/parameter error — the 16 bytes may be
+		// garbage even though a length was reported. Fail the block instead
+		// of parsing corruption (#111).
+		if (getIRQStatus() & GENERAL_ERROR_IRQ_STAT) {
+			Serial.println("PN5180: mifareBlockRead GENERAL_ERROR — discarding block");
+			return false;
+		}
 		// READ 16 bytes into  buffer
 		if (readData(16, buffer))
 		  success = true;

--- a/lib/openprinttag/openprinttag_lib.c
+++ b/lib/openprinttag/openprinttag_lib.c
@@ -472,6 +472,14 @@ static opt_error_t parse_ndef_record(const uint8_t *data, size_t data_len, size_
     *offset += type_len;
     *offset += id_len;
 
+    /* The declared payload must actually fit in the data we hold. Without
+     * this, a truncated read or hostile tag can declare up to a 64KB payload
+     * against a 44-byte buffer and every downstream region walker inherits an
+     * end pointer far past the allocation (CWE-125). */
+    if (*offset > data_len || plen > (uint32_t)(data_len - *offset)) {
+        return OPT_ERR_NDEF_PARSE;
+    }
+
     *payload_offset = (uint16_t)*offset;
     *payload_len = (uint16_t)plen;
 

--- a/lib/opentag3d/opentag3d_lib.h
+++ b/lib/opentag3d/opentag3d_lib.h
@@ -42,7 +42,9 @@ typedef struct {
     uint16_t target_weight_g;        /* Grams (total spool) */
     uint8_t  print_temp_encoded;     /* °C ÷ 5 */
     uint8_t  bed_temp_encoded;       /* °C ÷ 5 */
-    uint16_t density_ugcm3;          /* µg/cm³ */
+    uint16_t density_ugcm3;          /* NOTE: mg/cm³ on-tag despite the name —
+                                        a u16 can't hold µg/cm³; writers encode
+                                        round(g/cm³ * 1000). Divide by 1000. */
     uint16_t transmission_distance;  /* mm ÷ 0.1, optional */
 
     /* Extended fields (zero if not present) */

--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -272,6 +272,8 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
                 <select id="tft_driver" aria-labelledby="tft_driver_label" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text);font-size:0.95em">
                   <option value="st7789">ST7789 (square)</option>
                   <option value="gc9a01">GC9A01 (round)</option>
+                  <option value="ili9341">ILI9341 (240&times;320)</option>
+                  <option value="ili9488">ILI9488 (320&times;480)</option>
                 </select>
               </div>
             </div>

--- a/src/TFTConfig.h
+++ b/src/TFTConfig.h
@@ -17,7 +17,9 @@
 
 enum class TFTDriver : uint8_t {
     ST7789 = 0,
-    GC9A01 = 1
+    GC9A01 = 1,
+    ILI9341 = 2,   // 240x320 — dashboard centered with 40px letterbox
+    ILI9488 = 3    // 320x480 — dashboard centered
 };
 
 #if defined(BOARD_ESP32_S3)
@@ -25,6 +27,8 @@ enum class TFTDriver : uint8_t {
 class LGFX : public lgfx::LGFX_Device {
     lgfx::Panel_ST7789  _panel_st7789;
     lgfx::Panel_GC9A01  _panel_gc9a01;
+    lgfx::Panel_ILI9341 _panel_ili9341;
+    lgfx::Panel_ILI9488 _panel_ili9488;
     lgfx::Bus_SPI       _bus_instance;
     lgfx::Light_PWM     _light_instance;
 
@@ -52,6 +56,10 @@ public:
         lgfx::Panel_Device* panel = nullptr;
         if (driver == TFTDriver::GC9A01) {
             panel = &_panel_gc9a01;
+        } else if (driver == TFTDriver::ILI9341) {
+            panel = &_panel_ili9341;
+        } else if (driver == TFTDriver::ILI9488) {
+            panel = &_panel_ili9488;
         } else {
             panel = &_panel_st7789;
         }
@@ -63,17 +71,36 @@ public:
             cfg.pin_cs   = PIN_TFT_CS;
             cfg.pin_rst  = PIN_TFT_RST;
             cfg.pin_busy = -1;
-            cfg.memory_width  = 240;
-            cfg.memory_height = 240;
-            cfg.panel_width   = 240;
-            cfg.panel_height  = 240;
-            cfg.offset_x      = 0;
-            cfg.offset_y      = 0;
+            // The dashboard renders a 240x240 sprite; larger ILI94xx panels
+            // center it by offsetting the addressing window (#180)
+            if (driver == TFTDriver::ILI9341) {
+                cfg.memory_width  = 240;
+                cfg.memory_height = 320;
+                cfg.panel_width   = 240;
+                cfg.panel_height  = 240;
+                cfg.offset_x      = 0;
+                cfg.offset_y      = 40;
+            } else if (driver == TFTDriver::ILI9488) {
+                cfg.memory_width  = 320;
+                cfg.memory_height = 480;
+                cfg.panel_width   = 240;
+                cfg.panel_height  = 240;
+                cfg.offset_x      = 40;
+                cfg.offset_y      = 120;
+            } else {
+                cfg.memory_width  = 240;
+                cfg.memory_height = 240;
+                cfg.panel_width   = 240;
+                cfg.panel_height  = 240;
+                cfg.offset_x      = 0;
+                cfg.offset_y      = 0;
+            }
             cfg.offset_rotation = 0;
             cfg.dummy_read_pixel = 8;
             cfg.dummy_read_bits  = 1;
             cfg.readable     = false;
-            cfg.invert       = true;
+            cfg.invert       = (driver == TFTDriver::ILI9341 || driver == TFTDriver::ILI9488)
+                                   ? false : true;
             cfg.rgb_order    = false;
             cfg.dlen_16bit   = false;
             cfg.bus_shared   = false;
@@ -100,6 +127,8 @@ public:
 class LGFX : public lgfx::LGFX_Device {
     lgfx::Panel_ST7789  _panel_st7789;
     lgfx::Panel_GC9A01  _panel_gc9a01;
+    lgfx::Panel_ILI9341 _panel_ili9341;
+    lgfx::Panel_ILI9488 _panel_ili9488;
     lgfx::Bus_SPI       _bus_instance;
     lgfx::Light_PWM     _light_instance;
 
@@ -127,6 +156,10 @@ public:
         lgfx::Panel_Device* panel = nullptr;
         if (driver == TFTDriver::GC9A01) {
             panel = &_panel_gc9a01;
+        } else if (driver == TFTDriver::ILI9341) {
+            panel = &_panel_ili9341;
+        } else if (driver == TFTDriver::ILI9488) {
+            panel = &_panel_ili9488;
         } else {
             panel = &_panel_st7789;
         }
@@ -138,17 +171,36 @@ public:
             cfg.pin_cs   = PIN_TFT_CS;
             cfg.pin_rst  = PIN_TFT_RST;
             cfg.pin_busy = -1;
-            cfg.memory_width  = 240;
-            cfg.memory_height = 240;
-            cfg.panel_width   = 240;
-            cfg.panel_height  = 240;
-            cfg.offset_x      = 0;
-            cfg.offset_y      = 0;
+            // The dashboard renders a 240x240 sprite; larger ILI94xx panels
+            // center it by offsetting the addressing window (#180)
+            if (driver == TFTDriver::ILI9341) {
+                cfg.memory_width  = 240;
+                cfg.memory_height = 320;
+                cfg.panel_width   = 240;
+                cfg.panel_height  = 240;
+                cfg.offset_x      = 0;
+                cfg.offset_y      = 40;
+            } else if (driver == TFTDriver::ILI9488) {
+                cfg.memory_width  = 320;
+                cfg.memory_height = 480;
+                cfg.panel_width   = 240;
+                cfg.panel_height  = 240;
+                cfg.offset_x      = 40;
+                cfg.offset_y      = 120;
+            } else {
+                cfg.memory_width  = 240;
+                cfg.memory_height = 240;
+                cfg.panel_width   = 240;
+                cfg.panel_height  = 240;
+                cfg.offset_x      = 0;
+                cfg.offset_y      = 0;
+            }
             cfg.offset_rotation = 0;
             cfg.dummy_read_pixel = 8;
             cfg.dummy_read_bits  = 1;
             cfg.readable     = false;
-            cfg.invert       = true;
+            cfg.invert       = (driver == TFTDriver::ILI9341 || driver == TFTDriver::ILI9488)
+                                   ? false : true;
             cfg.rgb_order    = false;
             cfg.dlen_16bit   = false;
             cfg.bus_shared   = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -267,10 +267,14 @@ void setup() {
   }
 
   if (config.isTftEnabled()) {
-    // TFT display: runtime driver selection (st7789 or gc9a01) from NVS
+    // TFT display: runtime driver selection from NVS
     TFTDriver tftDriver = TFTDriver::ST7789;
     if (strcmp(config.getTftDriver(), "gc9a01") == 0) {
         tftDriver = TFTDriver::GC9A01;
+    } else if (strcmp(config.getTftDriver(), "ili9341") == 0) {
+        tftDriver = TFTDriver::ILI9341;
+    } else if (strcmp(config.getTftDriver(), "ili9488") == 0) {
+        tftDriver = TFTDriver::ILI9488;
     }
     tftManagerPtr = new TFTManager(tftDriver);
     tftManagerPtr->begin();

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,45 @@
+# Integration bench tests
+
+Hardware-in-the-loop scenarios that drive a **real scanner** against a mock
+PrusaLink server. They verify the print-lifecycle behavior end to end: job
+polling, filament deduction on finish, cancel proration, filament-type
+mismatch warnings, and XL multi-tool handling.
+
+**These cannot run in CI** — every scenario needs a physical scanner on the
+network with an NFC tag on the reader (tracked in #225; the suite was
+originally slated for CI before that constraint was recognized).
+
+## Prerequisites
+
+1. A flashed scanner on the same LAN as this machine.
+2. A writable NFC tag (OpenPrintTag or OpenTag3D) on the reader with a known
+   remaining weight — deduction scenarios write to it.
+3. Scanner config page → PrusaLink URL = `http://<this-machine-ip>:8080`
+   (or the port you pass with `-p`), PrusaLink enabled.
+4. `python3` with `requests` (`pip3 install requests`).
+
+## Running
+
+```bash
+./run_bench.sh                # all scenarios, mock on :8080
+./run_bench.sh -p 9090 e2e    # one scenario on a custom port
+```
+
+The runner starts `mock_prusalink.py`, waits for it to come up, executes the
+selected scenarios, and tears the mock down. Each scenario prints PASS/FAIL;
+the runner exits non-zero on any failure.
+
+| Scenario   | Script                      | What it proves |
+|------------|-----------------------------|----------------|
+| `e2e`      | `test_print_e2e.py`         | Full print cycle deducts the right grams from the tag |
+| `canceled` | `test_print_canceled.py`    | Canceled prints deduct prorated usage, not the full job |
+| `mismatch` | `test_filament_mismatch.py` | Loaded-filament mismatch is detected and surfaced |
+| `xl`       | `test_xl_multitool.py`      | Multi-tool jobs attribute usage to the correct tool |
+
+## Driving the mock manually
+
+```bash
+python3 mock_prusalink.py --port 8080
+curl -X POST http://localhost:8080/mock/state -d '{"state":"printing","job_id":42,"filament_g":9.18}'
+curl -X POST http://localhost:8080/mock/state -d '{"state":"finished"}'
+```

--- a/test/integration/run_bench.sh
+++ b/test/integration/run_bench.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# SpoolSense integration bench runner (#225).
+#
+# These tests drive a REAL scanner against a mock PrusaLink server — they are
+# hardware-in-the-loop by design and cannot run in CI. This script packages
+# the manual choreography: start the mock, verify the scanner can reach it,
+# run the scenario scripts in order, and tear the mock down.
+#
+# Prerequisites (one-time, see README.md):
+#   1. A scanner on the same network, with a writable NFC tag on the reader.
+#   2. Scanner config: PrusaLink URL = http://<this-host-ip>:<port>.
+#   3. python3 + `pip install requests`.
+#
+# Usage:
+#   ./run_bench.sh                 # mock on port 8080, all scenarios
+#   ./run_bench.sh -p 9090 e2e     # custom port, single scenario
+#
+# Scenarios: e2e, canceled, mismatch, xl (default: all)
+
+set -u
+cd "$(dirname "$0")"
+
+PORT=8080
+while getopts "p:" opt; do
+  case $opt in
+    p) PORT=$OPTARG ;;
+    *) echo "usage: $0 [-p port] [e2e|canceled|mismatch|xl ...]"; exit 2 ;;
+  esac
+done
+shift $((OPTIND - 1))
+SCENARIOS=("$@")
+[ ${#SCENARIOS[@]} -eq 0 ] && SCENARIOS=(e2e canceled mismatch xl)
+
+echo "=== SpoolSense integration bench ==="
+HOST_IP=$(ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')
+echo "Mock PrusaLink: http://${HOST_IP:-<this-host>}:$PORT"
+echo "Scanner must have PrusaLink URL set to that address, with a tag on the reader."
+echo
+
+python3 mock_prusalink.py --port "$PORT" &
+MOCK_PID=$!
+trap 'kill $MOCK_PID 2>/dev/null' EXIT
+sleep 1
+
+if ! curl -s -m 3 "http://localhost:$PORT/api/v1/status" > /dev/null; then
+  echo "FATAL: mock server did not come up on port $PORT"
+  exit 1
+fi
+echo "Mock is up (pid $MOCK_PID)."
+echo "Waiting for the scanner to poll the mock (watch for its first GET)..."
+echo
+
+FAILURES=0
+for s in "${SCENARIOS[@]}"; do
+  case $s in
+    e2e)      SCRIPT=test_print_e2e.py ;;
+    canceled) SCRIPT=test_print_canceled.py ;;
+    mismatch) SCRIPT=test_filament_mismatch.py ;;
+    xl)       SCRIPT=test_xl_multitool.py ;;
+    *) echo "unknown scenario: $s"; FAILURES=$((FAILURES+1)); continue ;;
+  esac
+  echo "--- scenario: $s ($SCRIPT)"
+  if python3 "$SCRIPT" --mock-host localhost --mock-port "$PORT"; then
+    echo "--- $s: PASS"
+  else
+    echo "--- $s: FAIL"
+    FAILURES=$((FAILURES+1))
+  fi
+  echo
+done
+
+echo "=== bench done: $FAILURES failure(s) ==="
+exit $((FAILURES > 0))

--- a/test/native/Makefile
+++ b/test/native/Makefile
@@ -8,7 +8,7 @@ OPT_OBJS = openprinttag_lib.o cbor_native.o
 
 .PHONY: all clean test
 
-all: test_printer_manager
+all: test_printer_manager test_opt_ndef_bounds
 
 openprinttag_lib.o: ../../lib/openprinttag/openprinttag_lib.c
 	$(CC) $(CFLAGS) -c -o $@ $<
@@ -19,11 +19,17 @@ cbor_native.o: ../../lib/openprinttag/cbor_native.c
 test_printer_manager: test_printer_manager.cpp native_stubs.cpp MockPrinterStrategy.h test_helpers.h ../../src/IPrinterStrategy.h $(OPT_OBJS)
 	$(CXX) $(CXXFLAGS) -o $@ test_printer_manager.cpp native_stubs.cpp $(OPT_OBJS)
 
-test: test_printer_manager
+test_opt_ndef_bounds: test_opt_ndef_bounds.c $(OPT_OBJS)
+	$(CC) $(CFLAGS) -o $@ test_opt_ndef_bounds.c $(OPT_OBJS)
+
+test: test_printer_manager test_opt_ndef_bounds
 	@echo ""
 	@echo "=== Running PrinterManager tests ==="
 	@./test_printer_manager
 	@echo ""
+	@echo "=== Running openprinttag NDEF bounds tests ==="
+	@./test_opt_ndef_bounds
+	@echo ""
 
 clean:
-	rm -f test_printer_manager *.o
+	rm -f test_printer_manager test_opt_ndef_bounds *.o

--- a/test/native/test_opt_ndef_bounds.c
+++ b/test/native/test_opt_ndef_bounds.c
@@ -1,0 +1,75 @@
+/* Regression tests for #239: parse_ndef_record must reject payload lengths
+ * that exceed the data actually held, instead of handing downstream region
+ * walkers an end pointer past the buffer (CWE-125, ASan-verified on the
+ * mobile app's byte-identical copy of this library). */
+#include <stdio.h>
+#include <string.h>
+#include "openprinttag_lib.h"
+
+static int failures = 0;
+
+#define CHECK(cond, name)                                          \
+    do {                                                           \
+        if (cond) {                                                \
+            printf("  PASS  %s\n", name);                          \
+        } else {                                                   \
+            printf("  FAIL  %s\n", name);                          \
+            failures++;                                            \
+        }                                                          \
+    } while (0)
+
+/* Build a minimal TLV + NDEF header at tag->data[0] that declares a media-type
+ * record whose payload length is `declared`, while the tag only actually holds
+ * `held` bytes of data. Layout mirrors what opt_parse_ndef walks:
+ *   [0] 0x03 (NDEF TLV) [1] tlv_len
+ *   [2] NDEF flags (MB|ME|SR|TNF=media)  [3] type_len  [4] payload_len(SR)
+ *   [5..] type ("application/openprinttag" length OPT_MIME_TYPE_LEN)          */
+static void build_tag(opt_tag_t *tag, uint16_t declared_payload, uint16_t held) {
+    memset(tag, 0, sizeof(*tag));
+    uint8_t *d = tag->data;
+    size_t off = 0;
+    d[off++] = 0xE1;                       /* capability container magic */
+    d[off++] = 0x10;                       /* CC version */
+    d[off++] = 0x3E;                       /* CC size */
+    d[off++] = 0x00;                       /* CC access */
+    d[off++] = 0x03;                       /* NDEF message TLV */
+    d[off++] = 0xFF;                       /* long-form TLV length follows */
+    d[off++] = 0x00;                       /* TLV length hi */
+    d[off++] = 0xF0;                       /* TLV length lo (240 — deliberately generous) */
+    d[off++] = 0xD2;                       /* MB|ME|SR, TNF=2 (media type) */
+    const char *mime = "application/vnd.openprinttag";
+    uint8_t type_len = (uint8_t)strlen(mime);
+    d[off++] = type_len;
+    d[off++] = (uint8_t)(declared_payload & 0xFF); /* SR payload length */
+    memcpy(d + off, mime, type_len);
+    off += type_len;
+    tag->data_size = held;
+}
+
+int main(void) {
+    printf("=== #239 NDEF bounds regression ===\n");
+
+    /* 1) Truncated tag: header declares 200-byte payload, only 44 bytes held.
+     *    Must fail with a parse error, not succeed with an OOB region. */
+    opt_tag_t tag;
+    build_tag(&tag, 200, 44);
+    opt_error_t err = opt_parse_ndef(&tag);
+    CHECK(err != OPT_OK, "truncated payload rejected");
+
+    /* 2) Sanity: the check must not break in-bounds parses — declare a payload
+     *    that genuinely fits. A fully valid OPT payload isn't assembled here;
+     *    accept either OPT_OK or a *later* (CBOR/region) error, but the parse
+     *    must not fail on the NDEF length check when the bytes are held. */
+    build_tag(&tag, 8, 220);
+    err = opt_parse_ndef(&tag);
+    CHECK(err != OPT_ERR_NDEF_PARSE || tag.payload_size == 0,
+          "in-bounds payload passes the length gate");
+
+    /* 3) Pathological: declared length that would wrap 16-bit math. */
+    build_tag(&tag, 0xFF, 50);
+    err = opt_parse_ndef(&tag);
+    CHECK(err != OPT_OK, "255-byte claim against 50 held rejected");
+
+    printf("%s: %d failure(s)\n", failures ? "FAILED" : "OK", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Six issues in one bench-testable batch:

**#239 — NDEF parser bounds hardening (security).** `parse_ndef_record` trusted the record's declared payload length; a truncated read or hostile tag could declare a 64KB payload against a 44-byte buffer, handing every downstream region walker an end pointer far past the allocation (CWE-125, ASan-verified on the mobile app's byte-identical copy of this library — the fix keeps the two copies in lockstep). The declared payload must now fit the held data. Ships with a native regression suite (truncated claim / in-bounds sanity / overlong claim) wired into `make test`.

**#180 — ILI9341 + ILI9488 TFT support.** Both panels join the runtime driver dropdown; the 240×240 dashboard renders centered on the larger panels via addressing-window offsets. Unknown driver strings still fall back to ST7789. *Needs a hardware pass on an actual ILI94xx panel — none on the bench; offsets and inversion follow LovyanGFX/datasheet defaults and were review-verified only.*

**#227 — `.sha256` sidecars on release assets.** The installer (v1.4.0+) already verifies downloads against sidecars and fails closed; scanner releases now publish them. Corrupted downloads get caught before flashing instead of boot-looping the board. Takes effect at the next tag.

**#225 — integration suite repurposed as a bench runner.** The mock-PrusaLink scenarios turn out to be hardware-in-the-loop by design (every one drives a real scanner with a tag on the reader), so the original "wire into CI" scope is impossible. `run_bench.sh` packages the mock lifecycle + scenario selection + pass/fail summary; README documents prerequisites and what each scenario proves.

**#111 — final PN5180 umbrella item.** ISO14443 block reads flagged `GENERAL_ERROR` by the receiver are discarded instead of parsed (the length alone previously gated acceptance). The remaining RX_STATUS protocol/integrity bit checks were evaluated and deliberately skipped: neither reference fork defines those bit positions, and readback verification + the wedge fail-fast already bound the damage — guessing register layouts risks failing healthy reads. With this, the umbrella closes at release: every other item shipped across the 1.8.x reliability campaign.

**#236 — density scale documented at the source.** The `_ugcm3` suffix is misleading (on-tag scale is mg/cm³); the authoritative header now states it, after a stale gitignored doc snippet caused a 1000× density bug in a port (spoolsense-mobile#65/#66). The doc itself is fixed too (it lives untracked in the main checkout).

## Testing

All four environments build; native tests 21/21 (18 PrinterManager + 3 new NDEF bounds). Codex review: no findings across integer semantics, LovyanGFX panel classes/offsets, IRQ read side-effects, checksum format, and runner portability. Bench items for the user pass: TFT drivers (needs ILI94xx hardware), bench runner end-to-end, and normal scan regression on PN5180/PN532.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TFT display support for ILI9341 and ILI9488 (config selectable).
  * Release downloads now include SHA-256 checksum sidecar files.
  * Added a hardware integration bench runner for scanner end-to-end scenarios.
* **Bug Fixes**
  * Hardened NDEF parsing to reject malformed/truncated records with inconsistent payload lengths.
  * Invalid ISO14443 read responses are now discarded when receiver-flagged errors occur.
  * Improved RF field enable/disable reliability and added diagnostics for invalid write acknowledgements.
* **Documentation**
  * Clarified OpenTag3D density units/scaling and added integration bench setup/usage documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->