### PR TITLE
Reject web writes that carry no bound tag UID (#283)

### DIFF
--- a/src/OpenPrintTagWriterHTML.h
+++ b/src/OpenPrintTagWriterHTML.h
@@ -5,7 +5,7 @@
 // API endpoints available to the page:
 //   GET  /api/status      — current tag state JSON
 //   POST /api/write-tag   — write all fields to tag (JSON body)
-//   POST /api/format-tag  — format a blank tag (optional JSON body: {"uid":"..."})
+//   POST /api/format-tag  — format a blank tag (JSON body: {"uid":"..."} required)
 
 const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
 <!DOCTYPE html>

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -633,6 +633,15 @@ async function sharedWriteFlow(config) {
   try {
     var presentStatus = await waitForTag(8000);
 
+    // The tag is detected here, at submit time — nothing requires the user to
+    // press Read first. But a tag can report present before its UID is
+    // readable, and writing without one lands on whatever tag is on the
+    // scanner. Stop with an explanation rather than sending an unbound write.
+    if (!presentStatus.uid) {
+      setStepState('step-wait', 'error');
+      throw new Error('Tag detected but its ID could not be read. Reposition it on the scanner and try again.');
+    }
+
     setStepState('step-detect', 'active');
     setBanner('statusBanner', 'Tag detected.');
     setResult('resultBox', 'UID: ' + (presentStatus.uid || 'Unknown'), '');

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -1574,6 +1574,10 @@ void WebServerManager::handleApiWriteTag() {
     }
 
     const char* uid        = doc["uid"] | "";
+    if (uid[0] == '\0') {
+        sendError(400, "uid required");
+        return;
+    }
     const char* mfr        = doc["manufacturer"] | "";
     float initial_weight_g = doc["initial_weight_g"] | 0.0f;
     float remaining_g      = doc["remaining_g"] | 0.0f;
@@ -1683,7 +1687,8 @@ void WebServerManager::handleApiWriteTag() {
 void WebServerManager::handleApiFormatTag() {
     Serial.println("WebServerManager: POST /api/format-tag received");
 
-    // Optional body: {"uid": "..."} to validate tag before formatting
+    // Body: {"uid": "..."} — required, and the format is bound to that tag so
+    // it cannot erase whichever tag happens to be on the scanner (#283).
     char uid[17] = {0};
     if (_server.hasArg("plain") && _server.arg("plain").length() > 2) {
         StaticJsonDocument<64> doc;
@@ -1691,6 +1696,11 @@ void WebServerManager::handleApiFormatTag() {
             const char* u = doc["uid"] | "";
             strncpy(uid, u, sizeof(uid) - 1);
         }
+    }
+
+    if (uid[0] == '\0') {
+        sendError(400, "uid required");
+        return;
     }
 
     NFCWriteRequest req;
@@ -1721,6 +1731,10 @@ void WebServerManager::handleApiWriteTigerTag() {
     }
 
     const char* uid = doc["uid"] | "";
+    if (uid[0] == '\0') {
+        sendError(400, "uid required");
+        return;
+    }
 
     // Assemble 40-byte TigerTag binary layout (32 bytes data + 8 bytes padding)
     uint8_t payload[40];
@@ -1813,6 +1827,10 @@ void WebServerManager::handleApiWriteOpenTag3D() {
     }
 
     const char* uid = doc["uid"] | "";
+    if (uid[0] == '\0') {
+        sendError(400, "uid required");
+        return;
+    }
 
     opentag3d_t ot3d;
     memset(&ot3d, 0, sizeof(ot3d));
@@ -1910,6 +1928,12 @@ void WebServerManager::handleApiWriteOpenSpool() {
         return;
     }
 
+    const char* uid = doc["uid"] | "";
+    if (uid[0] == '\0') {
+        sendError(400, "uid required");
+        return;
+    }
+
     // Build the tag payload using ArduinoJson to properly escape all values
     StaticJsonDocument<256> tagDoc;
     tagDoc["protocol"] = doc["protocol"] | "openspool";
@@ -1935,7 +1959,7 @@ void WebServerManager::handleApiWriteOpenSpool() {
     // exactly as the TigerTag and OpenTag3D handlers do. Without it
     // validateWriteUid() accepts whatever tag happens to be present, so a tag
     // swapped in after that detection receives this payload.
-    strncpy(req.expected_spool_id, doc["uid"] | "", sizeof(req.expected_spool_id) - 1);
+    strncpy(req.expected_spool_id, uid, sizeof(req.expected_spool_id) - 1);
 
     if (!NFCManager::getInstance().enqueueRawWrite(req, (const uint8_t*)jsonPayload, (size_t)jsonLen)) {
         sendError(503, "Write queue full or busy");


### PR DESCRIPTION
Closes #283. Completes the write-binding work started in #259.

## Problem

The writer pages submit `uid: uid || ''`. If detection produced no UID, the request went out with an empty `expected_spool_id`, which the write queue treats as an unbound legacy write and accepts against whatever tag is on the scanner.

## Server

The five destructive web handlers return **400 before touching the write queue**:

| Endpoint | Handler |
|---|---|
| `/api/write-tag` | `handleApiWriteTag` |
| `/api/format-tag` | `handleApiFormatTag` |
| `/api/write-tigertag` | `handleApiWriteTigerTag` |
| `/api/write-opentag3d` | `handleApiWriteOpenTag3D` |
| `/api/write-openspool` | `handleApiWriteOpenSpool` |

This matches the existing guard on `save-enrichment`. Internal callers in `ApplicationManager` and `DeductionManager` are unaffected — they build requests directly and intentionally keep unbound writes.

## Client — and explicitly no "press Read first"

The issue originally proposed disabling Write until a UID had been captured. That was **rejected**: it would have introduced a manual step where none exists. The writer pages already detect the tag at submit time inside `waitForTag(8000)`.

Instead the shared write flow (used by all four writer pages) stops before posting when detection yields no UID, and surfaces `Tag detected but its ID could not be read. Reposition it on the scanner and try again.` The guard therefore only fires in the real failure case — a tag reporting present without a readable UID.

## Verification

- Enumerated every write-enqueue site in the web server: five, all guarded, each before any side effect or hardware action.
- Traced every caller of the five endpoints in the served UI; none can now send an empty UID. The legacy `docs/tagwriter.html` already sends the detected UID and is not firmware-served.
- The format-then-write sequence reuses the same validated UID for both calls.
- Builds pass on esp32dev and esp32c6; native suites green.
- Also corrects two comments that still described the format-tag body as optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NFC tag handling by verifying that a readable UID is available before formatting or writing.
  * Write and format-tag requests now require a non-empty tag UID and are bound to the specified tag.
  * Added clearer failure handling when a tag’s UID cannot be read.

* **Documentation**
  * Updated the format-tag API documentation to state that the request must include a `uid` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->