### PR TITLE
Release v1.9.3 — write binding requires a tag ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.9.3] - 2026-08-06
+
+### Fixed
+
+- **Tag writes from the web pages are now always bound to the tag being written** — if the page detected a tag but could not read its ID, the write went out unbound and the firmware applied it to whichever tag was on the scanner at that moment. The writer pages now stop with an explanation, and the scanner rejects any write request that arrives without a tag ID. Writing still needs no extra steps: the page detects the tag when you press Write, exactly as before. (#283)
+
 ## [1.9.2] - 2026-08-03
 
 Write-path safety and OTA reliability fixes. No configuration changes;

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ extra_scripts = pre:scripts/gen_gzip_assets.py
 monitor_speed = 115200
 monitor_filters = direct, printable
 build_flags =
-	-DFIRMWARE_VERSION=\"1.9.2\"
+	-DFIRMWARE_VERSION=\"1.9.3\"
 ; Exact pins (#216): caret ranges let fresh checkouts resolve newer libraries
 ; than tested builds — same commit, different binary. Bump pins deliberately,
 ; in their own commit, with all four envs built.

--- a/src/OpenPrintTagWriterHTML.h
+++ b/src/OpenPrintTagWriterHTML.h
@@ -5,7 +5,7 @@
 // API endpoints available to the page:
 //   GET  /api/status      — current tag state JSON
 //   POST /api/write-tag   — write all fields to tag (JSON body)
-//   POST /api/format-tag  — format a blank tag (optional JSON body: {"uid":"..."})
+//   POST /api/format-tag  — format a blank tag (JSON body: {"uid":"..."} required)
 
 const char OPENPRINTTAG_WRITER_HTML[] PROGMEM = R"rawliteral(
 <!DOCTYPE html>

--- a/src/SharedJS.h
+++ b/src/SharedJS.h
@@ -633,6 +633,15 @@ async function sharedWriteFlow(config) {
   try {
     var presentStatus = await waitForTag(8000);
 
+    // The tag is detected here, at submit time — nothing requires the user to
+    // press Read first. But a tag can report present before its UID is
+    // readable, and writing without one lands on whatever tag is on the
+    // scanner. Stop with an explanation rather than sending an unbound write.
+    if (!presentStatus.uid) {
+      setStepState('step-wait', 'error');
+      throw new Error('Tag detected but its ID could not be read. Reposition it on the scanner and try again.');
+    }
+
     setStepState('step-detect', 'active');
     setBanner('statusBanner', 'Tag detected.');
     setResult('resultBox', 'UID: ' + (presentStatus.uid || 'Unknown'), '');

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -1574,6 +1574,10 @@ void WebServerManager::handleApiWriteTag() {
     }
 
     const char* uid        = doc["uid"] | "";
+    if (uid[0] == '\0') {
+        sendError(400, "uid required");
+        return;
+    }
     const char* mfr        = doc["manufacturer"] | "";
     float initial_weight_g = doc["initial_weight_g"] | 0.0f;
     float remaining_g      = doc["remaining_g"] | 0.0f;
@@ -1683,7 +1687,8 @@ void WebServerManager::handleApiWriteTag() {
 void WebServerManager::handleApiFormatTag() {
     Serial.println("WebServerManager: POST /api/format-tag received");
 
-    // Optional body: {"uid": "..."} to validate tag before formatting
+    // Body: {"uid": "..."} — required, and the format is bound to that tag so
+    // it cannot erase whichever tag happens to be on the scanner (#283).
     char uid[17] = {0};
     if (_server.hasArg("plain") && _server.arg("plain").length() > 2) {
         StaticJsonDocument<64> doc;
@@ -1691,6 +1696,11 @@ void WebServerManager::handleApiFormatTag() {
             const char* u = doc["uid"] | "";
             strncpy(uid, u, sizeof(uid) - 1);
         }
+    }
+
+    if (uid[0] == '\0') {
+        sendError(400, "uid required");
+        return;
     }
 
     NFCWriteRequest req;
@@ -1721,6 +1731,10 @@ void WebServerManager::handleApiWriteTigerTag() {
     }
 
     const char* uid = doc["uid"] | "";
+    if (uid[0] == '\0') {
+        sendError(400, "uid required");
+        return;
+    }
 
     // Assemble 40-byte TigerTag binary layout (32 bytes data + 8 bytes padding)
     uint8_t payload[40];
@@ -1813,6 +1827,10 @@ void WebServerManager::handleApiWriteOpenTag3D() {
     }
 
     const char* uid = doc["uid"] | "";
+    if (uid[0] == '\0') {
+        sendError(400, "uid required");
+        return;
+    }
 
     opentag3d_t ot3d;
     memset(&ot3d, 0, sizeof(ot3d));
@@ -1910,6 +1928,12 @@ void WebServerManager::handleApiWriteOpenSpool() {
         return;
     }
 
+    const char* uid = doc["uid"] | "";
+    if (uid[0] == '\0') {
+        sendError(400, "uid required");
+        return;
+    }
+
     // Build the tag payload using ArduinoJson to properly escape all values
     StaticJsonDocument<256> tagDoc;
     tagDoc["protocol"] = doc["protocol"] | "openspool";
@@ -1935,7 +1959,7 @@ void WebServerManager::handleApiWriteOpenSpool() {
     // exactly as the TigerTag and OpenTag3D handlers do. Without it
     // validateWriteUid() accepts whatever tag happens to be present, so a tag
     // swapped in after that detection receives this payload.
-    strncpy(req.expected_spool_id, doc["uid"] | "", sizeof(req.expected_spool_id) - 1);
+    strncpy(req.expected_spool_id, uid, sizeof(req.expected_spool_id) - 1);
 
     if (!NFCManager::getInstance().enqueueRawWrite(req, (const uint8_t*)jsonPayload, (size_t)jsonLen)) {
         sendError(503, "Write queue full or busy");


### PR DESCRIPTION
Promotes v1.9.3 to production. Single fix.

**#283** — Tag writes from the web pages are now always bound to the tag being written. If the page detected a tag but could not read its ID, the write previously went out unbound and the firmware applied it to whichever tag was on the scanner. The writer pages now stop with an explanation, and the five destructive write endpoints reject a request that arrives without a tag ID.

No new user steps: the pages still detect the tag when Write is pressed, exactly as before.

Completes the binding work started in #259. Full detail in CHANGELOG.md under [1.9.3].