### PR TITLE
bump: v1.8.3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ extra_scripts = pre:scripts/gen_gzip_assets.py
 monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
-	-DFIRMWARE_VERSION=\"1.8.2\"
+	-DFIRMWARE_VERSION=\"1.8.3\"
 ; Exact pins (#216): caret ranges let fresh checkouts resolve newer libraries
 ; than tested builds — same commit, different binary. Bump pins deliberately,
 ; in their own commit, with all four envs built.


### PR DESCRIPTION
Version bump for the 1.8.3 release: #239 NDEF bounds hardening, #201 runtime NFC pins, #180 ILI9341/ILI9488, #227 sha256 sidecars, #225 bench runner, #111 block-read check, gzip web UI, #253 self-test wizard.