### PR TITLE
Release v1.9.1 — correctness and responsiveness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.9.1] - 2026-08-01
+
+Correctness and responsiveness fixes from a full code review. No configuration
+changes; upgrade over OTA as usual.
+
+### Fixed
+
+- **TigerTag tags with newer version IDs were misread as plain UID tags** — the forward-compatibility fallback compared the diameter byte against the type constants, so any tag whose version ID was not yet in the public database fell through to generic-UID handling instead of being parsed. (#256)
+- **A partly-read Bambu tag could publish invented values** — an authentication failure mid-read left that block uninitialized and the parser consumed it anyway, so marginal coupling could report a random color, weight, diameter, or nozzle/bed temperature to Spoolman and the printer. Reads that miss an identity or print-critical block are now discarded, and a zeroed identity block is no longer published as a spool. (#257)
+- **Recent-spool history never updated, and every scan paid 50 ms for it** — the history helper tried to take a lock its callers already held, which cannot succeed on a non-recursive mutex, so each scan and write waited out the full timeout and then skipped the update. Scans get that time back. (#258)
+- **OpenSpool writes were not bound to the scanned tag** — unlike the other formats, the handler did not record which tag the write was for, so a tag swapped in after detection could receive the payload. (#259)
+- **Opening the troubleshooting page could stall the scanner** — its diagnostics request ran a live Spoolman check outside the lock that serializes outbound HTTP, colliding with a sync or printer poll in progress. The check is now serialized, with a short budget: when the connection is busy the page reports that instead of falsely claiming Spoolman is unreachable. (#262)
+- **Build warning on every target** — the PN5180 library defined `FIRMWARE_VERSION` as an EEPROM address, colliding with the firmware version string and burying real warnings. (#263)
+
 ## [1.9.0] - 2026-07-17
 
 ### Upgrade notes — read before updating

--- a/lib/PN5180/PN5180.h
+++ b/lib/PN5180/PN5180.h
@@ -42,17 +42,16 @@
 #define EMD_CONTROL         (0x28)
 #define ANT_CONTROL         (0x29)
 
-// PN5180 EEPROM Addresses
-#define DIE_IDENTIFIER      (0x00)
-#define PRODUCT_VERSION     (0x10)
-#define FIRMWARE_VERSION    (0x12)
-#define EEPROM_VERSION      (0x14)
-#define IRQ_PIN_CONFIG      (0x1A)
-
-// Aliases for compatibility
-#define PN5180_FIRMWARE_VERSION FIRMWARE_VERSION
-#define PN5180_PRODUCT_VERSION  PRODUCT_VERSION
-#define PN5180_EEPROM_VERSION   EEPROM_VERSION
+// PN5180 EEPROM Addresses.
+// Prefixed: the unprefixed FIRMWARE_VERSION collided with the application's
+// release-string macro (-DFIRMWARE_VERSION="x.y.z"), warning on every build and
+// leaving whichever definition won to include order. Any use of the app macro
+// after this header would silently have compiled as the EEPROM address 0x12.
+#define DIE_IDENTIFIER          (0x00)
+#define PN5180_PRODUCT_VERSION  (0x10)
+#define PN5180_FIRMWARE_VERSION (0x12)
+#define PN5180_EEPROM_VERSION   (0x14)
+#define IRQ_PIN_CONFIG          (0x1A)
 
 enum PN5180TransceiveStat {
   PN5180_TS_Idle = 0,

--- a/lib/bambutag/BambuTagParser.cpp
+++ b/lib/bambutag/BambuTagParser.cpp
@@ -61,5 +61,21 @@ bool parseBambuBlocks(const uint8_t blocks[][16], BambuTagData& out) {
 
     out.valid = (out.filament_type[0] != '\0');
 
+    // Report validity: an all-zero or corrupt identity block must not be
+    // published as a spool (it would fall back to a default material).
+    return out.valid;
+}
+
+bool bambuIsEssentialIndex(uint8_t idx) {
+    for (uint8_t i = 0; i < BAMBU_ESSENTIAL_COUNT; i++) {
+        if (BAMBU_ESSENTIAL_INDEXES[i] == idx) return true;
+    }
+    return false;
+}
+
+bool bambuEssentialBlocksPresent(const bool blockOk[]) {
+    for (uint8_t i = 0; i < BAMBU_ESSENTIAL_COUNT; i++) {
+        if (!blockOk[BAMBU_ESSENTIAL_INDEXES[i]]) return false;
+    }
     return true;
 }

--- a/lib/bambutag/BambuTagParser.h
+++ b/lib/bambutag/BambuTagParser.h
@@ -21,4 +21,22 @@ struct BambuTagData {
 static constexpr uint8_t BAMBU_BLOCKS[] = { 1, 2, 4, 5, 6, 13, 14, 16 };
 static constexpr uint8_t BAMBU_BLOCK_COUNT = 8;
 
+// Indexes into BAMBU_BLOCKS whose contents identify the filament or feed the
+// printer: block 1 material variant, block 2 filament type, block 5 colour /
+// weight / diameter, block 6 drying and nozzle/bed temperatures. A read that
+// misses any of these must be discarded rather than parsed — the rest
+// (block 4 unparsed, 13 date, 14 length, 16 extended colour) may be absent.
+static constexpr uint8_t BAMBU_ESSENTIAL_INDEXES[] = { 0, 1, 3, 4 };
+static constexpr uint8_t BAMBU_ESSENTIAL_COUNT = 4;
+
+
+// Parses the eight blocks into `out`. Returns out.valid — false when the
+// identity block is empty, so a zeroed/corrupt read is never published.
 bool parseBambuBlocks(const uint8_t blocks[][16], BambuTagData& out);
+
+// True when the block at this index into BAMBU_BLOCKS is essential.
+bool bambuIsEssentialIndex(uint8_t idx);
+
+// True when every essential block was read successfully. `blockOk` is indexed
+// like BAMBU_BLOCKS and must have BAMBU_BLOCK_COUNT entries.
+bool bambuEssentialBlocksPresent(const bool blockOk[]);

--- a/lib/tigertag/TigerTagParser.cpp
+++ b/lib/tigertag/TigerTagParser.cpp
@@ -166,9 +166,10 @@ bool tigerTagCheckMagic(const uint8_t* data, uint16_t dataLen) {
     }
 
     // Permissive mode: unknown version ID but layout looks like TigerTag.
-    // Check Type field (byte 13) = Filament or Resin, and Material (bytes 8-9) is non-zero.
+    // Check Type field (byte 12) = Filament or Resin, and Material (bytes 8-9) is non-zero.
     // TigerTag's docs/app may produce version IDs not yet in the public database.
-    uint8_t typeField = data[13];
+    // Byte 12 is the type field; byte 13 is diameter (see the layout map below).
+    uint8_t typeField = data[12];
     uint16_t materialId = (data[8] << 8) | data[9];
     if ((typeField == TIGERTAG_TYPE_FILAMENT || typeField == TIGERTAG_TYPE_RESIN) && materialId != 0) {
         return true;

--- a/lib/tigertag/TigerTagParser.h
+++ b/lib/tigertag/TigerTagParser.h
@@ -10,7 +10,7 @@
 #define TIGERTAG_INIT_V10       0x6C2B2DF1  // TigerTag Init V1.0
 #define TIGERTAG_PLUS_V10       0xBC0A5927  // TigerTag+ V1.0
 
-// Type field values (byte 13 in TigerTag layout)
+// Type field values (byte 12 in TigerTag layout; byte 13 is diameter)
 #define TIGERTAG_TYPE_FILAMENT  0x8E
 #define TIGERTAG_TYPE_RESIN     0xAD
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ extra_scripts = pre:scripts/gen_gzip_assets.py
 monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
-	-DFIRMWARE_VERSION=\"1.9.0\"
+	-DFIRMWARE_VERSION=\"1.9.1\"
 ; Exact pins (#216): caret ranges let fresh checkouts resolve newer libraries
 ; than tested builds — same commit, different binary. Bump pins deliberately,
 ; in their own commit, with all four envs built.

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -805,7 +805,7 @@ bool NFCManager::readAndParseTag(uint8_t* uid, uint8_t uid_length) {
     currentSpool.present = true;
     currentSpool.tag_data_valid = true;
 
-    addToRecentSpools();
+    addToRecentSpoolsLocked();
 
     Serial.printf("NFCManager: Parsed spool %s\n", currentSpool.spool_id);
 
@@ -913,7 +913,7 @@ bool NFCManager::formatNewSpool() {
                 currentSpool.tag_data_valid = true;
                 currentSpool.blank_tag_present = false;
                 currentSpool.kind = TagKind::OpenPrintTag;
-                addToRecentSpools();
+                addToRecentSpoolsLocked();
 
                 // Check if write queue is empty (no batched writes pending)
                 NFCWriteRequest dummyReq;
@@ -957,7 +957,7 @@ bool NFCManager::formatNewSpool() {
     currentSpool.tag_data_valid = true;
     currentSpool.blank_tag_present = false;
     currentSpool.kind = TagKind::OpenPrintTag;
-    addToRecentSpools();
+    addToRecentSpoolsLocked();
 
     // Check if write queue is empty (no batched writes pending)
     NFCWriteRequest dummyReq2;
@@ -1704,7 +1704,7 @@ bool NFCManager::writeRawTag() {
                 currentSpool.blank_tag_present = false;
                 currentSpool.kind = TagKind::OpenPrintTag;
                 lastSeenValid = false;  // Force re-detection on next scan
-                addToRecentSpools();
+                addToRecentSpoolsLocked();
                 sendOpenPrintTagMessage();
                 xSemaphoreGive(tagMutex);
 
@@ -1737,7 +1737,7 @@ bool NFCManager::writeRawTag() {
     currentSpool.blank_tag_present = false;
     currentSpool.kind = TagKind::OpenPrintTag;
     lastSeenValid = false;
-    addToRecentSpools();
+    addToRecentSpoolsLocked();
     sendOpenPrintTagMessage();
     xSemaphoreGive(tagMutex);
 
@@ -2197,7 +2197,7 @@ bool NFCManager::executeAtomicWrite(const NFCWriteRequest& request) {
     currentSpool.tag_data_valid = true;
     currentSpool.blank_tag_present = false;
     currentSpool.kind = TagKind::OpenPrintTag;
-    addToRecentSpools();
+    addToRecentSpoolsLocked();
     sendOpenPrintTagMessage();
     xSemaphoreGive(tagMutex);
 
@@ -2304,7 +2304,7 @@ bool NFCManager::executeWrite(const NFCWriteRequest& request) {
                 currentSpool.blank_tag_present = false;
                 currentSpool.kind = TagKind::OpenPrintTag;
                 lastSeenValid = false;
-                addToRecentSpools();
+                addToRecentSpoolsLocked();
                 sendOpenPrintTagMessage();
                 xSemaphoreGive(tagMutex);
                 return true;
@@ -2490,14 +2490,14 @@ void NFCManager::requestCurrentSpool() {
     }
 }
 
-void NFCManager::addToRecentSpools() {
-    if (tagMutex == nullptr) return;
-    if (xSemaphoreTake(tagMutex, pdMS_TO_TICKS(50)) != pdTRUE) return;
-
-    if (!currentSpool.tag_data_valid) {
-        xSemaphoreGive(tagMutex);
-        return;
-    }
+// Caller must hold tagMutex. FreeRTOS mutexes are not recursive and every
+// call site already holds it around the currentSpool update this reads, so
+// taking it here only ever timed out — the history silently stopped updating
+// and each scan paid the timeout. Running under the caller's lock also closes
+// the race against getRecentSpools(), which reads the array under the mutex
+// while the tail of this function used to rewrite it unlocked.
+void NFCManager::addToRecentSpoolsLocked() {
+    if (!currentSpool.tag_data_valid) return;
 
     // Check if this spool already exists in recent list
     int existingIndex = -1;
@@ -2532,8 +2532,6 @@ void NFCManager::addToRecentSpools() {
     int32_t smId = -1;
     opt_get_gp_spoolman_id(&currentSpool.tag_data, &smId);
     newEntry.spoolman_id = smId;
-
-    xSemaphoreGive(tagMutex);
 
     if (existingIndex >= 0) {
         // Spool exists - shift entries to remove it from current position

--- a/src/NFCManager.cpp
+++ b/src/NFCManager.cpp
@@ -2682,32 +2682,62 @@ bool NFCManager::isWriteQueueEmpty() const {
 
 bool NFCManager::readBambuTag(const uint8_t* uid, uint8_t uidLength, BambuTagData& out) {
     BambuKeys keys = deriveBambuKeys(uid, uidLength);
-    uint8_t blocks[BAMBU_BLOCK_COUNT][16];
+    // Zero-initialized: a block that never reads must not reach the parser as
+    // stack garbage (it would publish random colour/weight/temperature).
+    uint8_t blocks[BAMBU_BLOCK_COUNT][16] = {};
+    bool blockOk[BAMBU_BLOCK_COUNT] = {};
     uint8_t lastAuthSector = 0xFF;
 
     for (uint8_t i = 0; i < BAMBU_BLOCK_COUNT; i++) {
         uint8_t blockNo = BAMBU_BLOCKS[i];
         uint8_t sector = blockNo / 4;
+        bool failed = false;
 
         if (sector != lastAuthSector) {
             if (!connection_->mifareAuthenticate(blockNo, 0x60, keys.blockKey(blockNo))) {
                 Serial.printf("NFCManager: Bambu auth failed on block %d (sector %d)\n", blockNo, sector);
                 LogBuffer::getInstance().logPrintf("Bambu auth fail blk %d sec %d\n", blockNo, sector);
-                if (i == 0) return false;
-                continue;
+                failed = true;
+            } else {
+                lastAuthSector = sector;
             }
-            lastAuthSector = sector;
         }
 
-        if (!connection_->mifareClassicRead(blockNo, blocks[i])) {
-            Serial.printf("NFCManager: Bambu block read failed on block %d\n", blockNo);
-            memset(blocks[i], 0, 16);
-        } else {
-            Serial.printf("NFCManager: Bambu block %d: ", blockNo);
-            for (int b = 0; b < 16; b++) Serial.printf("%02X ", blocks[i][b]);
-            Serial.println();
+        if (!failed) {
+            if (!connection_->mifareClassicRead(blockNo, blocks[i])) {
+                Serial.printf("NFCManager: Bambu block read failed on block %d\n", blockNo);
+                memset(blocks[i], 0, 16);
+                failed = true;
+            } else {
+                blockOk[i] = true;
+                Serial.printf("NFCManager: Bambu block %d: ", blockNo);
+                for (int b = 0; b < 16; b++) Serial.printf("%02X ", blocks[i][b]);
+                Serial.println();
+            }
+        }
+
+        // Blocks carrying identity and print-critical values must all be
+        // present: a partial read would publish a plausible-looking spool with
+        // the wrong colour, weight, or nozzle/bed temperatures — worse than no
+        // read at all. Stop at the first essential failure instead of working
+        // through the rest; on a shared SPI bus each further attempt can block
+        // for the bus-guard timeout, and the whole read is discarded anyway.
+        // The remaining blocks (4 unparsed, 13 date, 14 length, 16 extended
+        // colour) degrade to zeros without misrepresenting the filament.
+        if (failed) {
+            if (bambuIsEssentialIndex(i)) {
+                Serial.printf("NFCManager: Bambu essential block %d missing, discarding read\n", blockNo);
+                LogBuffer::getInstance().logPrintf("Bambu incomplete read blk %d\n", blockNo);
+                return false;
+            }
+            // Optional block: everything required is already in hand, so stop
+            // rather than spend more time on a tag that is clearly struggling.
+            Serial.printf("NFCManager: Bambu optional block %d missing, using partial data\n", blockNo);
+            break;
         }
     }
 
-    return parseBambuBlocks(blocks, out);
+    // parseBambuBlocks reports validity: a zeroed identity block is never
+    // published as a spool.
+    return bambuEssentialBlocksPresent(blockOk) && parseBambuBlocks(blocks, out);
 }

--- a/src/NFCManager.h
+++ b/src/NFCManager.h
@@ -189,7 +189,7 @@ private:
     // Recent spools history (RAM only, most recent first)
     RecentSpoolEntry recentSpools[MAX_RECENT_SPOOLS];
     size_t recentSpoolsCount = 0;
-    void addToRecentSpools();
+    void addToRecentSpoolsLocked();  // caller must hold tagMutex
 
     // Last parsed TigerTag data (retained for /api/status)
     TigerTagData lastTigerTag_;

--- a/src/TroubleshootingHTML.h
+++ b/src/TroubleshootingHTML.h
@@ -283,6 +283,9 @@ const char TROUBLESHOOTING_HTML[] PROGMEM = R"rawliteral(
           const s = d.spoolman;
           if (!s.enabled) {
             setCheck('spoolman', 'warn', 'Spoolman', 'Disabled in config');
+          } else if (s.check_skipped) {
+            setCheck('spoolman', 'warn', 'Spoolman',
+              'Check skipped &mdash; the scanner was busy with another request. Refresh to retry.');
           } else if (s.reachable) {
             setCheck('spoolman', 'pass', 'Spoolman',
               'Connected &mdash; ' + s.url + (s.version ? ' (v' + s.version + ')' : ''));

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -39,6 +39,9 @@
 // Shared HTTP mutex — serializes all outbound HTTP requests across tasks
 extern SemaphoreHandle_t g_httpMutex;
 static constexpr TickType_t HTTP_MUTEX_TIMEOUT = pdMS_TO_TICKS(10000);
+// Diagnostics polls from loopTask: prefer reporting "busy" over stalling the
+// loop waiting for a sync or printer poll to finish.
+static constexpr TickType_t DIAG_HTTP_MUTEX_TIMEOUT = pdMS_TO_TICKS(500);
 
 extern "C" {
 #include "openprinttag_lib.h"
@@ -785,23 +788,40 @@ void WebServerManager::handleApiDiagnostics() {
     spoolman["enabled"] = spoolmanEnabled;
     spoolman["url"]     = cfg.spoolman_url;
     if (spoolmanEnabled) {
-        // Quick reachability check — GET /api/v1/info
-        HTTPClient http;
-        char infoUrl[160];
-        snprintf(infoUrl, sizeof(infoUrl), "%s/api/v1/info", cfg.spoolman_url);
-        http.begin(infoUrl);
-        http.setTimeout(3000);
-        int code = http.GET();
-        spoolman["reachable"] = (code == 200);
-        if (code == 200) {
-            // Extract version from response
-            String body = http.getString();
-            StaticJsonDocument<256> info;
-            if (!deserializeJson(info, body) && info.containsKey("version")) {
-                spoolman["version"] = info["version"].as<const char*>();
+        // Outbound HTTP is serialized by g_httpMutex; this endpoint used to skip
+        // it, so opening the troubleshooting page during a Spoolman sync or
+        // printer poll ran a second client concurrently. Wait only briefly —
+        // the page auto-polls this from loopTask, so a long wait would stall the
+        // loop worse than the request it is guarding. If the path is busy,
+        // report that instead of a reachability verdict we did not measure.
+        bool held = g_httpMutex &&
+                    (xSemaphoreTake(g_httpMutex, DIAG_HTTP_MUTEX_TIMEOUT) == pdTRUE);
+        if (g_httpMutex && !held) {
+            spoolman["reachable"] = false;
+            spoolman["check_skipped"] = true;
+        } else {
+            // Quick reachability check — GET /api/v1/info
+            HTTPClient http;
+            char infoUrl[160];
+            snprintf(infoUrl, sizeof(infoUrl), "%s/api/v1/info", cfg.spoolman_url);
+            http.begin(infoUrl);
+            // Both timeouts: setTimeout is the read timeout, and the default
+            // 5s connect timeout would otherwise dominate the loop stall.
+            http.setConnectTimeout(2000);
+            http.setTimeout(3000);
+            int code = http.GET();
+            spoolman["reachable"] = (code == 200);
+            if (code == 200) {
+                // Extract version from response
+                String body = http.getString();
+                StaticJsonDocument<256> info;
+                if (!deserializeJson(info, body) && info.containsKey("version")) {
+                    spoolman["version"] = info["version"].as<const char*>();
+                }
             }
+            http.end();
+            if (held) xSemaphoreGive(g_httpMutex);
         }
-        http.end();
     } else {
         spoolman["reachable"] = false;
     }

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -1911,6 +1911,11 @@ void WebServerManager::handleApiWriteOpenSpool() {
     memset(&req, 0, sizeof(req));
     req.request_id = NFCManager::getInstance().generateRequestId();
     req.type = NFCWriteType::WRITE_OPENSPOOL;
+    // Bind the write to the UID the page detected when Write was pressed,
+    // exactly as the TigerTag and OpenTag3D handlers do. Without it
+    // validateWriteUid() accepts whatever tag happens to be present, so a tag
+    // swapped in after that detection receives this payload.
+    strncpy(req.expected_spool_id, doc["uid"] | "", sizeof(req.expected_spool_id) - 1);
 
     if (!NFCManager::getInstance().enqueueRawWrite(req, (const uint8_t*)jsonPayload, (size_t)jsonLen)) {
         sendError(503, "Write queue full or busy");

--- a/test/native/Makefile
+++ b/test/native/Makefile
@@ -8,7 +8,7 @@ OPT_OBJS = openprinttag_lib.o cbor_native.o
 
 .PHONY: all clean test
 
-all: test_printer_manager test_opt_ndef_bounds test_diagnostics test_tft_landscape_layout
+all: test_printer_manager test_opt_ndef_bounds test_diagnostics test_tft_landscape_layout test_tigertag_parser
 
 openprinttag_lib.o: ../../lib/openprinttag/openprinttag_lib.c
 	$(CC) $(CFLAGS) -c -o $@ $<
@@ -28,8 +28,11 @@ test_diagnostics: test_diagnostics.cpp ../../src/DiagnosticsUtil.cpp ../../src/D
 test_tft_landscape_layout: test_tft_landscape_layout.cpp ../../src/TFTLandscapeLayout.cpp ../../src/TFTLandscapeLayout.h
 	$(CXX) $(CXXFLAGS) -o $@ test_tft_landscape_layout.cpp ../../src/TFTLandscapeLayout.cpp
 
+test_tigertag_parser: test_tigertag_parser.cpp ../../lib/tigertag/TigerTagParser.cpp ../../lib/tigertag/TigerTagParser.h
+	$(CXX) $(CXXFLAGS) -o $@ test_tigertag_parser.cpp ../../lib/tigertag/TigerTagParser.cpp
 
-test: test_printer_manager test_opt_ndef_bounds test_diagnostics test_tft_landscape_layout
+
+test: test_printer_manager test_opt_ndef_bounds test_diagnostics test_tft_landscape_layout test_tigertag_parser
 	@echo ""
 	@echo "=== Running PrinterManager tests ==="
 	@./test_printer_manager
@@ -43,12 +46,10 @@ test: test_printer_manager test_opt_ndef_bounds test_diagnostics test_tft_landsc
 	@echo "=== Running Landscape layout tests ==="
 	@./test_tft_landscape_layout
 	@echo ""
-
-clean:
-	rm -f test_printer_manager test_opt_ndef_bounds test_diagnostics *.o
-	@echo "=== Running Diagnostics tests ==="
-	@./test_diagnostics
+	@echo "=== Running TigerTag parser tests ==="
+	@./test_tigertag_parser
 	@echo ""
 
 clean:
-	rm -f test_printer_manager test_diagnostics *.o
+	rm -f test_printer_manager test_opt_ndef_bounds test_diagnostics \
+	      test_tft_landscape_layout test_tigertag_parser *.o

--- a/test/native/Makefile
+++ b/test/native/Makefile
@@ -8,7 +8,7 @@ OPT_OBJS = openprinttag_lib.o cbor_native.o
 
 .PHONY: all clean test
 
-all: test_printer_manager test_opt_ndef_bounds test_diagnostics test_tft_landscape_layout test_tigertag_parser
+all: test_printer_manager test_opt_ndef_bounds test_diagnostics test_tft_landscape_layout test_tigertag_parser test_bambutag_parser
 
 openprinttag_lib.o: ../../lib/openprinttag/openprinttag_lib.c
 	$(CC) $(CFLAGS) -c -o $@ $<
@@ -31,8 +31,11 @@ test_tft_landscape_layout: test_tft_landscape_layout.cpp ../../src/TFTLandscapeL
 test_tigertag_parser: test_tigertag_parser.cpp ../../lib/tigertag/TigerTagParser.cpp ../../lib/tigertag/TigerTagParser.h
 	$(CXX) $(CXXFLAGS) -o $@ test_tigertag_parser.cpp ../../lib/tigertag/TigerTagParser.cpp
 
+test_bambutag_parser: test_bambutag_parser.cpp ../../lib/bambutag/BambuTagParser.cpp ../../lib/bambutag/BambuTagParser.h
+	$(CXX) $(CXXFLAGS) -o $@ test_bambutag_parser.cpp ../../lib/bambutag/BambuTagParser.cpp
 
-test: test_printer_manager test_opt_ndef_bounds test_diagnostics test_tft_landscape_layout test_tigertag_parser
+
+test: test_printer_manager test_opt_ndef_bounds test_diagnostics test_tft_landscape_layout test_tigertag_parser test_bambutag_parser
 	@echo ""
 	@echo "=== Running PrinterManager tests ==="
 	@./test_printer_manager
@@ -49,7 +52,10 @@ test: test_printer_manager test_opt_ndef_bounds test_diagnostics test_tft_landsc
 	@echo "=== Running TigerTag parser tests ==="
 	@./test_tigertag_parser
 	@echo ""
+	@echo "=== Running Bambu parser tests ==="
+	@./test_bambutag_parser
+	@echo ""
 
 clean:
 	rm -f test_printer_manager test_opt_ndef_bounds test_diagnostics \
-	      test_tft_landscape_layout test_tigertag_parser *.o
+	      test_tft_landscape_layout test_tigertag_parser test_bambutag_parser *.o

--- a/test/native/test_bambutag_parser.cpp
+++ b/test/native/test_bambutag_parser.cpp
@@ -1,0 +1,124 @@
+// Bambu tag parser tests — the contract the read path in NFCManager relies on
+// after #257: blocks that never read arrive zeroed, and a zeroed identity block
+// must never produce a "valid" spool.
+#include "BambuTagParser.h"
+#include <cstdio>
+#include <cstring>
+
+static int failures = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  FAIL %s\n", msg); failures++; } \
+                              else { printf("  PASS %s\n", msg); } } while (0)
+
+// Fill a plausible tag: block 1 variant, block 2 type, block 5 colour/weight/
+// diameter, block 6 temps. Indexes follow BAMBU_BLOCKS.
+static void makeTag(uint8_t blocks[BAMBU_BLOCK_COUNT][16]) {
+    memset(blocks, 0, BAMBU_BLOCK_COUNT * 16);
+    memcpy(blocks[0], "A00-K0", 6);            // material variant
+    memcpy(blocks[1], "PLA Basic", 9);         // filament type
+    blocks[3][0] = 0xFF; blocks[3][1] = 0x66;  // colour RGBA
+    blocks[3][2] = 0x00; blocks[3][3] = 0xFF;
+    blocks[3][4] = 0xE8; blocks[3][5] = 0x03;  // weight 1000 g (LE)
+    blocks[4][8] = 0xE6; blocks[4][9] = 0x00;  // hotend max 230
+    blocks[4][10] = 0xC8; blocks[4][11] = 0x00; // hotend min 200
+}
+
+int main() {
+    printf("=== Bambu parser tests ===\n");
+    uint8_t blocks[BAMBU_BLOCK_COUNT][16];
+    BambuTagData d;
+
+    makeTag(blocks);
+    d = BambuTagData();
+    parseBambuBlocks(blocks, d);
+    CHECK(d.valid, "complete tag is valid");
+    CHECK(strcmp(d.filament_type, "PLA Basic") == 0, "filament type parsed");
+    CHECK(d.weight_g == 1000, "weight parsed");
+    CHECK(d.color_r == 0xFF && d.color_g == 0x66, "colour parsed");
+    CHECK(d.hotend_max == 230 && d.hotend_min == 200, "hotend temps parsed");
+
+    // #257: a failed/never-read block reaches the parser zeroed, not as stack
+    // garbage. A zeroed identity block must not yield a usable spool.
+    makeTag(blocks);
+    memset(blocks[1], 0, 16);   // block 2 (filament type) missing
+    d = BambuTagData();
+    parseBambuBlocks(blocks, d);
+    CHECK(!d.valid, "missing filament-type block is not valid");
+
+    // Zeroed colour/weight block yields zeros, never random values — the read
+    // path rejects this case outright, but the parser must stay deterministic.
+    makeTag(blocks);
+    memset(blocks[3], 0, 16);
+    d = BambuTagData();
+    parseBambuBlocks(blocks, d);
+    CHECK(d.weight_g == 0, "missing weight block reads as zero");
+    CHECK(d.color_r == 0 && d.color_g == 0 && d.color_b == 0,
+          "missing colour block reads as zero");
+
+    // Entirely zeroed input (worst case) must be inert.
+    memset(blocks, 0, sizeof(blocks));
+    d = BambuTagData();
+    parseBambuBlocks(blocks, d);
+    CHECK(!d.valid, "all-zero blocks are not valid");
+    CHECK(d.filament_type[0] == '\0', "all-zero blocks leave type empty");
+
+    // #257: the essential-block completeness gate the read path uses. Every
+    // essential index must veto; every non-essential index must be tolerated.
+    {
+        bool ok[BAMBU_BLOCK_COUNT];
+        for (int i = 0; i < BAMBU_BLOCK_COUNT; i++) ok[i] = true;
+        CHECK(bambuEssentialBlocksPresent(ok), "all blocks read -> complete");
+
+        for (int e = 0; e < BAMBU_ESSENTIAL_COUNT; e++) {
+            for (int i = 0; i < BAMBU_BLOCK_COUNT; i++) ok[i] = true;
+            ok[BAMBU_ESSENTIAL_INDEXES[e]] = false;
+            char msg[64];
+            snprintf(msg, sizeof(msg), "missing essential block %d -> incomplete",
+                     BAMBU_BLOCKS[BAMBU_ESSENTIAL_INDEXES[e]]);
+            CHECK(!bambuEssentialBlocksPresent(ok), msg);
+        }
+
+        for (int idx = 0; idx < BAMBU_BLOCK_COUNT; idx++) {
+            bool essential = false;
+            for (int e = 0; e < BAMBU_ESSENTIAL_COUNT; e++)
+                if (BAMBU_ESSENTIAL_INDEXES[e] == idx) essential = true;
+            if (essential) continue;
+            for (int i = 0; i < BAMBU_BLOCK_COUNT; i++) ok[i] = true;
+            ok[idx] = false;
+            char msg[64];
+            snprintf(msg, sizeof(msg), "missing optional block %d -> still complete",
+                     BAMBU_BLOCKS[idx]);
+            CHECK(bambuEssentialBlocksPresent(ok), msg);
+        }
+    }
+
+    // Per-index essential predicate — drives the read path's fail-fast exit.
+    {
+        for (int idx = 0; idx < BAMBU_BLOCK_COUNT; idx++) {
+            bool expected = false;
+            for (int e = 0; e < BAMBU_ESSENTIAL_COUNT; e++)
+                if (BAMBU_ESSENTIAL_INDEXES[e] == idx) expected = true;
+            char msg[64];
+            snprintf(msg, sizeof(msg), "block %d essential=%d", BAMBU_BLOCKS[idx], expected);
+            CHECK(bambuIsEssentialIndex(idx) == expected, msg);
+        }
+    }
+
+    // parseBambuBlocks must report validity, not an unconditional true —
+    // the read path uses the return value to decide whether to publish.
+    memset(blocks, 0, sizeof(blocks));
+    d = BambuTagData();
+    CHECK(!parseBambuBlocks(blocks, d), "parse returns false for zeroed blocks");
+    makeTag(blocks);
+    d = BambuTagData();
+    CHECK(parseBambuBlocks(blocks, d), "parse returns true for a complete tag");
+
+    // Strings must stay terminated even when a block has no NUL byte.
+    makeTag(blocks);
+    memset(blocks[1], 'X', 16);
+    d = BambuTagData();
+    parseBambuBlocks(blocks, d);
+    CHECK(strlen(d.filament_type) <= 15, "unterminated type string is bounded");
+
+    printf(failures ? "\nFAILURES: %d\n" : "\nOK: 0 failure(s)\n", failures);
+    return failures ? 1 : 0;
+}

--- a/test/native/test_tigertag_parser.cpp
+++ b/test/native/test_tigertag_parser.cpp
@@ -1,0 +1,67 @@
+// TigerTag parser tests — focused on the unknown-version permissive fallback
+// (#256), where the type check read the diameter byte instead of the type byte.
+#include "TigerTagParser.h"
+#include <cstdio>
+#include <cstring>
+
+static int failures = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  FAIL %s\n", msg); failures++; } \
+                              else { printf("  PASS %s\n", msg); } } while (0)
+
+// Build a 32-byte TigerTag payload (offsets relative to page 4).
+//   0-3 version, 8-9 material, 12 type, 13 diameter
+static void makeTag(uint8_t* buf, uint32_t versionId, uint16_t materialId,
+                    uint8_t typeId, uint8_t diameterId) {
+    memset(buf, 0, 32);
+    buf[0] = (uint8_t)(versionId >> 24); buf[1] = (uint8_t)(versionId >> 16);
+    buf[2] = (uint8_t)(versionId >> 8);  buf[3] = (uint8_t)versionId;
+    buf[8] = (uint8_t)(materialId >> 8); buf[9] = (uint8_t)materialId;
+    buf[12] = typeId;
+    buf[13] = diameterId;
+}
+
+int main() {
+    printf("=== TigerTag parser tests ===\n");
+    uint8_t buf[32];
+
+    // A known version ID is accepted regardless of the type/diameter bytes.
+    makeTag(buf, TIGERTAG_V10, 8345, TIGERTAG_TYPE_FILAMENT, 56);
+    CHECK(tigerTagCheckMagic(buf, sizeof(buf)), "known version accepted");
+
+    // #256: unknown version + real filament tag. Type (byte 12) says filament,
+    // diameter (byte 13) is 56 = 1.75mm. Reading byte 13 as the type rejects it.
+    makeTag(buf, 0x00ABCDEF, 8345, TIGERTAG_TYPE_FILAMENT, 56);
+    CHECK(tigerTagCheckMagic(buf, sizeof(buf)),
+          "unknown version + filament type accepted (1.75mm)");
+
+    makeTag(buf, 0x00ABCDEF, 8345, TIGERTAG_TYPE_FILAMENT, 221);
+    CHECK(tigerTagCheckMagic(buf, sizeof(buf)),
+          "unknown version + filament type accepted (2.85mm)");
+
+    makeTag(buf, 0x00ABCDEF, 8394, TIGERTAG_TYPE_RESIN, 0);
+    CHECK(tigerTagCheckMagic(buf, sizeof(buf)),
+          "unknown version + resin type accepted");
+
+    // The inverse of the bug: a diameter byte that happens to hold a type
+    // constant must not make a non-TigerTag payload look valid.
+    makeTag(buf, 0x00ABCDEF, 8345, 0x00, TIGERTAG_TYPE_FILAMENT);
+    CHECK(!tigerTagCheckMagic(buf, sizeof(buf)),
+          "type constant in the diameter byte does not validate");
+
+    // Guards that must still hold.
+    makeTag(buf, 0x00ABCDEF, 0, TIGERTAG_TYPE_FILAMENT, 56);
+    CHECK(!tigerTagCheckMagic(buf, sizeof(buf)), "zero material rejected");
+
+    makeTag(buf, 0x00ABCDEF, 8345, 0x42, 56);
+    CHECK(!tigerTagCheckMagic(buf, sizeof(buf)), "unknown type byte rejected");
+
+    // Parsed fields keep their documented offsets.
+    makeTag(buf, TIGERTAG_V10, 8345, TIGERTAG_TYPE_FILAMENT, 221);
+    TigerTagData d = tigerTagParse(buf, sizeof(buf));
+    CHECK(d.type_id == TIGERTAG_TYPE_FILAMENT, "parse: type_id from byte 12");
+    CHECK(d.diameter_id == 221, "parse: diameter_id from byte 13");
+    CHECK(d.material_id == 8345, "parse: material_id from bytes 8-9");
+
+    printf(failures ? "\nFAILURES: %d\n" : "\nOK: 0 failure(s)\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Promotes v1.9.1 to production. Six fixes from the July code review — logic only, no configuration changes, no hardware dependency.

- **#256** TigerTag tags with newer version IDs were misread as plain UID tags
- **#257** A partly-read Bambu tag could publish invented color, weight, diameter, or temperatures
- **#258** Recent-spool history never updated, and every scan paid 50 ms for it
- **#259** OpenSpool writes were not bound to the scanned tag
- **#262** Opening the troubleshooting page could stall the scanner
- **#263** `FIRMWARE_VERSION` redefinition warning on every target

Upgrade over OTA as usual. Full detail in CHANGELOG.md under [1.9.1].

Deferred and tracked: #276 (scan-cooldown dedup vs write UID validation) and #277 (OTA and `g_httpMutex`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TigerTag recognition and version handling.
  * Increased reliability when reading partially available or damaged Bambu tags.
  * Prevented recent-spool history update issues.
  * Ensured OpenSpool writes target the detected tag, even if tags are swapped.
  * Improved diagnostics responsiveness and clearly indicate when checks are skipped because the scanner is busy.
  * Resolved a firmware-version build warning.

* **Documentation**
  * Added release notes for version 1.9.1.

* **Tests**
  * Expanded parser coverage for TigerTag and Bambu tag formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->