### PR TITLE
Runtime-configurable NFC reader pins (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- **Runtime-configurable NFC reader pins** — a new "NFC Reader Pins (advanced)" section on the config page remaps the reader wiring (RST, NSS/SS, BUSY, SCK, MOSI, MISO) without a custom firmware build, for boards whose pinout differs from the supported variants (#201; also the pin-map half of #197's C3-OLED board). Blank means board default; overrides are validated at the NVS boundary — board-invalid pins revert individually, and any conflict within the set or against the status LED or enabled feature pins reverts the whole set with a serial warning, so a half-applied remap can't wedge the reader. Applies on the post-save restart. PN532 shares the same six slots (BUSY unused).
 - **ILI9341 and ILI9488 TFT support** — both ILI94xx panels join the TFT driver dropdown. The 240×240 dashboard renders centered on the larger panels. (#180)
 - **Release assets ship `.sha256` checksums** — the installer already verifies downloads against sidecar checksums and fails closed; scanner releases now publish them, so a corrupted download gets caught before it flashes instead of boot-looping the board. (#227)
 - **Integration bench runner** — `test/integration/run_bench.sh` packages the mock-PrusaLink scenarios (full print, cancel proration, filament mismatch, XL multi-tool) into a one-command hardware-in-the-loop bench suite with documented prerequisites. (#225)

--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -253,6 +253,22 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
                        aria-labelledby="led_pin_label"
                        style="width:150px;padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text);font-size:0.95em" />
               </div>
+
+              <div class="field">
+                <details>
+                  <summary style="cursor:pointer;color:var(--accent);font-size:0.95em">NFC Reader Pins (advanced)</summary>
+                  <div class="hint" style="margin:8px 0">Remap the reader wiring for boards with different pinouts (blank = board default). Values are validated and conflicting sets revert to defaults. Changes apply after the device restarts on save. <strong>Wrong pins stop the reader from working until corrected.</strong></div>
+                  <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px">
+                    <label style="font-size:0.85em">RST<input id="pin_nfc_rst" type="number" min="0" max="48" style="width:100%"/></label>
+                    <label style="font-size:0.85em">NSS/SS<input id="pin_nfc_nss" type="number" min="0" max="48" style="width:100%"/></label>
+                    <label style="font-size:0.85em">BUSY<input id="pin_nfc_busy" type="number" min="0" max="48" style="width:100%"/></label>
+                    <label style="font-size:0.85em">SCK<input id="pin_nfc_sck" type="number" min="0" max="48" style="width:100%"/></label>
+                    <label style="font-size:0.85em">MOSI<input id="pin_nfc_mosi" type="number" min="0" max="48" style="width:100%"/></label>
+                    <label style="font-size:0.85em">MISO<input id="pin_nfc_miso" type="number" min="0" max="48" style="width:100%"/></label>
+                  </div>
+                  <div class="hint" style="margin-top:6px">BUSY applies to PN5180 only; PN532 uses RST/NSS + SPI pins.</div>
+                </details>
+              </div>
               <div class="toggle-row">
                 <span id="keypad_enabled_label" class="toggle-label">3x4 Matrix Keypad</span>
                 <label class="toggle-switch">
@@ -333,6 +349,14 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
       document.getElementById('lcd_enabled').checked = !!cfg.lcd_enabled;
       document.getElementById('led_enabled').checked = !!cfg.led_enabled;
       if (cfg.led_pin !== undefined && cfg.led_pin !== '') document.getElementById('led_pin').value = cfg.led_pin;
+      ['rst','nss','busy','sck','mosi','miso'].forEach(function(p){
+        var el = document.getElementById('pin_nfc_' + p);
+        if (!el) return;
+        var v = cfg['pin_nfc_' + p];
+        if (v !== undefined && v !== '') el.value = v;
+        var d = cfg['pin_nfc_' + p + '_default'];
+        if (d !== undefined) el.placeholder = d;
+      });
       document.getElementById('keypad_enabled').checked = !!cfg.keypad_enabled;
       document.getElementById('tft_enabled').checked = !!cfg.tft_enabled;
       if (cfg.tft_driver) document.getElementById('tft_driver').value = cfg.tft_driver;
@@ -422,6 +446,12 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
         lcd_enabled: document.getElementById('lcd_enabled').checked ? 1 : 0,
         led_enabled: document.getElementById('led_enabled').checked ? 1 : 0,
         led_pin: document.getElementById('led_pin').value.trim(),
+        pin_nfc_rst: document.getElementById('pin_nfc_rst').value.trim(),
+        pin_nfc_nss: document.getElementById('pin_nfc_nss').value.trim(),
+        pin_nfc_busy: document.getElementById('pin_nfc_busy').value.trim(),
+        pin_nfc_sck: document.getElementById('pin_nfc_sck').value.trim(),
+        pin_nfc_mosi: document.getElementById('pin_nfc_mosi').value.trim(),
+        pin_nfc_miso: document.getElementById('pin_nfc_miso').value.trim(),
         keypad_enabled: document.getElementById('keypad_enabled').checked ? 1 : 0,
         tft_enabled: document.getElementById('tft_enabled').checked ? 1 : 0,
         tft_driver: document.getElementById('tft_driver').value,

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -42,6 +42,16 @@ static const char* NVS_KEY_U1_CHANNEL    = "u1_channel";
 static const char* NVS_KEY_U1_MODE       = "u1_mode";
 static const char* NVS_KEY_U1_AUTOPICK   = "u1_autopick";
 static const char* NVS_KEY_LED_PIN       = "led_pin";
+// NfcPinId order: rst, nss, busy, sck, mosi, miso
+static const char* NVS_KEYS_NFC_PIN[6] = {
+    "pin_nfc_rst", "pin_nfc_nss", "pin_nfc_busy",
+    "pin_nfc_sck", "pin_nfc_mosi", "pin_nfc_miso",
+};
+static const int16_t NFC_PIN_DEFAULTS[6] = {
+    PIN_PN5180_RST, PIN_PN5180_NSS, PIN_PN5180_BUSY,
+    PIN_PN5180_SCK, PIN_PN5180_MOSI, PIN_PN5180_MISO,
+};
+static const char* NFC_PIN_NAMES[6] = { "RST", "NSS", "BUSY", "SCK", "MOSI", "MISO" };
 
 // Sanitize hostname: enforce mDNS naming constraints (lowercase alphanum + hyphens,
 // no leading/trailing hyphens) and reject empty strings to avoid boot-time errors.
@@ -63,6 +73,36 @@ void sanitizeHostname(char* buf, size_t cap) {
     }
     strncpy(buf, out, cap - 1);
     buf[cap - 1] = '\0';
+}
+
+// Board-level GPIO validity — shared by every runtime pin override (#201,
+// #203). Blocklists are selected by the same BOARD_* flags as BoardPins.h.
+static bool boardPinUsable(uint8_t pin) {
+    bool valid;
+#if defined(BOARD_ESP32_C3)
+    // C3 exposes only GPIO 0-21; flash (12-17), USB-serial (18-19) and straps
+    // (2,8,9) are unusable, so validate against the known-good allowlist.
+    switch (pin) {
+        case 0: case 1: case 3: case 4: case 5: case 6: case 7:
+        case 10: case 20: case 21:
+            valid = true; break;
+        default:
+            valid = false; break;
+    }
+#elif defined(BOARD_ESP32_S3)
+    // S3: reject straps/USB-JTAG (0,3,19,20), SPI flash (26-32), straps (45,46).
+    valid = !(pin == 0 || pin == 3 || pin == 19 || pin == 20 ||
+              (pin >= 26 && pin <= 32) || pin == 45 || pin == 46 || pin > 48);
+  #if defined(BOARD_S3_DEVKITC)
+    // N16R8 octal PSRAM additionally claims GPIO 33-37.
+    if (pin >= 33 && pin <= 37) valid = false;
+  #endif
+#else
+    // ESP32 WROOM: reject straps (0,2,12,15), SPI flash (6-11), input-only (34-39).
+    valid = !(pin == 0 || pin == 2 || (pin >= 6 && pin <= 11) || pin == 12 ||
+              pin == 15 || (pin >= 34 && pin <= 39) || pin > 39);
+#endif
+    return valid;
 }
 
 // Reject GPIOs that can't safely drive the status LED on the CURRENT board and
@@ -90,32 +130,7 @@ static uint8_t sanitizeLedPin(uint8_t pin) {
         }
     }
 
-    bool valid;
-#if defined(BOARD_ESP32_C3)
-    // C3 exposes only GPIO 0-21; flash (12-17), USB-serial (18-19) and straps
-    // (2,8,9) are unusable, so validate against the known-good allowlist.
-    switch (pin) {
-        case 0: case 1: case 3: case 4: case 5: case 6: case 7:
-        case 10: case 20: case 21:
-            valid = true; break;
-        default:
-            valid = false; break;
-    }
-#elif defined(BOARD_ESP32_S3)
-    // S3: reject straps/USB-JTAG (0,3,19,20), SPI flash (26-32), straps (45,46).
-    valid = !(pin == 0 || pin == 3 || pin == 19 || pin == 20 ||
-              (pin >= 26 && pin <= 32) || pin == 45 || pin == 46 || pin > 48);
-  #if defined(BOARD_S3_DEVKITC)
-    // N16R8 octal PSRAM additionally claims GPIO 33-37.
-    if (pin >= 33 && pin <= 37) valid = false;
-  #endif
-#else
-    // ESP32 WROOM: reject straps (0,2,12,15), SPI flash (6-11), input-only (34-39).
-    valid = !(pin == 0 || pin == 2 || (pin >= 6 && pin <= 11) || pin == 12 ||
-              pin == 15 || (pin >= 34 && pin <= 39) || pin > 39);
-#endif
-
-    if (!valid) {
+    if (!boardPinUsable(pin)) {
         Serial.printf("ConfigurationManager: led_pin %u invalid for this board, using default GPIO %u\n",
                       (unsigned)pin, (unsigned)PIN_STATUS_LED);
         return LED_PIN_DEFAULT;
@@ -157,6 +172,76 @@ static uint8_t rejectFeaturePins(uint8_t pin, bool lcdOn, bool tftOn, bool keypa
         }
     }
     return pin;
+}
+
+// Validate an NFC pin override SET (#201). Per-pin: board-usable or revert to
+// sentinel. Then set-wide: the six EFFECTIVE pins (override-or-default) must
+// be distinct and must not collide with enabled-feature pins or the status
+// LED; any collision reverts the whole set — a half-applied remap is a wiring
+// short waiting to happen, and defaults are always safe.
+static void sanitizeNfcPinSet(uint8_t pins[6], bool lcdOn, bool tftOn, bool keypadOn,
+                              uint8_t effectiveLedPin) {
+    for (int i = 0; i < 6; i++) {
+        if (pins[i] == LED_PIN_DEFAULT) continue;
+        if (!boardPinUsable(pins[i])) {
+            Serial.printf("ConfigurationManager: NFC %s pin %u invalid for this board, using default\n",
+                          NFC_PIN_NAMES[i], (unsigned)pins[i]);
+            pins[i] = LED_PIN_DEFAULT;
+        }
+    }
+
+    int16_t effective[6];
+    for (int i = 0; i < 6; i++) {
+        effective[i] = (pins[i] == LED_PIN_DEFAULT) ? NFC_PIN_DEFAULTS[i] : (int16_t)pins[i];
+    }
+
+    bool conflict = false;
+    for (int i = 0; i < 6 && !conflict; i++) {
+        for (int j = i + 1; j < 6; j++) {
+            if (effective[i] >= 0 && effective[i] == effective[j]) {
+                Serial.printf("ConfigurationManager: NFC pin conflict — %s and %s both GPIO %d\n",
+                              NFC_PIN_NAMES[i], NFC_PIN_NAMES[j], (int)effective[i]);
+                conflict = true;
+                break;
+            }
+        }
+    }
+
+    struct OtherPin { int16_t pin; bool active; const char* what; };
+    const OtherPin others[] = {
+        { PIN_LCD_SDA,     lcdOn,    "LCD" },
+        { PIN_LCD_SCL,     lcdOn,    "LCD" },
+        { PIN_TFT_MOSI,    tftOn,    "TFT" },
+        { PIN_TFT_SCLK,    tftOn,    "TFT" },
+        { PIN_TFT_CS,      tftOn,    "TFT" },
+        { PIN_TFT_DC,      tftOn,    "TFT" },
+        { PIN_TFT_RST,     tftOn,    "TFT" },
+        { PIN_TFT_BL,      tftOn,    "TFT" },
+        { PIN_KEYPAD_ROW1, keypadOn, "keypad" },
+        { PIN_KEYPAD_ROW2, keypadOn, "keypad" },
+        { PIN_KEYPAD_ROW3, keypadOn, "keypad" },
+        { PIN_KEYPAD_ROW4, keypadOn, "keypad" },
+        { PIN_KEYPAD_COL1, keypadOn, "keypad" },
+        { PIN_KEYPAD_COL2, keypadOn, "keypad" },
+        { PIN_KEYPAD_COL3, keypadOn, "keypad" },
+        { (int16_t)effectiveLedPin, true, "status LED" },
+    };
+    for (int i = 0; i < 6 && !conflict; i++) {
+        if (pins[i] == LED_PIN_DEFAULT) continue;  // defaults pre-date the features; only police overrides
+        for (const auto& o : others) {
+            if (o.active && o.pin >= 0 && effective[i] == o.pin) {
+                Serial.printf("ConfigurationManager: NFC %s pin %d is in use by the enabled %s\n",
+                              NFC_PIN_NAMES[i], (int)effective[i], o.what);
+                conflict = true;
+                break;
+            }
+        }
+    }
+
+    if (conflict) {
+        Serial.println("ConfigurationManager: reverting ALL NFC pin overrides to board defaults");
+        for (int i = 0; i < 6; i++) pins[i] = LED_PIN_DEFAULT;
+    }
 }
 
 ConfigurationManager& ConfigurationManager::getInstance() {
@@ -381,6 +466,20 @@ bool ConfigurationManager::loadFromNVS() {
         anyOverride = true;
     }
 
+    {
+        bool anyNfcPin = false;
+        for (int i = 0; i < 6; i++) {
+            if (prefs.isKey(NVS_KEYS_NFC_PIN[i])) {
+                _nfcPins[i] = prefs.getUChar(NVS_KEYS_NFC_PIN[i], LED_PIN_DEFAULT);
+                anyNfcPin = true;
+            }
+        }
+        if (anyNfcPin) {
+            sanitizeNfcPinSet(_nfcPins, _lcdEnabled, _tftEnabled, _keypadEnabled, getLedPin());
+            anyOverride = true;
+        }
+    }
+
     prefs.end();
     return anyOverride;
 }
@@ -510,6 +609,13 @@ uint8_t ConfigurationManager::getLedPin() const {
     return (_ledPin == LED_PIN_DEFAULT) ? PIN_STATUS_LED : _ledPin;
 }
 
+uint8_t ConfigurationManager::getNfcPin(NfcPinId id) const {
+    uint8_t i = (uint8_t)id;
+    if (i >= 6) return 0;
+    if (_nfcPins[i] != LED_PIN_DEFAULT) return _nfcPins[i];
+    return (uint8_t)NFC_PIN_DEFAULTS[i];
+}
+
 void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     memset(&out, 0, sizeof(out));
     strncpy(out.wifi_ssid, _ssid, sizeof(out.wifi_ssid) - 1);
@@ -540,6 +646,7 @@ void ConfigurationManager::getCurrentConfig(ConfigUpdate& out) const {
     out.u1_mode = _u1Mode;
     out.u1_auto_pick = _u1AutoPick ? 1 : 0;
     out.led_pin = _ledPin;
+    memcpy(out.nfc_pins, _nfcPins, sizeof(out.nfc_pins));
 }
 
 #ifndef NATIVE_TEST
@@ -589,11 +696,23 @@ bool ConfigurationManager::saveToNVS(const ConfigUpdate& update) {
     prefs.putUChar(NVS_KEY_U1_CHANNEL, (update.u1_channel <= 3) ? update.u1_channel : 0);
     prefs.putUChar(NVS_KEY_U1_MODE, (update.u1_mode <= 1) ? update.u1_mode : 0);
     prefs.putBool(NVS_KEY_U1_AUTOPICK, update.u1_auto_pick != 0);
+    uint8_t savedLedPin;
     {
         uint8_t ledPin = sanitizeLedPin(update.led_pin);
         ledPin = rejectFeaturePins(ledPin, update.lcd_enabled != 0,
                                    update.tft_enabled != 0, update.keypad_enabled != 0);
         prefs.putUChar(NVS_KEY_LED_PIN, ledPin);
+        savedLedPin = ledPin;
+    }
+    {
+        uint8_t pins[6];
+        memcpy(pins, update.nfc_pins, sizeof(pins));
+        uint8_t effLed = (savedLedPin == LED_PIN_DEFAULT) ? PIN_STATUS_LED : savedLedPin;
+        sanitizeNfcPinSet(pins, update.lcd_enabled != 0, update.tft_enabled != 0,
+                          update.keypad_enabled != 0, effLed);
+        for (int i = 0; i < 6; i++) {
+            prefs.putUChar(NVS_KEYS_NFC_PIN[i], pins[i]);
+        }
     }
 
     // Invalidate Spoolman enrichment cache on config change to force re-fetch

--- a/src/ConfigurationManager.h
+++ b/src/ConfigurationManager.h
@@ -13,6 +13,11 @@ void sanitizeHostname(char* buf, size_t cap);
 #endif
 #define DEVICE_VERSION FIRMWARE_VERSION
 
+// Runtime-configurable NFC reader pins (#201). Index order is fixed — NVS
+// keys, config API fields, and the UI all follow it. PN532 uses the same six
+// slots (SS=NSS; no BUSY — that slot is simply unused by the PN532 driver).
+enum class NfcPinId : uint8_t { Rst = 0, Nss, Busy, Sck, Mosi, Miso, Count };
+
 // led_pin sentinel: absent in NVS or 0xFF means "use the board default"
 // (PIN_STATUS_LED). Any other value is a user GPIO override. (#203)
 static constexpr uint8_t LED_PIN_DEFAULT = 0xFF;
@@ -51,6 +56,7 @@ struct ConfigUpdate {
     uint8_t u1_mode;          // 0 = fixed channel, 1 = stage (pick channel after each scan)
     uint8_t u1_auto_pick;     // stage mode: 1 = assign to the first lane that loads (default on)
     uint8_t led_pin;          // status LED GPIO override; LED_PIN_DEFAULT = board default (#203)
+    uint8_t nfc_pins[6];      // NFC reader pin overrides (NfcPinId order); 0xFF = board default (#201)
 };
 
 class ConfigurationManager {
@@ -97,6 +103,10 @@ public:
 
     // Effective status-LED GPIO: user override when set and valid, else PIN_STATUS_LED (#203)
     uint8_t getLedPin() const;
+    // Effective NFC reader pin: NVS override when set and valid, else the
+    // board default from BoardPins.h. Consumers read these once at begin();
+    // changes apply on the post-save reboot. (#201)
+    uint8_t getNfcPin(NfcPinId id) const;
 
     // Low-spool threshold (grams) — LED breathes when remaining weight is at or below this
     uint16_t getLowSpoolThreshold() const;
@@ -173,6 +183,8 @@ private:
     bool _u1AutoPick = true;  // stage mode: motion-sensor auto-assign
 
     uint8_t _ledPin = LED_PIN_DEFAULT;  // 0xFF = use board default (PIN_STATUS_LED)
+    uint8_t _nfcPins[6] = { LED_PIN_DEFAULT, LED_PIN_DEFAULT, LED_PIN_DEFAULT,
+                            LED_PIN_DEFAULT, LED_PIN_DEFAULT, LED_PIN_DEFAULT };
 
     bool _initialized = false;
 };

--- a/src/HardwareNFCConnection.cpp
+++ b/src/HardwareNFCConnection.cpp
@@ -1,4 +1,5 @@
 #include "HardwareNFCConnection.h"
+#include "ConfigurationManager.h"
 #include <Arduino.h>
 #include <cstring>
 #include <esp_task_wdt.h>
@@ -88,29 +89,40 @@ bool HardwareNFCConnection::begin() {
     pinMode(PIN_PN5180_GPIO, INPUT);   // Card detection (unused, manual polling via getInventory)
     pinMode(PIN_PN5180_AUX, INPUT);    // Auxiliary/monitoring (unused)
 
-    nfc_ = new PN5180ISO15693(PIN_PN5180_NSS, PIN_PN5180_BUSY, PIN_PN5180_RST,
-                               PIN_PN5180_SCK, PIN_PN5180_MISO, PIN_PN5180_MOSI);
-    iso14443a_ = new PN5180ISO14443(PIN_PN5180_NSS, PIN_PN5180_BUSY, PIN_PN5180_RST,
-                                    PIN_PN5180_SCK, PIN_PN5180_MISO, PIN_PN5180_MOSI);
+    // Runtime pin overrides (#201): board defaults unless remapped in config
+    {
+        auto& cfg = ConfigurationManager::getInstance();
+        pinRst_  = cfg.getNfcPin(NfcPinId::Rst);
+        pinNss_  = cfg.getNfcPin(NfcPinId::Nss);
+        pinBusy_ = cfg.getNfcPin(NfcPinId::Busy);
+        pinSck_  = cfg.getNfcPin(NfcPinId::Sck);
+        pinMosi_ = cfg.getNfcPin(NfcPinId::Mosi);
+        pinMiso_ = cfg.getNfcPin(NfcPinId::Miso);
+    }
+
+    nfc_ = new PN5180ISO15693(pinNss_, pinBusy_, pinRst_,
+                               pinSck_, pinMiso_, pinMosi_);
+    iso14443a_ = new PN5180ISO14443(pinNss_, pinBusy_, pinRst_,
+                                    pinSck_, pinMiso_, pinMosi_);
 
     Serial.println("HardwareNFCConnection: Starting PN5180...");
     Serial.printf("HardwareNFCConnection: Pins — NSS=%d BUSY=%d RST=%d SCK=%d MISO=%d MOSI=%d\n",
-                  PIN_PN5180_NSS, PIN_PN5180_BUSY, PIN_PN5180_RST,
-                  PIN_PN5180_SCK, PIN_PN5180_MISO, PIN_PN5180_MOSI);
+                  pinNss_, pinBusy_, pinRst_,
+                  pinSck_, pinMiso_, pinMosi_);
     nfc_->begin();
     iso14443a_->begin();
     Serial.println("HardwareNFCConnection: SPI begin done, resetting...");
-    Serial.printf("HardwareNFCConnection: BUSY pin=%d before reset\n", digitalRead(PIN_PN5180_BUSY));
+    Serial.printf("HardwareNFCConnection: BUSY pin=%d before reset\n", digitalRead(pinBusy_));
 
     // Manual reset with timeout: PN5180::reset() library call has no timeout, blocking on hung chips
-    digitalWrite(PIN_PN5180_RST, LOW);
+    digitalWrite(pinRst_, LOW);
     delay(10);
-    digitalWrite(PIN_PN5180_RST, HIGH);
+    digitalWrite(pinRst_, HIGH);
     Serial.println("HardwareNFCConnection: RST pin released, waiting for boot...");
 
     // BUSY signal indicates RF subsystem boot state; timeout detects dead/unreliable chips
     unsigned long start = millis();
-    while (digitalRead(PIN_PN5180_BUSY) == HIGH) {
+    while (digitalRead(pinBusy_) == HIGH) {
         if (millis() - start > 2000) {
             Serial.println("HardwareNFCConnection: TIMEOUT waiting for BUSY LOW after reset!");
             break;
@@ -174,14 +186,14 @@ bool HardwareNFCConnection::hardwareReset() {
     Serial.println("HardwareNFC: hardwareReset() - toggling RST pin");
 
     // Toggle RST pin to force full hardware reset
-    digitalWrite(PIN_PN5180_RST, LOW);
+    digitalWrite(pinRst_, LOW);
     delay(10);
-    digitalWrite(PIN_PN5180_RST, HIGH);
+    digitalWrite(pinRst_, HIGH);
     PN5180::clearBusWedged();  // fresh chip — release the fail-fast latch
 
     // Wait for BUSY to go LOW with timeout
     unsigned long start = millis();
-    while (digitalRead(PIN_PN5180_BUSY) == HIGH) {
+    while (digitalRead(pinBusy_) == HIGH) {
         if (millis() - start > 2000) {
             Serial.println("HardwareNFC: hardwareReset TIMEOUT waiting for BUSY LOW");
             return false;

--- a/src/HardwareNFCConnection.h
+++ b/src/HardwareNFCConnection.h
@@ -36,6 +36,10 @@ public:
     bool isPN5180Ready() const { return pn5180Ready_; }
 
 private:
+    // Effective NFC pins, captured once from ConfigurationManager at begin()
+    // — runtime overrides (#201) apply on the post-save reboot
+    uint8_t pinRst_ = 0, pinNss_ = 0, pinBusy_ = 0;
+    uint8_t pinSck_ = 0, pinMosi_ = 0, pinMiso_ = 0;
     PN5180ISO15693* nfc_ = nullptr;
     PN5180ISO14443* iso14443a_ = nullptr;
     opt_nfc_hal_t hal_;

--- a/src/HardwareNFCConnectionPN532.cpp
+++ b/src/HardwareNFCConnectionPN532.cpp
@@ -1,4 +1,5 @@
 #include "HardwareNFCConnectionPN532.h"
+#include "ConfigurationManager.h"
 #include "openprinttag_adafruit_pn532.h"
 #include "BoardPins.h"
 
@@ -21,9 +22,18 @@ HardwareNFCConnectionPN532::~HardwareNFCConnectionPN532() {
 
 bool HardwareNFCConnectionPN532::begin() {
     // PN532 uses separate SPI bus; explicit pin mapping prevents conflicts with PN5180 on HSPI
-    SPI.begin(PIN_PN532_SCK, PIN_PN532_MISO, PIN_PN532_MOSI, PIN_PN532_SS);
+    // Runtime pin overrides (#201): PN532 shares the NFC pin slots (SS=NSS; BUSY unused)
+    {
+        auto& cfg = ConfigurationManager::getInstance();
+        pinRst_ = cfg.getNfcPin(NfcPinId::Rst);
+        pinSs_  = cfg.getNfcPin(NfcPinId::Nss);
+        pinSck_ = cfg.getNfcPin(NfcPinId::Sck);
+        pinMosi_ = cfg.getNfcPin(NfcPinId::Mosi);
+        pinMiso_ = cfg.getNfcPin(NfcPinId::Miso);
+    }
+    SPI.begin(pinSck_, pinMiso_, pinMosi_, pinSs_);
 
-    pn532_ = new Adafruit_PN532(PIN_PN532_SS, &SPI);
+    pn532_ = new Adafruit_PN532(pinSs_, &SPI);
     if (!pn532_) {
         Serial.println("PN532: Failed to allocate");
         return false;
@@ -74,10 +84,10 @@ void HardwareNFCConnectionPN532::reset() {
 
 bool HardwareNFCConnectionPN532::hardwareReset() {
     // Toggle RST pin for hardware reset: forces state machine reboot
-    pinMode(PIN_PN532_RST, OUTPUT);
-    digitalWrite(PIN_PN532_RST, LOW);
+    pinMode(pinRst_, OUTPUT);
+    digitalWrite(pinRst_, LOW);
     delay(10);
-    digitalWrite(PIN_PN532_RST, HIGH);
+    digitalWrite(pinRst_, HIGH);
     delay(50);  // PN532 boot time before first SPI command
 
     if (pn532_) {

--- a/src/HardwareNFCConnectionPN532.h
+++ b/src/HardwareNFCConnectionPN532.h
@@ -32,6 +32,8 @@ public:
     void logDiagnostics() override;
 
 private:
+    // Effective NFC pins from ConfigurationManager (#201); BUSY slot unused on PN532
+    uint8_t pinRst_ = 0, pinSs_ = 0, pinSck_ = 0, pinMosi_ = 0, pinMiso_ = 0;
     Adafruit_PN532* pn532_ = nullptr;
     opt_nfc_hal_t hal_;
     uint8_t currentUid_[10];

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -810,6 +810,20 @@ void WebServerManager::handleApiGetConfig() {
     }
     doc["tft_enabled"] = cfg.tft_enabled;
     doc["tft_driver"] = cfg.tft_driver;
+    {
+        // NFC pin overrides (#201): "" = board default; *_default carries the
+        // effective default so the page can show it as the placeholder
+        static const char* keys[6] = {"pin_nfc_rst","pin_nfc_nss","pin_nfc_busy",
+                                      "pin_nfc_sck","pin_nfc_mosi","pin_nfc_miso"};
+        auto& cm = ConfigurationManager::getInstance();
+        for (int i = 0; i < 6; i++) {
+            char defKey[24];
+            snprintf(defKey, sizeof(defKey), "%s_default", keys[i]);
+            if (cfg.nfc_pins[i] == LED_PIN_DEFAULT) doc[keys[i]] = "";
+            else doc[keys[i]] = cfg.nfc_pins[i];
+            doc[defKey] = cm.getNfcPin((NfcPinId)i);
+        }
+    }
     doc["ap_mode"] = _apMode;
     if (_apMode) {
         extern char g_apSSID[];
@@ -887,6 +901,22 @@ void WebServerManager::handleApiPostConfig() {
             long p = strtol(ledPinStr, &end, 10);
             bool numeric = (end != ledPinStr) && (*end == '\0');
             update.led_pin = (numeric && p >= 0 && p <= 254) ? (uint8_t)p : LED_PIN_DEFAULT;
+        }
+    }
+    {
+        // NFC pin overrides (#201): same string convention as led_pin
+        static const char* keys[6] = {"pin_nfc_rst","pin_nfc_nss","pin_nfc_busy",
+                                      "pin_nfc_sck","pin_nfc_mosi","pin_nfc_miso"};
+        for (int i = 0; i < 6; i++) {
+            const char* s = doc[keys[i]] | "";
+            if (s[0] == '\0') {
+                update.nfc_pins[i] = LED_PIN_DEFAULT;
+                continue;
+            }
+            char* end = nullptr;
+            long p = strtol(s, &end, 10);
+            bool numeric = (end != s) && (*end == '\0');
+            update.nfc_pins[i] = (numeric && p >= 0 && p <= 254) ? (uint8_t)p : LED_PIN_DEFAULT;
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #201 (and covers the pin-map half of #197). Generalizes the `led_pin` machinery (#203) to the reader's six pins — **RST, NSS/SS, BUSY, SCK, MOSI, MISO** — configurable from a new "NFC Reader Pins (advanced)" section on the config page. One set covers both readers (PN532 aliases the PN5180 defaults on every board; its BUSY slot is simply unused). Boards with shuffled pinouts — the C3-OLED SuperMini sibling from #197, hand-wired builds, future variants — no longer need a custom firmware build.

**Safety model (the part that matters):** overrides are validated at the NVS boundary on both load and save. Per-pin board validity (strap/flash/input-only/PSRAM rules, factored into a shared `boardPinUsable()`) reverts an invalid pin individually; then the six *effective* pins (override-or-default) are checked as a set — duplicates, collisions with enabled feature pins (LCD/TFT/keypad), or the status LED revert **the entire set** with a serial warning, because a half-applied remap is a wiring short waiting to happen and board defaults are always safe. Changes apply on the config page's existing save-and-restart cycle.

Config API follows the `led_pin` convention (string fields, empty = default, strict-numeric parse) and additionally publishes each pin's board default so the page shows real per-board placeholders.

Known conservative edge: the LED validator still blocklists the *compile-time* NFC defaults, so after remapping the reader away from a default pin, that pin remains rejected for the LED — over-restrictive in the safe direction.

## Stacked

Based on #246 (the release batch); retarget to `dev` after #246 merges.

## Testing

All four environments build; native tests 21/21. Codex review: no findings (load ordering, consumer coverage, duplicate detection, ConfigUpdate copies all verified). Bench pass wanted: remap NSS/RST to adjacent free pins on the bench board, physically rewire, confirm scanning; then set a deliberately-conflicting pair and confirm the loud revert-to-defaults path.