### PR TITLE
fix(#287): strip rendering on no-PSRAM boards — frees 42KB, 16-bit colour

### DIFF
--- a/docs/shared-spi-bench-checklist.md
+++ b/docs/shared-spi-bench-checklist.md
@@ -89,11 +89,12 @@ task stack high-water marks, and reset reason.
 
 6. **No-PSRAM memory review**
 
-   - Confirm the C6 creates the expected 8-bit 240x240 sprite (about 57.6 kB)
-     and does not log sprite allocation failure. Exercise OTA `freeForOTA()`
-     and its direct progress/error drawing while NFC is active.
+   - Confirm the C6 holds no persistent framebuffer (strip rendering: frames
+     draw through a transient 240x32 16-bit strip, about 15.4 kB only while
+     rendering) and does not log strip allocation failure. Exercise OTA
+     `freeForOTA()` and its direct progress/error drawing while NFC is active.
    - Compare diagnostics before TFT init, after init, after one hour, and after
-     OTA sprite release. Pass: stable heap/largest-block floors, no allocation
+     OTA display release. Pass: stable heap/largest-block floors, no allocation
      failure, and no task stack high-water mark below the project safety floor.
    - Repeat on C5 (compile-enabled; validation pending).
 

--- a/src/TFTDashboard.cpp
+++ b/src/TFTDashboard.cpp
@@ -11,24 +11,24 @@ uint32_t TFTDashboard::contrastTextColor(uint8_t r, uint8_t g, uint8_t b) {
     return luminance > 128.0f ? COLOR_BLACK : COLOR_WHITE;
 }
 
-void TFTDashboard::renderEmptyCell(LGFX_Sprite* sprite, int x, int y, int w, int h, bool small) {
-    sprite->fillRect(x, y, w, h, COLOR_EMPTY_BG);
-    sprite->setTextColor(COLOR_EMPTY_TEXT);
-    sprite->setTextDatum(MC_DATUM);
-    sprite->setTextSize(small ? 1 : 2);
-    sprite->drawString("-", x + w / 2, y + h / 2);
+void TFTDashboard::drawEmptyCell(LGFX_Sprite& canvas, int x, int y, int w, int h, bool small) {
+    canvas.fillRect(x, y, w, h, COLOR_EMPTY_BG);
+    canvas.setTextColor(COLOR_EMPTY_TEXT);
+    canvas.setTextDatum(MC_DATUM);
+    canvas.setTextSize(small ? 1 : 2);
+    canvas.drawString("-", x + w / 2, y + h / 2);
 }
 
-void TFTDashboard::renderCell(LGFX_Sprite* sprite, int x, int y, int w, int h,
-                               const TrayData& tray, bool small) {
+void TFTDashboard::drawCell(LGFX_Sprite& canvas, int x, int y, int w, int h,
+                            const TrayData& tray, bool small) {
     uint32_t bgColor = (static_cast<uint32_t>(tray.color[0]) << 16) |
                        (static_cast<uint32_t>(tray.color[1]) << 8) |
                         static_cast<uint32_t>(tray.color[2]);
-    sprite->fillRect(x, y, w, h, bgColor);
+    canvas.fillRect(x, y, w, h, bgColor);
 
     uint32_t textColor = contrastTextColor(tray.color[0], tray.color[1], tray.color[2]);
-    sprite->setTextColor(textColor);
-    sprite->setTextDatum(MC_DATUM);
+    canvas.setTextColor(textColor);
+    canvas.setTextDatum(MC_DATUM);
 
     char label[6];
     snprintf(label, sizeof(label), "T%d", tray.tray_index + 1);
@@ -42,32 +42,29 @@ void TFTDashboard::renderCell(LGFX_Sprite* sprite, int x, int y, int w, int h,
 
     if (small) {
         // 4x4 grid: compact layout
-        sprite->setTextSize(1);
+        canvas.setTextSize(1);
         int cy = y + h / 2;
-        sprite->drawString(label, x + w / 2, cy - 14);
-        sprite->drawString(tray.material, x + w / 2, cy);
-        sprite->drawString(weight, x + w / 2, cy + 14);
+        canvas.drawString(label, x + w / 2, cy - 14);
+        canvas.drawString(tray.material, x + w / 2, cy);
+        canvas.drawString(weight, x + w / 2, cy + 14);
     } else {
         // 2x2 grid: spacious layout
         int cy = y + h / 2;
-        sprite->setTextSize(1);
-        sprite->drawString(label, x + w / 2, cy - 28);
-        sprite->setTextSize(2);
-        sprite->drawString(tray.material, x + w / 2, cy);
-        sprite->setTextSize(1);
-        sprite->drawString(weight, x + w / 2, cy + 28);
+        canvas.setTextSize(1);
+        canvas.drawString(label, x + w / 2, cy - 28);
+        canvas.setTextSize(2);
+        canvas.drawString(tray.material, x + w / 2, cy);
+        canvas.setTextSize(1);
+        canvas.drawString(weight, x + w / 2, cy + 28);
     }
 }
 
-void TFTDashboard::render(LGFX_Sprite* sprite, const TrayDashboardState& state, int offX, int offY) {
-    sprite->fillScreen(0x000000);
-
+void TFTDashboard::draw(LGFX_Sprite& canvas, int yOffset, const TrayDashboardState& state) {
     if (state.tray_count == 0) {
-        sprite->setTextColor(COLOR_EMPTY_TEXT);
-        sprite->setTextDatum(MC_DATUM);
-        sprite->setTextSize(2);
-        sprite->drawString("No Trays", 120, 120);
-        sprite->pushSprite(offX, offY);
+        canvas.setTextColor(COLOR_EMPTY_TEXT);
+        canvas.setTextDatum(MC_DATUM);
+        canvas.setTextSize(2);
+        canvas.drawString("No Trays", 120, 120 - yOffset);
         return;
     }
 
@@ -89,14 +86,12 @@ void TFTDashboard::render(LGFX_Sprite* sprite, const TrayDashboardState& state, 
         uint8_t col = i % cols;
         uint8_t row = i / cols;
         int x = CELL_GAP + col * (cellW + CELL_GAP);
-        int y = CELL_GAP + row * (cellH + CELL_GAP);
+        int y = CELL_GAP + row * (cellH + CELL_GAP) - yOffset;
 
         if (i < state.tray_count && state.trays[i].populated) {
-            renderCell(sprite, x, y, cellW, cellH, state.trays[i], small);
+            drawCell(canvas, x, y, cellW, cellH, state.trays[i], small);
         } else {
-            renderEmptyCell(sprite, x, y, cellW, cellH, small);
+            drawEmptyCell(canvas, x, y, cellW, cellH, small);
         }
     }
-
-    sprite->pushSprite(offX, offY);
 }

--- a/src/TFTDashboard.h
+++ b/src/TFTDashboard.h
@@ -4,11 +4,14 @@
 
 class TFTDashboard {
 public:
-    void render(LGFX_Sprite* sprite, const TrayDashboardState& state, int offX = 0, int offY = 0);
+    // Draw the 240x240 tray grid into `canvas`, shifting all Y by -yOffset —
+    // same body contract as TFTManager's draw*240 functions. The caller's
+    // backend owns background fill and pushing to the panel.
+    void draw(LGFX_Sprite& canvas, int yOffset, const TrayDashboardState& state);
 
 private:
-    void renderCell(LGFX_Sprite* sprite, int x, int y, int w, int h,
-                    const TrayData& tray, bool small);
-    void renderEmptyCell(LGFX_Sprite* sprite, int x, int y, int w, int h, bool small);
+    void drawCell(LGFX_Sprite& canvas, int x, int y, int w, int h,
+                  const TrayData& tray, bool small);
+    void drawEmptyCell(LGFX_Sprite& canvas, int x, int y, int w, int h, bool small);
     uint32_t contrastTextColor(uint8_t r, uint8_t g, uint8_t b);
 };

--- a/src/TFTManager.cpp
+++ b/src/TFTManager.cpp
@@ -814,7 +814,10 @@ bool TFTManager::renderTextLandscape(const char* l1, const char* l2, uint32_t l1
     }
     const int STRIP_H = 32;
     _strip.setColorDepth(16);
-    if (!_strip.createSprite(W, STRIP_H)) return false;
+    if (!_strip.createSprite(W, STRIP_H)) {
+        Serial.println("TFT: landscape text strip alloc failed");
+        return false;
+    }
     for (int bandY = 0; bandY < H; bandY += STRIP_H) {
         _strip.fillScreen(COLOR_BG);
         drawStatusBar(_strip, bandY);

--- a/src/TFTManager.cpp
+++ b/src/TFTManager.cpp
@@ -351,7 +351,7 @@ void TFTManager::processQueue() {
                         renderStatus("Error", msg.statusText);
                     break;
                 case TFTState::TrayDashboard:
-                    _dashboard.render(&_sprite, msg.dashboardState, _blitOx, _blitOy);
+                    renderTrayDashboard(msg.dashboardState);
                     break;
             }
             // Commit state only after a successful (guarded) render, so the idle
@@ -441,99 +441,100 @@ void TFTManager::blitCanvas() {
     _sprite.pushSprite(_blitOx, _blitOy);
 }
 
-void TFTManager::renderBoot(const char* version) {
+// Shared 240x240 backend: full persistent sprite. Bodies take (canvas, yOffset)
+// so this can flip to strip bands without touching them.
+template <typename DrawFn>
+void TFTManager::render240Frame(DrawFn&& drawBody) {
     _sprite.fillScreen(COLOR_BG);
-
-    // Centered logo text
-    _sprite.setTextColor(COLOR_ACCENT);
-    _sprite.setTextSize(3);
-    _sprite.setTextDatum(MC_DATUM);
-    _sprite.drawString("SpoolSense", _sprite.width() / 2, _sprite.height() / 2 - 20);
-
-    _sprite.setTextColor(COLOR_SUBTEXT);
-    _sprite.setTextSize(1);
-    _sprite.drawString(version, _sprite.width() / 2, _sprite.height() / 2 + 20);
-
+    drawBody(_sprite, 0);
     blitCanvas();
+}
+
+void TFTManager::renderBoot(const char* version) {
+    render240Frame([&](LGFX_Sprite& c, int y) { drawBoot240(c, y, version); });
+}
+
+void TFTManager::drawBoot240(LGFX_Sprite& canvas, int yOffset, const char* version) {
+    const int W = 240, H = 240;
+    auto Y = [&](int y){ return y - yOffset; };
+
+    canvas.setTextColor(COLOR_ACCENT);
+    canvas.setTextSize(3);
+    canvas.setTextDatum(MC_DATUM);
+    canvas.drawString("SpoolSense", W / 2, Y(H / 2 - 20));
+
+    canvas.setTextColor(COLOR_SUBTEXT);
+    canvas.setTextSize(1);
+    canvas.drawString(version, W / 2, Y(H / 2 + 20));
 }
 
 void TFTManager::renderReady() {
-    _sprite.fillScreen(COLOR_BG);
+    render240Frame([&](LGFX_Sprite& c, int y) { drawReady240(c, y); });
+}
 
-    // Header bar
-    _sprite.fillRect(0, 0, _sprite.width(), 28, COLOR_HEADER_BG);
-    _sprite.setTextColor(COLOR_ACCENT);
-    _sprite.setTextSize(1);
-    _sprite.setTextDatum(MC_DATUM);
-    _sprite.drawString("SpoolSense", _sprite.width() / 2, 14);
-    drawWifiIcon240();
+void TFTManager::drawReady240(LGFX_Sprite& canvas, int yOffset) {
+    const int W = 240, H = 240;
+    auto Y = [&](int y){ return y - yOffset; };
+
+    canvas.fillRect(0, Y(0), W, 28, COLOR_HEADER_BG);
+    canvas.setTextColor(COLOR_ACCENT);
+    canvas.setTextSize(1);
+    canvas.setTextDatum(MC_DATUM);
+    canvas.drawString("SpoolSense", W / 2, Y(14));
+    drawWifiIcon240(canvas, yOffset);
 
     // Idle spool graphic: grey fill indicates no spool selected (waiting for tag)
-    int cx = _sprite.width() / 2;
-    int cy = _sprite.height() / 2 + 10;
-    drawSpoolImage(_sprite, cx, cy, 0x888888, 0, 150);  // neutral grey idle spool
+    int cx = W / 2;
+    int cy = H / 2 + 10;
+    drawSpoolImage(canvas, cx, cy, 0x888888, yOffset, 150);
 
-    // Prompt
-    _sprite.setTextColor(COLOR_SUBTEXT);
-    _sprite.setTextSize(1);
-    _sprite.setTextDatum(MC_DATUM);
-    _sprite.drawString("Tap a spool to scan", cx, _sprite.height() - 16);
-
-    blitCanvas();
+    canvas.setTextColor(COLOR_SUBTEXT);
+    canvas.setTextSize(1);
+    canvas.setTextDatum(MC_DATUM);
+    canvas.drawString("Tap a spool to scan", cx, Y(H - 16));
 }
 
 void TFTManager::renderSpoolScanned(const DisplaySpoolData& spool) {
-    _sprite.fillScreen(COLOR_BG);
+    render240Frame([&](LGFX_Sprite& c, int y) { drawSpool240(c, y, spool); });
+}
 
-    int W = _sprite.width();   // 240
-    int H = _sprite.height();  // 240
+void TFTManager::drawSpool240(LGFX_Sprite& canvas, int yOffset, const DisplaySpoolData& spool) {
+    const int W = 240;
+    auto Y = [&](int y){ return y - yOffset; };
 
-    // Header bar
-    _sprite.fillRect(0, 0, W, 28, COLOR_HEADER_BG);
+    canvas.fillRect(0, Y(0), W, 28, COLOR_HEADER_BG);
+    drawTagIcon(canvas, spool.tagType, 4, Y(2));
+    canvas.setTextColor(COLOR_ACCENT);
+    canvas.setTextSize(1);
+    canvas.setTextDatum(MC_DATUM);
+    canvas.drawString("SpoolSense", W / 2, Y(14));
+    drawWifiIcon240(canvas, yOffset);
 
-    // Tag type icon top-left in header
-    drawTagIcon(spool.tagType, 4, 2);
-
-    // "SpoolSense" in header
-    _sprite.setTextColor(COLOR_ACCENT);
-    _sprite.setTextSize(1);
-    _sprite.setTextDatum(MC_DATUM);
-    _sprite.drawString("SpoolSense", _sprite.width() / 2, 14);
-    drawWifiIcon240();
-
-    // ---- Spool graphic ----
     uint32_t fillColor = hexToRgb(spool.colorHex);
     int cx = W / 2;
-    int cy = 110;
-    drawSpoolImage(_sprite, cx, cy, fillColor, 0, 150);
+    drawSpoolImage(canvas, cx, 110, fillColor, yOffset, 150);
 
-    // ---- Text area ----
     int textY = 190;
-    _sprite.setTextDatum(MC_DATUM);
+    canvas.setTextDatum(MC_DATUM);
 
-    // Brand + material
     char brandMat[48];
     snprintf(brandMat, sizeof(brandMat), "%s  %s", spool.brand, spool.material);
-    _sprite.setTextColor(COLOR_TEXT);
-    _sprite.setTextSize(1);
-    _sprite.drawString(brandMat, cx, textY);
+    canvas.setTextColor(COLOR_TEXT);
+    canvas.setTextSize(1);
+    canvas.drawString(brandMat, cx, Y(textY));
 
-    // Weight bar
     if (spool.totalWeight > 0) {
-        drawWeightBar(20, textY + 14, W - 40, 8,
+        drawWeightBar(canvas, 20, Y(textY + 14), W - 40, 8,
                       spool.remainingWeight, spool.totalWeight);
 
-        // Weight text
         char weightStr[32];
         snprintf(weightStr, sizeof(weightStr), "%.0fg / %.0fg",
                  spool.remainingWeight, spool.totalWeight);
-        _sprite.setTextColor(COLOR_SUBTEXT);
-        _sprite.setTextSize(1);
-        _sprite.setTextDatum(MC_DATUM);
-        _sprite.drawString(weightStr, cx, textY + 30);
+        canvas.setTextColor(COLOR_SUBTEXT);
+        canvas.setTextSize(1);
+        canvas.setTextDatum(MC_DATUM);
+        canvas.drawString(weightStr, cx, Y(textY + 30));
     }
-
-    blitCanvas();
 }
 
 // Tinted 3D spool image. For each luminance pixel: brightness gates how much of
@@ -583,13 +584,12 @@ void TFTManager::drawWifiBars(LGFX_Sprite& canvas, int x, int y, int rssi, bool 
     }
 }
 
-// Shared top bar: "SpoolSense" + WiFi/HA/Printer status. Status is queried live
-// (bool reads / WiFi calls are safe from the TFT task).
 // Same signal-bars indicator as the landscape status bar, sized for the
-// 240x240 header (top-right corner).
-void TFTManager::drawWifiIcon240() {
+// 240x240 header (top-right corner). WiFi status is queried live (safe from
+// the TFT task).
+void TFTManager::drawWifiIcon240(LGFX_Sprite& canvas, int yOffset) {
     bool up = (WiFi.status() == WL_CONNECTED);
-    drawWifiBars(_sprite, _sprite.width() - 26, 22, up ? (int)WiFi.RSSI() : -127, up);
+    drawWifiBars(canvas, 240 - 26, 22 - yOffset, up ? (int)WiFi.RSSI() : -127, up);
 }
 
 void TFTManager::drawStatusBar(LGFX_Sprite& canvas, int yOffset) {
@@ -809,93 +809,96 @@ void TFTManager::refreshStatusBar() {
 }
 
 void TFTManager::renderStatus(const char* line1, const char* line2) {
-    _sprite.fillScreen(COLOR_BG);
+    render240Frame([&](LGFX_Sprite& c, int y) { drawStatus240(c, y, line1, line2); });
+}
 
-    _sprite.fillRect(0, 0, _sprite.width(), 28, COLOR_HEADER_BG);
-    _sprite.setTextColor(COLOR_ACCENT);
-    _sprite.setTextSize(1);
-    _sprite.setTextDatum(MC_DATUM);
-    _sprite.drawString("SpoolSense", _sprite.width() / 2, 14);
-    drawWifiIcon240();
+void TFTManager::drawStatus240(LGFX_Sprite& canvas, int yOffset,
+                               const char* line1, const char* line2) {
+    const int W = 240, H = 240;
+    auto Y = [&](int y){ return y - yOffset; };
 
-    int cy = _sprite.height() / 2;
-    _sprite.setTextColor(COLOR_TEXT);
-    _sprite.setTextSize(2);
-    _sprite.setTextDatum(MC_DATUM);
-    _sprite.drawString(line1, _sprite.width() / 2, line2 ? cy - 12 : cy);
+    canvas.fillRect(0, Y(0), W, 28, COLOR_HEADER_BG);
+    canvas.setTextColor(COLOR_ACCENT);
+    canvas.setTextSize(1);
+    canvas.setTextDatum(MC_DATUM);
+    canvas.drawString("SpoolSense", W / 2, Y(14));
+    drawWifiIcon240(canvas, yOffset);
+
+    int cy = H / 2;
+    canvas.setTextColor(COLOR_TEXT);
+    canvas.setTextSize(2);
+    canvas.setTextDatum(MC_DATUM);
+    canvas.drawString(line1, W / 2, Y(line2 ? cy - 12 : cy));
 
     if (line2) {
-        _sprite.setTextColor(COLOR_SUBTEXT);
-        _sprite.setTextSize(1);
-        _sprite.drawString(line2, _sprite.width() / 2, cy + 12);
+        canvas.setTextColor(COLOR_SUBTEXT);
+        canvas.setTextSize(1);
+        canvas.drawString(line2, W / 2, Y(cy + 12));
     }
-
-    blitCanvas();
 }
 
 void TFTManager::renderWriteResult(bool success, const char* tagFormat) {
-    _sprite.fillScreen(COLOR_BG);
-    _sprite.fillRect(0, 0, _sprite.width(), 28, COLOR_HEADER_BG);
-    _sprite.setTextColor(COLOR_ACCENT);
-    _sprite.setTextSize(1);
-    _sprite.setTextDatum(MC_DATUM);
-    _sprite.drawString("SpoolSense", _sprite.width() / 2, 14);
-    drawWifiIcon240();
+    render240Frame([&](LGFX_Sprite& c, int y) { drawWriteResult240(c, y, success, tagFormat); });
+}
 
-    int cx = _sprite.width() / 2;
-    int cy = _sprite.height() / 2;
+void TFTManager::drawWriteResult240(LGFX_Sprite& canvas, int yOffset,
+                                    bool success, const char* tagFormat) {
+    const int W = 240, H = 240;
+    auto Y = [&](int y){ return y - yOffset; };
 
-    if (success) {
-        // Green checkmark circle
-        _sprite.fillCircle(cx, cy - 20, 22, 0x00CC66);
-        _sprite.setTextColor(COLOR_BG);
-        _sprite.setTextSize(3);
-        _sprite.setTextDatum(MC_DATUM);
-        _sprite.drawString("OK", cx, cy - 20);
-        _sprite.setTextColor(COLOR_TEXT);
-        _sprite.setTextSize(1);
-        _sprite.drawString("Write OK", cx, cy + 12);
-        _sprite.setTextColor(COLOR_SUBTEXT);
-        _sprite.drawString(tagFormat, cx, cy + 26);
-    } else {
-        _sprite.fillCircle(cx, cy - 20, 22, 0xFF4444);
-        _sprite.setTextColor(COLOR_BG);
-        _sprite.setTextSize(3);
-        _sprite.setTextDatum(MC_DATUM);
-        _sprite.drawString("X", cx, cy - 20);
-        _sprite.setTextColor(COLOR_TEXT);
-        _sprite.setTextSize(1);
-        _sprite.drawString("Write failed", cx, cy + 12);
-        _sprite.setTextColor(COLOR_SUBTEXT);
-        _sprite.drawString(tagFormat, cx, cy + 26);
-    }
+    canvas.fillRect(0, Y(0), W, 28, COLOR_HEADER_BG);
+    canvas.setTextColor(COLOR_ACCENT);
+    canvas.setTextSize(1);
+    canvas.setTextDatum(MC_DATUM);
+    canvas.drawString("SpoolSense", W / 2, Y(14));
+    drawWifiIcon240(canvas, yOffset);
 
-    blitCanvas();
+    int cx = W / 2;
+    int cy = H / 2;
+
+    canvas.fillCircle(cx, Y(cy - 20), 22, success ? 0x00CC66 : 0xFF4444);
+    canvas.setTextColor(COLOR_BG);
+    canvas.setTextSize(3);
+    canvas.setTextDatum(MC_DATUM);
+    canvas.drawString(success ? "OK" : "X", cx, Y(cy - 20));
+    canvas.setTextColor(COLOR_TEXT);
+    canvas.setTextSize(1);
+    canvas.drawString(success ? "Write OK" : "Write failed", cx, Y(cy + 12));
+    canvas.setTextColor(COLOR_SUBTEXT);
+    canvas.drawString(tagFormat, cx, Y(cy + 26));
 }
 
 void TFTManager::renderKeypadEntry(const char* toolNumber) {
-    _sprite.fillScreen(COLOR_BG);
-    _sprite.fillRect(0, 0, _sprite.width(), 28, COLOR_HEADER_BG);
-    _sprite.setTextColor(COLOR_ACCENT);
-    _sprite.setTextSize(1);
-    _sprite.setTextDatum(MC_DATUM);
-    _sprite.drawString("SpoolSense", _sprite.width() / 2, 14);
-    drawWifiIcon240();
+    render240Frame([&](LGFX_Sprite& c, int y) { drawKeypad240(c, y, toolNumber); });
+}
 
-    int cx = _sprite.width() / 2;
-    _sprite.setTextColor(COLOR_SUBTEXT);
-    _sprite.setTextSize(1);
-    _sprite.drawString("Assign to tool:", cx, 100);
+void TFTManager::drawKeypad240(LGFX_Sprite& canvas, int yOffset, const char* toolNumber) {
+    const int W = 240;
+    auto Y = [&](int y){ return y - yOffset; };
 
-    _sprite.setTextColor(COLOR_TEXT);
-    _sprite.setTextSize(4);
-    _sprite.drawString(toolNumber, cx, 130);
+    canvas.fillRect(0, Y(0), W, 28, COLOR_HEADER_BG);
+    canvas.setTextColor(COLOR_ACCENT);
+    canvas.setTextSize(1);
+    canvas.setTextDatum(MC_DATUM);
+    canvas.drawString("SpoolSense", W / 2, Y(14));
+    drawWifiIcon240(canvas, yOffset);
 
-    _sprite.setTextColor(COLOR_SUBTEXT);
-    _sprite.setTextSize(1);
-    _sprite.drawString("Press # to confirm", cx, 185);
+    int cx = W / 2;
+    canvas.setTextColor(COLOR_SUBTEXT);
+    canvas.setTextSize(1);
+    canvas.drawString("Assign to tool:", cx, Y(100));
 
-    blitCanvas();
+    canvas.setTextColor(COLOR_TEXT);
+    canvas.setTextSize(4);
+    canvas.drawString(toolNumber, cx, Y(130));
+
+    canvas.setTextColor(COLOR_SUBTEXT);
+    canvas.setTextSize(1);
+    canvas.drawString("Press # to confirm", cx, Y(185));
+}
+
+void TFTManager::renderTrayDashboard(const TrayDashboardState& state) {
+    render240Frame([&](LGFX_Sprite& c, int y) { _dashboard.draw(c, y, state); });
 }
 
 // ---------------------------------------------------------------------------
@@ -903,7 +906,7 @@ void TFTManager::renderKeypadEntry(const char* toolNumber) {
 // ---------------------------------------------------------------------------
 
 
-void TFTManager::drawWeightBar(int x, int y, int w, int h,
+void TFTManager::drawWeightBar(LGFX_Sprite& canvas, int x, int y, int w, int h,
                                 float remaining, float total) {
     float ratio = (total > 0) ? (remaining / total) : 0.0f;
     ratio = constrain(ratio, 0.0f, 1.0f);
@@ -912,17 +915,14 @@ void TFTManager::drawWeightBar(int x, int y, int w, int h,
     // Red bar when ≤10% remaining (visual alert for respool soon)
     uint32_t barColor = (ratio <= 0.1f) ? COLOR_BAR_LOW : COLOR_BAR_FG;
 
-    // Background tray
-    _sprite.fillRoundRect(x, y, w, h, h / 2, COLOR_BAR_BG);
-    // Filled portion (green or red)
+    canvas.fillRoundRect(x, y, w, h, h / 2, COLOR_BAR_BG);
     if (filled > 0) {
-        _sprite.fillRoundRect(x, y, filled, h, h / 2, barColor);
+        canvas.fillRoundRect(x, y, filled, h, h / 2, barColor);
     }
-    // Outline for definition
-    _sprite.drawRoundRect(x, y, w, h, h / 2, 0x555555);
+    canvas.drawRoundRect(x, y, w, h, h / 2, 0x555555);
 }
 
-void TFTManager::drawTagIcon(uint8_t tagType, int x, int y) {
+void TFTManager::drawTagIcon(LGFX_Sprite& canvas, uint8_t tagType, int x, int y) {
     const char* label = nullptr;
     uint32_t color = COLOR_SUBTEXT;
 
@@ -956,10 +956,10 @@ void TFTManager::drawTagIcon(uint8_t tagType, int x, int y) {
             return;  // unknown type; skip label
     }
 
-    _sprite.setTextColor(color);
-    _sprite.setTextSize(1);
-    _sprite.setTextDatum(TR_DATUM);  // top-right aligned
-    _sprite.drawString(label, x + 22, y);
+    canvas.setTextColor(color);
+    canvas.setTextSize(1);
+    canvas.setTextDatum(TR_DATUM);  // top-right aligned
+    canvas.drawString(label, x + 22, y);
 }
 
 uint32_t TFTManager::hexToRgb(const char* hex) {

--- a/src/TFTManager.cpp
+++ b/src/TFTManager.cpp
@@ -9,9 +9,12 @@
 #include <WiFi.h>
 #include <Arduino.h>
 
-// TFT display controller for 240x240 ST7789 or GC9A01 (round). Manages sprite rendering to PSRAM
-// (16-bit color), screen timeout/breathing animations, and OTA progress. Task runs on core 0.
-// Sprite reduces flicker vs direct-to-panel rendering; 5ms task loop allows other tasks to run.
+// TFT display controller (ST7789/GC9A01 240x240, ILI9341/ILI9488). All screens
+// render through sprites for flicker-free updates: PSRAM boards hold a
+// persistent 16-bit full framebuffer, no-PSRAM boards draw each frame through
+// a transient 16-bit strip band (see render240Frame / renderLandscapeFrame).
+// Also manages screen timeout, low-spool breathing, and OTA progress. Task
+// runs on core 0.
 
 // Color constants for UI elements
 // ────────────────────────────────────────────────────────────────────────
@@ -79,23 +82,19 @@ void TFTManager::begin() {
     _tft.fillScreen(COLOR_BG);
 
 #ifdef BOARD_HAS_PSRAM
-    // 16-bit color needs PSRAM on S3-DevKitC: 240x240x2 bytes = 115KB, internal RAM only ~50KB free
+    // Persistent 16-bit full framebuffer in PSRAM (240x240x2 = 115KB). On
+    // failure render240Frame falls back to strip rendering, same as no-PSRAM.
     _sprite.setPsram(true);
     _sprite.setColorDepth(16);
-    if (!_sprite.createSprite(240, 240)) {
-        Serial.println("TFTManager: PSRAM sprite failed, falling back to 8-bit internal RAM");
-        _sprite.setPsram(false);
-        _sprite.setColorDepth(8);  // 8-bit indexed color fits in internal RAM; reduced colors
-        if (!_sprite.createSprite(240, 240)) {
-            Serial.println("TFTManager: WARNING — sprite allocation failed");
-        }
-    }
-#else
-    _sprite.setColorDepth(8);
-    if (!_sprite.createSprite(240, 240)) {
-        Serial.println("TFTManager: WARNING — sprite allocation failed");
+    _fullFrame = _sprite.createSprite(240, 240);
+    if (!_fullFrame) {
+        Serial.println("TFTManager: PSRAM sprite failed; using strip rendering");
     }
 #endif
+    // Without PSRAM no persistent framebuffer is held: render240Frame draws
+    // each frame through a transient 240x32 16-bit strip (15.4KB during a
+    // render vs 57.6KB held forever at 8-bit), keeping ~42KB of internal RAM
+    // free for WiFi/TLS/JSON and giving these panels full 16-bit colour.
 
     _messageQueue = xQueueCreate(8, sizeof(TFTMessage));
     if (_messageQueue == nullptr) {
@@ -421,33 +420,55 @@ void TFTManager::processQueue() {
 // Rendering
 // ---------------------------------------------------------------------------
 
-void TFTManager::blitCanvas() {
-    // On wide panels clear the gutters around the centered 240x240 canvas so a
-    // prior full-screen landscape frame doesn't linger behind legacy views.
-    // (Runs inside processQueue's shared-SPI guard; no-op on 240x240 panels.)
-    if (_wide) {
-        const int W = _tft.width(), H = _tft.height();
-        if (_blitOx > 0) {
-            _tft.fillRect(0, 0, _blitOx, H, COLOR_BG);
-            _tft.fillRect(_blitOx + 240, 0, W - _blitOx - 240, H, COLOR_BG);
-        }
-        if (_blitOy > 0) {
-            _tft.fillRect(_blitOx, 0, 240, _blitOy, COLOR_BG);
-            _tft.fillRect(_blitOx, _blitOy + 240, 240, H - _blitOy - 240, COLOR_BG);
-        }
+// On wide panels clear the gutters around the centered 240x240 area so a
+// prior full-screen landscape frame doesn't linger behind legacy views.
+// (Runs inside processQueue's shared-SPI guard; no-op on 240x240 panels.)
+void TFTManager::clearWideGutters() {
+    if (!_wide) return;
+    const int W = _tft.width(), H = _tft.height();
+    if (_blitOx > 0) {
+        _tft.fillRect(0, 0, _blitOx, H, COLOR_BG);
+        _tft.fillRect(_blitOx + 240, 0, W - _blitOx - 240, H, COLOR_BG);
     }
+    if (_blitOy > 0) {
+        _tft.fillRect(_blitOx, 0, 240, _blitOy, COLOR_BG);
+        _tft.fillRect(_blitOx, _blitOy + 240, 240, H - _blitOy - 240, COLOR_BG);
+    }
+}
+
+void TFTManager::blitCanvas() {
+    clearWideGutters();
     // 240x240 sprite pushed at the panel-aware origin: (0,0) on 240x240 panels,
     // centered on wide panels (ILI9488).
     _sprite.pushSprite(_blitOx, _blitOy);
 }
 
-// Shared 240x240 backend: full persistent sprite. Bodies take (canvas, yOffset)
-// so this can flip to strip bands without touching them.
+// Shared 240x240 backend — same shape as renderLandscapeFrame: persistent full
+// sprite when one exists, otherwise a reused 240x32 16-bit strip drawn
+// band-by-band (bands overhanging 240 rows clip at the panel edge).
 template <typename DrawFn>
 void TFTManager::render240Frame(DrawFn&& drawBody) {
-    _sprite.fillScreen(COLOR_BG);
-    drawBody(_sprite, 0);
-    blitCanvas();
+    if (_fullFrame) {
+        _sprite.fillScreen(COLOR_BG);
+        drawBody(_sprite, 0);
+        blitCanvas();
+        return;
+    }
+
+    const int STRIP_H = 32;
+    LGFX_Sprite strip(&_tft);
+    strip.setColorDepth(16);
+    if (!strip.createSprite(240, STRIP_H)) {
+        Serial.println("TFT: 240 strip alloc failed");
+        return;
+    }
+    clearWideGutters();
+    for (int bandY = 0; bandY < 240; bandY += STRIP_H) {
+        strip.fillScreen(COLOR_BG);
+        drawBody(strip, bandY);
+        strip.pushSprite(_blitOx, _blitOy + bandY);
+    }
+    strip.deleteSprite();
 }
 
 void TFTManager::renderBoot(const char* version) {
@@ -1056,9 +1077,13 @@ void TFTManager::freeForOTA() {
         Serial.println("TFTManager: Task stopped for OTA");
     }
 
-    // Delete sprite to recover 57.6KB heap for OTA SSL/HTTPS buffer (16-bit color on 240x240)
-    _sprite.deleteSprite();
-    Serial.printf("TFTManager: Sprite freed, heap now %u\n", ESP.getFreeHeap());
+    // Release the persistent framebuffer for the OTA TLS/HTTPS buffers (#59).
+    // Strip-rendering boards hold no framebuffer between frames.
+    if (_fullFrame) {
+        _sprite.deleteSprite();
+        _fullFrame = false;
+        Serial.printf("TFTManager: Sprite freed, heap now %u\n", ESP.getFreeHeap());
+    }
 
     SharedSPIBus::Guard busGuard;
     if (!busGuard) {

--- a/src/TFTManager.cpp
+++ b/src/TFTManager.cpp
@@ -264,6 +264,12 @@ void TFTManager::taskFunc(void* param) {
 
 void TFTManager::taskLoop() {
     while (true) {
+        if (_stopRequested) {
+            // Park at a clean point — the bus guard and transient strip are
+            // released every iteration — so freeForOTA can delete this task
+            // without stranding the shared-SPI mutex or a sprite buffer.
+            vTaskSuspend(nullptr);
+        }
         processQueue();
         MemoryDiagnostics::reportSelf(MemoryDiagnostics::Task::TFT);
         vTaskDelay(pdMS_TO_TICKS(20));  // 50 Hz update rate; allows other tasks to run between renders
@@ -293,61 +299,65 @@ void TFTManager::processQueue() {
             switch (msg.state) {
                 case TFTState::Boot:
                     if (_driver == TFTDriver::ILI9488)
-                        renderTextLandscape("SpoolSense", msg.statusText, COLOR_ACCENT);
+                        rendered = renderTextLandscape("SpoolSense", msg.statusText, COLOR_ACCENT);
                     else
                         rendered = renderBoot(msg.statusText);
                     break;
                 case TFTState::WifiConnecting:
                     if (_driver == TFTDriver::ILI9488)
-                        renderTextLandscape(msg.statusText, msg.statusText2[0] ? msg.statusText2 : nullptr, COLOR_TEXT);
+                        rendered = renderTextLandscape(msg.statusText, msg.statusText2[0] ? msg.statusText2 : nullptr, COLOR_TEXT);
                     else
                         rendered = renderStatus(msg.statusText, msg.statusText2[0] ? msg.statusText2 : nullptr);
                     break;
                 case TFTState::Ready:
                     if (_driver == TFTDriver::ILI9488) {
-                        renderReadyLandscape();
+                        rendered = renderReadyLandscape();
                     } else {
                         rendered = renderReady();
                     }
                     break;
                 case TFTState::SpoolScanned:
-                    // Breathing animation for low-weight spools (< 100g): visual cue for respool
-                    _isBreathing = (msg.spool.remainingWeight > 0 &&
-                                    msg.spool.remainingWeight <= (float)ConfigurationManager::getInstance().getLowSpoolThreshold());
-                    if (_isBreathing) {
-                        _breathColor = hexToRgb(msg.spool.colorHex);
-                        _breathBrightness = 255;
-                        _breathDirection = -1;  // start dimming
-                    }
                     if (_driver == TFTDriver::ILI9488) {
-                        renderSpoolScannedLandscape(msg.spool);
+                        rendered = renderSpoolScannedLandscape(msg.spool);
                     } else {
                         rendered = renderSpoolScanned(msg.spool);
+                    }
+                    // Breathing animation for low-weight spools (< 100g): visual
+                    // cue for respool. Armed only for frames actually displayed —
+                    // a dropped frame must not pulse whatever screen it left up.
+                    if (rendered) {
+                        _isBreathing = (msg.spool.remainingWeight > 0 &&
+                                        msg.spool.remainingWeight <= (float)ConfigurationManager::getInstance().getLowSpoolThreshold());
+                        if (_isBreathing) {
+                            _breathColor = hexToRgb(msg.spool.colorHex);
+                            _breathBrightness = 255;
+                            _breathDirection = -1;  // start dimming
+                        }
                     }
                     break;
                 case TFTState::Writing:
                     if (_driver == TFTDriver::ILI9488)
-                        renderTextLandscape("Writing...", msg.statusText, COLOR_TEXT);
+                        rendered = renderTextLandscape("Writing...", msg.statusText, COLOR_TEXT);
                     else
                         rendered = renderStatus("Writing...", msg.statusText);
                     break;
                 case TFTState::WriteResult:
                     if (_driver == TFTDriver::ILI9488)
-                        renderTextLandscape(msg.writeSuccess ? "Success" : "Write Failed",
-                                            msg.statusText,
-                                            msg.writeSuccess ? COLOR_BAR_FG : COLOR_BAR_LOW);
+                        rendered = renderTextLandscape(msg.writeSuccess ? "Success" : "Write Failed",
+                                                       msg.statusText,
+                                                       msg.writeSuccess ? COLOR_BAR_FG : COLOR_BAR_LOW);
                     else
                         rendered = renderWriteResult(msg.writeSuccess, msg.statusText);
                     break;
                 case TFTState::KeypadEntry:
                     if (_driver == TFTDriver::ILI9488)
-                        renderTextLandscape("Tool", msg.statusText, COLOR_ACCENT);
+                        rendered = renderTextLandscape("Tool", msg.statusText, COLOR_ACCENT);
                     else
                         rendered = renderKeypadEntry(msg.statusText);
                     break;
                 case TFTState::Error:
                     if (_driver == TFTDriver::ILI9488)
-                        renderTextLandscape("Error", msg.statusText, COLOR_BAR_LOW);
+                        rendered = renderTextLandscape("Error", msg.statusText, COLOR_BAR_LOW);
                     else
                         rendered = renderStatus("Error", msg.statusText);
                     break;
@@ -720,7 +730,8 @@ void TFTManager::drawLandscapeReady(LGFX_Sprite& canvas, int yOffset) {
 
 // Shared landscape backend: PSRAM -> one full 480x320 16-bit sprite; no-PSRAM ->
 // a reused 32-row RGB565 strip drawn band-by-band. spool==nullptr renders idle.
-void TFTManager::renderLandscapeFrame(const DisplaySpoolData* spool) {
+// Returns false if the frame was dropped because no sprite could be allocated.
+bool TFTManager::renderLandscapeFrame(const DisplaySpoolData* spool) {
     const int W = 480, H = 320;
 
     if (psramFound()) {
@@ -734,7 +745,7 @@ void TFTManager::renderLandscapeFrame(const DisplaySpoolData* spool) {
             else       drawLandscapeReady(full, 0);
             full.pushSprite(0, 0);
             full.deleteSprite();
-            return;
+            return true;
         }
         Serial.println("TFT: PSRAM landscape sprite failed, using strips");
     }
@@ -743,7 +754,7 @@ void TFTManager::renderLandscapeFrame(const DisplaySpoolData* spool) {
     _strip.setColorDepth(16);
     if (!_strip.createSprite(W, STRIP_H)) {
         Serial.println("TFT: landscape strip alloc failed");
-        return;
+        return false;
     }
     for (int bandY = 0; bandY < H; bandY += STRIP_H) {
         _strip.fillScreen(COLOR_BG);
@@ -753,14 +764,15 @@ void TFTManager::renderLandscapeFrame(const DisplaySpoolData* spool) {
         _strip.pushSprite(0, bandY);
     }
     _strip.deleteSprite();
+    return true;
 }
 
-void TFTManager::renderSpoolScannedLandscape(const DisplaySpoolData& spool) {
-    renderLandscapeFrame(&spool);
+bool TFTManager::renderSpoolScannedLandscape(const DisplaySpoolData& spool) {
+    return renderLandscapeFrame(&spool);
 }
 
-void TFTManager::renderReadyLandscape() {
-    renderLandscapeFrame(nullptr);
+bool TFTManager::renderReadyLandscape() {
+    return renderLandscapeFrame(nullptr);
 }
 
 // Centered status text body (scan-progress / write-result screens), FreeFonts.
@@ -784,7 +796,7 @@ void TFTManager::drawLandscapeText(LGFX_Sprite& canvas, int yOffset,
     }
 }
 
-void TFTManager::renderTextLandscape(const char* l1, const char* l2, uint32_t l1Color) {
+bool TFTManager::renderTextLandscape(const char* l1, const char* l2, uint32_t l1Color) {
     const int W = 480, H = 320;
     if (psramFound()) {
         LGFX_Sprite full(&_tft);
@@ -796,13 +808,13 @@ void TFTManager::renderTextLandscape(const char* l1, const char* l2, uint32_t l1
             drawLandscapeText(full, 0, l1, l2, l1Color);
             full.pushSprite(0, 0);
             full.deleteSprite();
-            return;
+            return true;
         }
         Serial.println("TFT: PSRAM text sprite failed, using strips");
     }
     const int STRIP_H = 32;
     _strip.setColorDepth(16);
-    if (!_strip.createSprite(W, STRIP_H)) return;
+    if (!_strip.createSprite(W, STRIP_H)) return false;
     for (int bandY = 0; bandY < H; bandY += STRIP_H) {
         _strip.fillScreen(COLOR_BG);
         drawStatusBar(_strip, bandY);
@@ -810,6 +822,7 @@ void TFTManager::renderTextLandscape(const char* l1, const char* l2, uint32_t l1
         _strip.pushSprite(0, bandY);
     }
     _strip.deleteSprite();
+    return true;
 }
 
 // Repaint only the top status band (cheap, ~24KB strip) so idle status stays
@@ -1072,15 +1085,28 @@ void TFTManager::showSpool(const DisplaySpoolData& spool) {
 void TFTManager::freeForOTA() {
     // Stop TFT task before OTA: queue messages from main task would race with direct
     // frame buffer writes. OTA may reboot (success) or hang (failure); sprite not restored.
+    // Cooperative stop: ask the task to park at its clean point, then delete
+    // it there. Deleting it mid-frame would strand whatever it held — the
+    // shared-SPI mutex (dead OTA screen + dead NFC on shared-bus boards) and
+    // any transient sprite — because vTaskDelete does not unwind the stack.
+    // NFC is already paused, so the task cannot block on the bus for long;
+    // the bound comfortably exceeds the guard's own acquire timeout.
     if (_taskHandle != nullptr) {
+        _stopRequested = true;
+        for (int i = 0; i < 500 && eTaskGetState(_taskHandle) != eSuspended; ++i) {
+            vTaskDelay(pdMS_TO_TICKS(10));
+        }
+        if (eTaskGetState(_taskHandle) != eSuspended) {
+            Serial.println("TFTManager: render task did not park; deleting anyway");
+        } else {
+            Serial.println("TFTManager: Task stopped for OTA");
+        }
         vTaskDelete(_taskHandle);
         _taskHandle = nullptr;
-        Serial.println("TFTManager: Task stopped for OTA");
     }
 
-    // vTaskDelete above does not unwind the render task's stack, so a kill
-    // landing mid-frame leaves the transient strip allocated — reclaim it
-    // here (safe no-op when it holds no buffer).
+    // Reclaim the transient strip in case the task had to be deleted without
+    // parking (safe no-op when it holds no buffer).
     _strip.deleteSprite();
 
     // Release the persistent framebuffer for the OTA TLS/HTTPS buffers (#59).

--- a/src/TFTManager.cpp
+++ b/src/TFTManager.cpp
@@ -35,6 +35,7 @@ static const uint32_t COLOR_ACCENT    = 0x4FC3F7;
 TFTManager::TFTManager(TFTDriver driver)
     : _tft(driver),
       _sprite(&_tft),
+      _strip(&_tft),
       _messageQueue(nullptr),
       _taskHandle(nullptr),
       _screenTimeoutMs(DEFAULT_SCREEN_TIMEOUT_MS),
@@ -288,24 +289,25 @@ void TFTManager::processQueue() {
                 _tft.setBrightness(255);
             }
 
+            bool rendered = true;
             switch (msg.state) {
                 case TFTState::Boot:
                     if (_driver == TFTDriver::ILI9488)
                         renderTextLandscape("SpoolSense", msg.statusText, COLOR_ACCENT);
                     else
-                        renderBoot(msg.statusText);
+                        rendered = renderBoot(msg.statusText);
                     break;
                 case TFTState::WifiConnecting:
                     if (_driver == TFTDriver::ILI9488)
                         renderTextLandscape(msg.statusText, msg.statusText2[0] ? msg.statusText2 : nullptr, COLOR_TEXT);
                     else
-                        renderStatus(msg.statusText, msg.statusText2[0] ? msg.statusText2 : nullptr);
+                        rendered = renderStatus(msg.statusText, msg.statusText2[0] ? msg.statusText2 : nullptr);
                     break;
                 case TFTState::Ready:
                     if (_driver == TFTDriver::ILI9488) {
                         renderReadyLandscape();
                     } else {
-                        renderReady();
+                        rendered = renderReady();
                     }
                     break;
                 case TFTState::SpoolScanned:
@@ -320,14 +322,14 @@ void TFTManager::processQueue() {
                     if (_driver == TFTDriver::ILI9488) {
                         renderSpoolScannedLandscape(msg.spool);
                     } else {
-                        renderSpoolScanned(msg.spool);
+                        rendered = renderSpoolScanned(msg.spool);
                     }
                     break;
                 case TFTState::Writing:
                     if (_driver == TFTDriver::ILI9488)
                         renderTextLandscape("Writing...", msg.statusText, COLOR_TEXT);
                     else
-                        renderStatus("Writing...", msg.statusText);
+                        rendered = renderStatus("Writing...", msg.statusText);
                     break;
                 case TFTState::WriteResult:
                     if (_driver == TFTDriver::ILI9488)
@@ -335,29 +337,31 @@ void TFTManager::processQueue() {
                                             msg.statusText,
                                             msg.writeSuccess ? COLOR_BAR_FG : COLOR_BAR_LOW);
                     else
-                        renderWriteResult(msg.writeSuccess, msg.statusText);
+                        rendered = renderWriteResult(msg.writeSuccess, msg.statusText);
                     break;
                 case TFTState::KeypadEntry:
                     if (_driver == TFTDriver::ILI9488)
                         renderTextLandscape("Tool", msg.statusText, COLOR_ACCENT);
                     else
-                        renderKeypadEntry(msg.statusText);
+                        rendered = renderKeypadEntry(msg.statusText);
                     break;
                 case TFTState::Error:
                     if (_driver == TFTDriver::ILI9488)
                         renderTextLandscape("Error", msg.statusText, COLOR_BAR_LOW);
                     else
-                        renderStatus("Error", msg.statusText);
+                        rendered = renderStatus("Error", msg.statusText);
                     break;
                 case TFTState::TrayDashboard:
-                    renderTrayDashboard(msg.dashboardState);
+                    rendered = renderTrayDashboard(msg.dashboardState);
                     break;
             }
             // Commit state only after a successful (guarded) render, so the idle
             // status-bar refresh never paints a header over a screen that failed
-            // to render (dropped frame on a lock timeout).
-            _currentState = msg.state;
-            _lastStatusRefreshMs = millis();
+            // to render (frame dropped on a lock timeout or strip alloc failure).
+            if (rendered) {
+                _currentState = msg.state;
+                _lastStatusRefreshMs = millis();
+            }
         }
     }
 
@@ -444,35 +448,35 @@ void TFTManager::blitCanvas() {
 }
 
 // Shared 240x240 backend — same shape as renderLandscapeFrame: persistent full
-// sprite when one exists, otherwise a reused 240x32 16-bit strip drawn
+// sprite when one exists, otherwise the transient 240x32 16-bit strip drawn
 // band-by-band (bands overhanging 240 rows clip at the panel edge).
 template <typename DrawFn>
-void TFTManager::render240Frame(DrawFn&& drawBody) {
+bool TFTManager::render240Frame(DrawFn&& drawBody) {
     if (_fullFrame) {
         _sprite.fillScreen(COLOR_BG);
         drawBody(_sprite, 0);
         blitCanvas();
-        return;
+        return true;
     }
 
     const int STRIP_H = 32;
-    LGFX_Sprite strip(&_tft);
-    strip.setColorDepth(16);
-    if (!strip.createSprite(240, STRIP_H)) {
+    _strip.setColorDepth(16);
+    if (!_strip.createSprite(240, STRIP_H)) {
         Serial.println("TFT: 240 strip alloc failed");
-        return;
+        return false;
     }
     clearWideGutters();
     for (int bandY = 0; bandY < 240; bandY += STRIP_H) {
-        strip.fillScreen(COLOR_BG);
-        drawBody(strip, bandY);
-        strip.pushSprite(_blitOx, _blitOy + bandY);
+        _strip.fillScreen(COLOR_BG);
+        drawBody(_strip, bandY);
+        _strip.pushSprite(_blitOx, _blitOy + bandY);
     }
-    strip.deleteSprite();
+    _strip.deleteSprite();
+    return true;
 }
 
-void TFTManager::renderBoot(const char* version) {
-    render240Frame([&](LGFX_Sprite& c, int y) { drawBoot240(c, y, version); });
+bool TFTManager::renderBoot(const char* version) {
+    return render240Frame([&](LGFX_Sprite& c, int y) { drawBoot240(c, y, version); });
 }
 
 void TFTManager::drawBoot240(LGFX_Sprite& canvas, int yOffset, const char* version) {
@@ -489,8 +493,8 @@ void TFTManager::drawBoot240(LGFX_Sprite& canvas, int yOffset, const char* versi
     canvas.drawString(version, W / 2, Y(H / 2 + 20));
 }
 
-void TFTManager::renderReady() {
-    render240Frame([&](LGFX_Sprite& c, int y) { drawReady240(c, y); });
+bool TFTManager::renderReady() {
+    return render240Frame([&](LGFX_Sprite& c, int y) { drawReady240(c, y); });
 }
 
 void TFTManager::drawReady240(LGFX_Sprite& canvas, int yOffset) {
@@ -515,8 +519,8 @@ void TFTManager::drawReady240(LGFX_Sprite& canvas, int yOffset) {
     canvas.drawString("Tap a spool to scan", cx, Y(H - 16));
 }
 
-void TFTManager::renderSpoolScanned(const DisplaySpoolData& spool) {
-    render240Frame([&](LGFX_Sprite& c, int y) { drawSpool240(c, y, spool); });
+bool TFTManager::renderSpoolScanned(const DisplaySpoolData& spool) {
+    return render240Frame([&](LGFX_Sprite& c, int y) { drawSpool240(c, y, spool); });
 }
 
 void TFTManager::drawSpool240(LGFX_Sprite& canvas, int yOffset, const DisplaySpoolData& spool) {
@@ -736,20 +740,19 @@ void TFTManager::renderLandscapeFrame(const DisplaySpoolData* spool) {
     }
 
     const int STRIP_H = 32;
-    LGFX_Sprite strip(&_tft);
-    strip.setColorDepth(16);
-    if (!strip.createSprite(W, STRIP_H)) {
+    _strip.setColorDepth(16);
+    if (!_strip.createSprite(W, STRIP_H)) {
         Serial.println("TFT: landscape strip alloc failed");
         return;
     }
     for (int bandY = 0; bandY < H; bandY += STRIP_H) {
-        strip.fillScreen(COLOR_BG);
-        drawStatusBar(strip, bandY);
-        if (spool) drawLandscapeSpool(strip, bandY, *spool);
-        else       drawLandscapeReady(strip, bandY);
-        strip.pushSprite(0, bandY);
+        _strip.fillScreen(COLOR_BG);
+        drawStatusBar(_strip, bandY);
+        if (spool) drawLandscapeSpool(_strip, bandY, *spool);
+        else       drawLandscapeReady(_strip, bandY);
+        _strip.pushSprite(0, bandY);
     }
-    strip.deleteSprite();
+    _strip.deleteSprite();
 }
 
 void TFTManager::renderSpoolScannedLandscape(const DisplaySpoolData& spool) {
@@ -798,16 +801,15 @@ void TFTManager::renderTextLandscape(const char* l1, const char* l2, uint32_t l1
         Serial.println("TFT: PSRAM text sprite failed, using strips");
     }
     const int STRIP_H = 32;
-    LGFX_Sprite strip(&_tft);
-    strip.setColorDepth(16);
-    if (!strip.createSprite(W, STRIP_H)) return;
+    _strip.setColorDepth(16);
+    if (!_strip.createSprite(W, STRIP_H)) return;
     for (int bandY = 0; bandY < H; bandY += STRIP_H) {
-        strip.fillScreen(COLOR_BG);
-        drawStatusBar(strip, bandY);
-        drawLandscapeText(strip, bandY, l1, l2, l1Color);
-        strip.pushSprite(0, bandY);
+        _strip.fillScreen(COLOR_BG);
+        drawStatusBar(_strip, bandY);
+        drawLandscapeText(_strip, bandY, l1, l2, l1Color);
+        _strip.pushSprite(0, bandY);
     }
-    strip.deleteSprite();
+    _strip.deleteSprite();
 }
 
 // Repaint only the top status band (cheap, ~24KB strip) so idle status stays
@@ -820,17 +822,16 @@ void TFTManager::refreshStatusBar() {
     SharedSPIBus::Guard g;
     if (!g) return;
     LandscapeLayout L = landscapeLayout(480, 320);
-    LGFX_Sprite bar(&_tft);
-    bar.setColorDepth(16);
-    if (!bar.createSprite(480, L.headerH)) return;
-    bar.fillScreen(COLOR_BG);
-    drawStatusBar(bar, 0);
-    bar.pushSprite(0, 0);
-    bar.deleteSprite();
+    _strip.setColorDepth(16);
+    if (!_strip.createSprite(480, L.headerH)) return;
+    _strip.fillScreen(COLOR_BG);
+    drawStatusBar(_strip, 0);
+    _strip.pushSprite(0, 0);
+    _strip.deleteSprite();
 }
 
-void TFTManager::renderStatus(const char* line1, const char* line2) {
-    render240Frame([&](LGFX_Sprite& c, int y) { drawStatus240(c, y, line1, line2); });
+bool TFTManager::renderStatus(const char* line1, const char* line2) {
+    return render240Frame([&](LGFX_Sprite& c, int y) { drawStatus240(c, y, line1, line2); });
 }
 
 void TFTManager::drawStatus240(LGFX_Sprite& canvas, int yOffset,
@@ -858,8 +859,8 @@ void TFTManager::drawStatus240(LGFX_Sprite& canvas, int yOffset,
     }
 }
 
-void TFTManager::renderWriteResult(bool success, const char* tagFormat) {
-    render240Frame([&](LGFX_Sprite& c, int y) { drawWriteResult240(c, y, success, tagFormat); });
+bool TFTManager::renderWriteResult(bool success, const char* tagFormat) {
+    return render240Frame([&](LGFX_Sprite& c, int y) { drawWriteResult240(c, y, success, tagFormat); });
 }
 
 void TFTManager::drawWriteResult240(LGFX_Sprite& canvas, int yOffset,
@@ -889,8 +890,8 @@ void TFTManager::drawWriteResult240(LGFX_Sprite& canvas, int yOffset,
     canvas.drawString(tagFormat, cx, Y(cy + 26));
 }
 
-void TFTManager::renderKeypadEntry(const char* toolNumber) {
-    render240Frame([&](LGFX_Sprite& c, int y) { drawKeypad240(c, y, toolNumber); });
+bool TFTManager::renderKeypadEntry(const char* toolNumber) {
+    return render240Frame([&](LGFX_Sprite& c, int y) { drawKeypad240(c, y, toolNumber); });
 }
 
 void TFTManager::drawKeypad240(LGFX_Sprite& canvas, int yOffset, const char* toolNumber) {
@@ -918,8 +919,8 @@ void TFTManager::drawKeypad240(LGFX_Sprite& canvas, int yOffset, const char* too
     canvas.drawString("Press # to confirm", cx, Y(185));
 }
 
-void TFTManager::renderTrayDashboard(const TrayDashboardState& state) {
-    render240Frame([&](LGFX_Sprite& c, int y) { _dashboard.draw(c, y, state); });
+bool TFTManager::renderTrayDashboard(const TrayDashboardState& state) {
+    return render240Frame([&](LGFX_Sprite& c, int y) { _dashboard.draw(c, y, state); });
 }
 
 // ---------------------------------------------------------------------------
@@ -1076,6 +1077,11 @@ void TFTManager::freeForOTA() {
         _taskHandle = nullptr;
         Serial.println("TFTManager: Task stopped for OTA");
     }
+
+    // vTaskDelete above does not unwind the render task's stack, so a kill
+    // landing mid-frame leaves the transient strip allocated — reclaim it
+    // here (safe no-op when it holds no buffer).
+    _strip.deleteSprite();
 
     // Release the persistent framebuffer for the OTA TLS/HTTPS buffers (#59).
     // Strip-rendering boards hold no framebuffer between frames.

--- a/src/TFTManager.h
+++ b/src/TFTManager.h
@@ -123,27 +123,28 @@ private:
     void taskLoop();
     void processQueue();
 
-    // --- Rendering ---
-    void renderBoot(const char* version);
-    void renderReady();
-    void renderSpoolScanned(const DisplaySpoolData& spool);
+    // --- Rendering (bool renderers report a dropped frame, see render240Frame) ---
+    bool renderBoot(const char* version);
+    bool renderReady();
+    bool renderSpoolScanned(const DisplaySpoolData& spool);
     void renderSpoolScannedLandscape(const DisplaySpoolData& spool);  // ILI9488 480x320
     void renderReadyLandscape();                                      // ILI9488 idle screen
     void renderTextLandscape(const char* l1, const char* l2, uint32_t l1Color);  // ILI9488 status text
     void renderLandscapeFrame(const DisplaySpoolData* spool);         // shared backend (nullptr=idle)
     void refreshStatusBar();                                          // periodic header-only update
-    void renderStatus(const char* line1, const char* line2 = nullptr);
-    void renderWriteResult(bool success, const char* tagFormat);
-    void renderKeypadEntry(const char* toolNumber);
-    void renderTrayDashboard(const TrayDashboardState& state);
+    bool renderStatus(const char* line1, const char* line2 = nullptr);
+    bool renderWriteResult(bool success, const char* tagFormat);
+    bool renderKeypadEntry(const char* toolNumber);
+    bool renderTrayDashboard(const TrayDashboardState& state);
 
     // Shared 240x240 backend: fills the background, runs drawBody over the
     // frame, and pushes it at the panel-aware origin. With a persistent full
     // framebuffer (PSRAM boards) that is one pass; otherwise a transient
     // 240x32 16-bit strip is drawn band-by-band. Bodies draw the full virtual
     // 240x240 frame shifted by -yOffset and must not read canvas dimensions
-    // for layout (the canvas may be a strip band).
-    template <typename DrawFn> void render240Frame(DrawFn&& drawBody);
+    // for layout (the canvas may be a strip band). Returns false if the frame
+    // was dropped because the strip could not be allocated.
+    template <typename DrawFn> bool render240Frame(DrawFn&& drawBody);
 
     // 240x240 frame bodies — same (canvas, yOffset) contract as drawLandscape*.
     void drawBoot240(LGFX_Sprite& canvas, int yOffset, const char* version);
@@ -178,6 +179,11 @@ private:
 
     LGFX _tft;
     LGFX_Sprite _sprite;
+    // Transient render canvas (strip bands, landscape strips, status bar).
+    // Member-owned rather than stack-local so freeForOTA can reclaim its
+    // buffer: vTaskDelete does not unwind the render task's stack, so a kill
+    // landing mid-frame would otherwise leak the allocation.
+    LGFX_Sprite _strip;
     TFTDriver _driver;
     TFTDashboard _dashboard;
 

--- a/src/TFTManager.h
+++ b/src/TFTManager.h
@@ -138,9 +138,11 @@ private:
     void renderTrayDashboard(const TrayDashboardState& state);
 
     // Shared 240x240 backend: fills the background, runs drawBody over the
-    // frame, and pushes it at the panel-aware origin. Bodies draw the full
-    // virtual 240x240 frame shifted by -yOffset and must not read canvas
-    // dimensions for layout (the canvas may be a strip band).
+    // frame, and pushes it at the panel-aware origin. With a persistent full
+    // framebuffer (PSRAM boards) that is one pass; otherwise a transient
+    // 240x32 16-bit strip is drawn band-by-band. Bodies draw the full virtual
+    // 240x240 frame shifted by -yOffset and must not read canvas dimensions
+    // for layout (the canvas may be a strip band).
     template <typename DrawFn> void render240Frame(DrawFn&& drawBody);
 
     // 240x240 frame bodies — same (canvas, yOffset) contract as drawLandscape*.
@@ -156,6 +158,7 @@ private:
                        float remaining, float total);
     void drawTagIcon(LGFX_Sprite& canvas, uint8_t tagType, int x, int y);
     void blitCanvas();  // push _sprite at the panel-aware (centered on wide panels) origin
+    void clearWideGutters();  // blank the panel around the centered 240x240 area
     // Draw the full 480x320 landscape layout into any canvas, shifting all Y by
     // -yOffset (so one function fills a full sprite or a strip band).
     void drawLandscapeSpool(LGFX_Sprite& canvas, int yOffset, const DisplaySpoolData& spool);
@@ -181,6 +184,7 @@ private:
     QueueHandle_t _messageQueue;
     TaskHandle_t _taskHandle;
     bool _began = false;  // panel + bus initialized; render task must not start otherwise
+    bool _fullFrame = false;  // persistent 240x240 _sprite exists; false = strip rendering
     bool _wide = false;   // panel larger than 240x240 (ILI9488) — landscape-capable
     int  _blitOx = 0;     // centered-blit origin for the 240x240 sprite on wide panels
     int  _blitOy = 0;

--- a/src/TFTManager.h
+++ b/src/TFTManager.h
@@ -127,10 +127,10 @@ private:
     bool renderBoot(const char* version);
     bool renderReady();
     bool renderSpoolScanned(const DisplaySpoolData& spool);
-    void renderSpoolScannedLandscape(const DisplaySpoolData& spool);  // ILI9488 480x320
-    void renderReadyLandscape();                                      // ILI9488 idle screen
-    void renderTextLandscape(const char* l1, const char* l2, uint32_t l1Color);  // ILI9488 status text
-    void renderLandscapeFrame(const DisplaySpoolData* spool);         // shared backend (nullptr=idle)
+    bool renderSpoolScannedLandscape(const DisplaySpoolData& spool);  // ILI9488 480x320
+    bool renderReadyLandscape();                                      // ILI9488 idle screen
+    bool renderTextLandscape(const char* l1, const char* l2, uint32_t l1Color);  // ILI9488 status text
+    bool renderLandscapeFrame(const DisplaySpoolData* spool);         // shared backend (nullptr=idle)
     void refreshStatusBar();                                          // periodic header-only update
     bool renderStatus(const char* line1, const char* line2 = nullptr);
     bool renderWriteResult(bool success, const char* tagFormat);
@@ -189,6 +189,10 @@ private:
 
     QueueHandle_t _messageQueue;
     TaskHandle_t _taskHandle;
+    // freeForOTA sets this to park the render task at a clean point (no bus
+    // guard held, no transient sprite allocated) before deleting it —
+    // vTaskDelete does not unwind the victim's stack.
+    volatile bool _stopRequested = false;
     bool _began = false;  // panel + bus initialized; render task must not start otherwise
     bool _fullFrame = false;  // persistent 240x240 _sprite exists; false = strip rendering
     bool _wide = false;   // panel larger than 240x240 (ILI9488) — landscape-capable

--- a/src/TFTManager.h
+++ b/src/TFTManager.h
@@ -135,10 +135,26 @@ private:
     void renderStatus(const char* line1, const char* line2 = nullptr);
     void renderWriteResult(bool success, const char* tagFormat);
     void renderKeypadEntry(const char* toolNumber);
+    void renderTrayDashboard(const TrayDashboardState& state);
 
-    // --- Drawing helpers ---
-    void drawWeightBar(int x, int y, int w, int h, float remaining, float total);
-    void drawTagIcon(uint8_t tagType, int x, int y);
+    // Shared 240x240 backend: fills the background, runs drawBody over the
+    // frame, and pushes it at the panel-aware origin. Bodies draw the full
+    // virtual 240x240 frame shifted by -yOffset and must not read canvas
+    // dimensions for layout (the canvas may be a strip band).
+    template <typename DrawFn> void render240Frame(DrawFn&& drawBody);
+
+    // 240x240 frame bodies — same (canvas, yOffset) contract as drawLandscape*.
+    void drawBoot240(LGFX_Sprite& canvas, int yOffset, const char* version);
+    void drawReady240(LGFX_Sprite& canvas, int yOffset);
+    void drawSpool240(LGFX_Sprite& canvas, int yOffset, const DisplaySpoolData& spool);
+    void drawStatus240(LGFX_Sprite& canvas, int yOffset, const char* line1, const char* line2);
+    void drawWriteResult240(LGFX_Sprite& canvas, int yOffset, bool success, const char* tagFormat);
+    void drawKeypad240(LGFX_Sprite& canvas, int yOffset, const char* toolNumber);
+
+    // --- Drawing helpers (y arrives already band-translated by the caller) ---
+    void drawWeightBar(LGFX_Sprite& canvas, int x, int y, int w, int h,
+                       float remaining, float total);
+    void drawTagIcon(LGFX_Sprite& canvas, uint8_t tagType, int x, int y);
     void blitCanvas();  // push _sprite at the panel-aware (centered on wide panels) origin
     // Draw the full 480x320 landscape layout into any canvas, shifting all Y by
     // -yOffset (so one function fills a full sprite or a strip band).
@@ -153,7 +169,7 @@ private:
     void drawSpoolImage(LGFX_Sprite& canvas, int cx, int cy, uint32_t tint, int yOffset,
                         int size = 0);
     void drawWifiBars(LGFX_Sprite& canvas, int x, int y, int rssi, bool connected);
-    void drawWifiIcon240();  // signal bars in the 240x240 header's top-right
+    void drawWifiIcon240(LGFX_Sprite& canvas, int yOffset);  // signal bars in the 240x240 header's top-right
     uint32_t hexToRgb(const char* hex);
     uint32_t dimColor(uint32_t color, uint8_t brightness); // for low-spool breathing
 

--- a/src/WebServerManager.cpp
+++ b/src/WebServerManager.cpp
@@ -1176,10 +1176,12 @@ void WebServerManager::otaDownloadTask(void* param) {
     // Pause NFC during OTA
     NFCManager::getInstance().pauseScanTask();
 
-    // Free TFT sprite to reclaim ~57KB heap for SSL
+    // Stop display rendering and release any display buffers before the TLS
+    // handshake (PSRAM boards free their persistent framebuffer; strip-
+    // rendering boards reclaim an in-flight strip at most).
     if (self->_display) {
         self->_display->freeForOTA();
-        Serial.printf("OTA: Free heap after sprite release: %u\n", ESP.getFreeHeap());
+        Serial.printf("OTA: Free heap after display release: %u\n", ESP.getFreeHeap());
     }
 
     WiFiClientSecure secureClient;


### PR DESCRIPTION
Fixes the WROOM + TFT out-of-memory from the field (#287). Root cause: boards without PSRAM held a persistent 240x240 8-bit framebuffer (57.6KB of internal RAM, the firmware's largest allocation), leaving ~94KB free.

## Approach — reviewable in two steps

1. **cb54cda — behaviour-preserving conversion.** All six 240x240 renderers, the drawing helpers, and the tray dashboard now draw through `(canvas, yOffset)` body functions behind a shared `render240Frame` backend — the same contract the ILI9488 landscape path already ships (`renderLandscapeFrame` + `drawLandscape*`). Still renders into the full sprite; coordinates unchanged. Only deliberate delta: dashboard frames now clear wide-panel gutters like every other 240x240 view.
2. **cd3b79a — backend flip.** No-PSRAM boards hold no framebuffer; each frame renders through a transient 240x32 16-bit strip (15.4KB only while drawing). **~42KB returned permanently**, and ST7789/GC9A01/ILI9341 go from 256-colour to full 16-bit — removing the banding on the tinted spool image. PSRAM boards keep the persistent full 16-bit sprite (`_fullFrame`); if its allocation fails they fall back to strips instead of the old 8-bit internal full frame.

## Hardening from review (rounds 2–3)

3. **1d76869** — the transient strip is a member (`_strip`) so `freeForOTA()` can reclaim it; a dropped frame (strip alloc failure) no longer commits `_currentState`. Stale OTA comment and shared-SPI bench checklist refreshed.
4. **43b08ce** — OTA stops the render task **cooperatively**: it parks via `vTaskSuspend` at its loop top (bus guard released, no sprite in flight) and is deleted there, bounded 5s wait, forced delete only if wedged. Killing it mid-frame could strand the shared-SPI mutex — dead OTA screen, and dead NFC on C5/C6 after a failed OTA (pre-existing exposure, now closed). Landscape renderers report dropped frames like the portrait ones, and low-spool breathing arms only after the spool frame actually displayed.

## Verification

- All 6 envs (esp32dev / s3zero / c3 / s3devkitc / c6 / c5) + 7-suite native tests green after **every** commit
- Static review confirmed every converted Y coordinate shifts exactly once, no canvas-dimension reads in layout, band overhang at 224 clips safely on all four panel types, and the park/delete handshake is race-free on same-core scheduling (`INCLUDE_eTaskGetState=1` on all pinned targets)
- **Hardware gap:** needs a WROOM + TFT pass — bench boards all have PSRAM. Plan: field validation with the Discord reporter once this is on dev. PSRAM boards (S3-DevKitC) can bench-verify no regression + OTA flow.

#287 closes at release per repo convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for wide ILI9488 displays with centered content and cleared gutters.
  * Improved dashboard and screen rendering across full-frame and strip-based display modes.
  * Display rendering now reports failures to improve frame handling.

* **Bug Fixes**
  * Reduced memory usage on devices without PSRAM through transient strip rendering.
  * Display buffers are released before OTA downloads to provide more memory for updates.
  * Improved rendering cleanup and shutdown behavior during OTA operations.
  * Updated OTA progress and error rendering for reliable strip-based display operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->