### PR TITLE
feat(#293): PN5180 boot and BUSY-timeout lines in the web log

### DIFF
--- a/lib/PN5180/PN5180.cpp
+++ b/lib/PN5180/PN5180.cpp
@@ -590,6 +590,23 @@ status register contain information on the exception.
 // within one 50ms scan cycle.
 static volatile bool pn5180_busWedged = false;
 
+static PN5180::TimeoutLogSink pn5180_timeoutSink = nullptr;
+
+void PN5180::setTimeoutLogSink(TimeoutLogSink sink) {
+  pn5180_timeoutSink = sink;
+}
+
+// One line per handshake timeout, routed through the installed sink so the
+// application can mirror it into its web log (#293).
+static void logBusyTimeout(const char* phase) {
+  if (pn5180_timeoutSink) {
+    pn5180_timeoutSink(phase);
+  } else {
+    Serial.print("PN5180: TIMEOUT ");
+    Serial.println(phase);
+  }
+}
+
 void PN5180::clearBusWedged() {
   pn5180_busWedged = false;
 }
@@ -623,7 +640,7 @@ bool PN5180::transceiveCommand(uint8_t *sendBuffer, size_t sendBufferLen, uint8_
     unsigned long t = millis();
     while (LOW != digitalRead(PN5180_BUSY)) { // wait until busy is low
       if (millis() - t > 1000) {
-        Serial.println("PN5180: TIMEOUT BUSY-LOW pre-send");
+        logBusyTimeout("BUSY-LOW pre-send");
         pn5180_busWedged = true;
         return false;
       }
@@ -640,7 +657,7 @@ bool PN5180::transceiveCommand(uint8_t *sendBuffer, size_t sendBufferLen, uint8_
     unsigned long t = millis();
     while(HIGH != digitalRead(PN5180_BUSY)) {  // wait until BUSY is high
       if (millis() - t > 1000) {
-        Serial.println("PN5180: TIMEOUT BUSY-HIGH post-send");
+        logBusyTimeout("BUSY-HIGH post-send");
         digitalWrite(PN5180_NSS, HIGH);
         pn5180_busWedged = true;
         return false;
@@ -654,7 +671,7 @@ bool PN5180::transceiveCommand(uint8_t *sendBuffer, size_t sendBufferLen, uint8_
     unsigned long t = millis();
     while (LOW != digitalRead(PN5180_BUSY)) { // wait until BUSY is low
       if (millis() - t > 1000) {
-        Serial.println("PN5180: TIMEOUT BUSY-LOW post-send");
+        logBusyTimeout("BUSY-LOW post-send");
         pn5180_busWedged = true;
         return false;
       }
@@ -677,7 +694,7 @@ bool PN5180::transceiveCommand(uint8_t *sendBuffer, size_t sendBufferLen, uint8_
     unsigned long t = millis();
     while(HIGH != digitalRead(PN5180_BUSY)) {  // wait until BUSY is high
       if (millis() - t > 1000) {
-        Serial.println("PN5180: TIMEOUT BUSY-HIGH post-recv");
+        logBusyTimeout("BUSY-HIGH post-recv");
         pn5180_busWedged = true;
         digitalWrite(PN5180_NSS, HIGH);
         return false;
@@ -691,7 +708,7 @@ bool PN5180::transceiveCommand(uint8_t *sendBuffer, size_t sendBufferLen, uint8_
     unsigned long t = millis();
     while(LOW != digitalRead(PN5180_BUSY)) {  // wait until BUSY is low
       if (millis() - t > 1000) {
-        Serial.println("PN5180: TIMEOUT BUSY-LOW post-recv");
+        logBusyTimeout("BUSY-LOW post-recv");
         pn5180_busWedged = true;
         return false;
       }

--- a/lib/PN5180/PN5180.h
+++ b/lib/PN5180/PN5180.h
@@ -161,6 +161,15 @@ public:
   // Read the bus-wedged fail-fast latch state (for diagnostics).
   static bool isBusWedged();
 
+  // Sink for the BUSY-handshake timeout lines (the wedge-latch sites in
+  // transceiveCommand). The library stays application-agnostic: with no sink
+  // installed the lines go to Serial as before; the application may install
+  // one to mirror them elsewhere (e.g. a web log ring). The sink owns the
+  // whole line — the library does not also print. `phase` names the
+  // handshake, e.g. "BUSY-LOW pre-send".
+  typedef void (*TimeoutLogSink)(const char* phase);
+  static void setTimeoutLogSink(TimeoutLogSink sink);
+
 private:
   bool transceiveCommand(uint8_t *sendBuffer, size_t sendBufferLen, uint8_t *recvBuffer = 0, size_t recvBufferLen = 0);
 

--- a/lib/htcw_bits/LICENSE
+++ b/lib/htcw_bits/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 honey the codewitch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/htcw_bits/README.md
+++ b/lib/htcw_bits/README.md
@@ -1,0 +1,12 @@
+# bits
+
+A set of advanced bit manipulation routines
+
+```
+[env:node32s]
+platform = espressif32
+board = node32s
+framework = arduino
+lib_deps = 
+	codewitch-honey-crisis/htcw_bits@^1.0.4
+```

--- a/lib/htcw_bits/htcw_bits.h
+++ b/lib/htcw_bits/htcw_bits.h
@@ -1,0 +1,4 @@
+#ifndef HTCW_BITS_H
+#define HTCW_BITS_H
+#include "htcw_bits.hpp"
+#endif

--- a/lib/htcw_bits/htcw_bits.hpp
+++ b/lib/htcw_bits/htcw_bits.hpp
@@ -1,0 +1,638 @@
+#ifndef HTCW_BITS_HPP
+#define HTCW_BITS_HPP
+#include "htcw_endian.hpp"
+#define HTCW_PACKED __attribute__((packed))
+#define HTCW_PACK  // TODO: Add Microsoft pack pragmas here
+#define HTCW_RESTORE_PACK
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+namespace bits {
+constexpr size_t get_word_size(size_t size) {
+#if HTCW_MAX_WORD >= 64
+    if (size > 64) return 0;
+    if (size > 32) return 64;
+#else
+    if (size > 32) return 0;
+#endif
+
+    if (size > 16) return 32;
+    if (size > 8) return 16;
+    return 8;
+}
+
+constexpr size_t get_word_count(size_t size) {
+    size_t result = 0;
+    while (size > 0) {
+        size_t ws = get_word_size(size);
+        if (ws == 0)
+            break;
+        size -= ws;
+        ++result;
+    }
+    return result;
+}
+constexpr size_t get_left_word(size_t size, size_t index) {
+    size_t i = 0;
+    while (size > 0 && i <= index) {
+        size_t ws = get_word_size(size);
+        if (ws == 0)
+            return 0;
+        if (index == i)
+            return ws;
+        size -= ws;
+        ++i;
+    }
+    return 0;
+}
+constexpr size_t get_right_word(size_t size, size_t index) {
+    size_t c = get_word_count(size);
+    return get_left_word(size, c - index - 1);
+    size_t i = 0;
+    while (size > 0 && i <= index) {
+        size_t ws = get_word_size(size);
+        if (ws == 0)
+            return 0;
+        if (index == i)
+            return ws;
+        size -= ws;
+        ++i;
+    }
+    return 0;
+}
+namespace helpers {
+class dummy_unsigned {};
+class dummy_signed {};
+}  // namespace helpers
+template <size_t BitWidth>
+class int_helper {};
+template <>
+struct int_helper<8> {
+    using type = int8_t;
+};
+template <>
+struct int_helper<16> {
+    using type = int16_t;
+};
+template <>
+struct int_helper<32> {
+    using type = int32_t;
+};
+#if HTCW_MAX_WORD >= 64
+template <>
+struct int_helper<64> {
+    using type = int64_t;
+};
+template <size_t Width>
+using intx = typename int_helper<Width>::type;
+using int_max = typename int_helper<HTCW_MAX_WORD>::type;
+#endif
+template <size_t BitWidth>
+class uint_helper {};
+template <>
+struct uint_helper<8> {
+    using type = uint8_t;
+};
+template <>
+struct uint_helper<16> {
+    using type = uint16_t;
+};
+template <>
+struct uint_helper<32> {
+    using type = uint32_t;
+};
+#if HTCW_MAX_WORD >= 64
+template <>
+struct uint_helper<64> {
+    using type = uint64_t;
+};
+#endif
+template <size_t Width>
+using uintx = typename uint_helper<Width>::type;
+using uint_max = uint_helper<HTCW_MAX_WORD>::type;
+template <size_t BitWidth>
+class real_helper {};
+template <>
+struct real_helper<32> {
+    using type = float;
+};
+#if HTCW_MAX_WORD >= 64
+template <>
+struct real_helper<64> {
+    using type = double;
+};
+#endif
+template <size_t Width>
+using realx = typename real_helper<Width>::type;
+using real_max = typename real_helper<HTCW_MAX_WORD>::type;
+template <typename T>
+struct signed_helper {
+    using type = helpers::dummy_signed;
+};
+template <>
+struct signed_helper<float> {
+    using type = float;
+};
+template <>
+struct signed_helper<double> {
+    using type = double;
+};
+template <>
+struct signed_helper<int8_t> {
+    using type = int8_t;
+};
+template <>
+struct signed_helper<uint8_t> {
+    using type = int8_t;
+};
+template <>
+struct signed_helper<int16_t> {
+    using type = int16_t;
+};
+template <>
+struct signed_helper<uint16_t> {
+    using type = int16_t;
+};
+template <>
+struct signed_helper<int32_t> {
+    using type = int32_t;
+};
+template <>
+struct signed_helper<uint32_t> {
+    using type = int32_t;
+};
+#if HTCW_MAX_WORD >= 64
+template <>
+struct signed_helper<int64_t> {
+    using type = int64_t;
+};
+template <>
+struct signed_helper<uint64_t> {
+    using type = int64_t;
+};
+#endif
+template <typename T>
+struct signed_helper_no_real {
+    using type = helpers::dummy_signed;
+};
+template <>
+struct signed_helper_no_real<int8_t> {
+    using type = int8_t;
+};
+template <>
+struct signed_helper_no_real<uint8_t> {
+    using type = int8_t;
+};
+template <>
+struct signed_helper_no_real<int16_t> {
+    using type = int16_t;
+};
+template <>
+struct signed_helper_no_real<uint16_t> {
+    using type = int16_t;
+};
+template <>
+struct signed_helper_no_real<int32_t> {
+    using type = int32_t;
+};
+template <>
+struct signed_helper_no_real<uint32_t> {
+    using type = int32_t;
+};
+#if HTCW_MAX_WORD >= 64
+template <>
+struct signed_helper_no_real<int64_t> {
+    using type = int64_t;
+};
+template <>
+struct signed_helper_no_real<uint64_t> {
+    using type = int64_t;
+};
+#endif
+
+template <typename T>
+using signedx = typename signed_helper<T>::type;
+template <typename T>
+using signedx_no_real = typename signed_helper_no_real<T>::type;
+
+template <typename T>
+struct unsigned_helper {
+    using type = helpers::dummy_unsigned;
+};
+// template <> struct unsigned_helper<float> { using type = float; };
+// template <> struct unsigned_helper<double> { using type = double; };
+template <>
+struct unsigned_helper<int8_t> {
+    using type = uint8_t;
+};
+template <>
+struct unsigned_helper<uint8_t> {
+    using type = uint8_t;
+};
+template <>
+struct unsigned_helper<int16_t> {
+    using type = uint16_t;
+};
+template <>
+struct unsigned_helper<uint16_t> {
+    using type = uint16_t;
+};
+template <>
+struct unsigned_helper<int32_t> {
+    using type = uint32_t;
+};
+template <>
+struct unsigned_helper<uint32_t> {
+    using type = uint32_t;
+};
+#if HTCW_MAX_WORD >= 64
+template <>
+struct unsigned_helper<int64_t> {
+    using type = uint64_t;
+};
+template <>
+struct unsigned_helper<uint64_t> {
+    using type = uint64_t;
+};
+#endif
+template <typename T>
+using unsignedx = typename unsigned_helper<T>::type;
+
+template <typename T>
+struct num_metrics {
+    constexpr static const unsignedx<T> bit_mask = unsignedx<T>(~unsignedx<T>(0));
+    constexpr static const bool is_signed = bool(T(-1) < T(0));
+    constexpr static const T max = is_signed ? T(unsignedx<T>(unsignedx<T>(bit_mask << 1) >> 1)) : T(~T(0));
+    constexpr static const T min = is_signed ? ~max : T(0);
+    constexpr static const T zero = 0;
+};
+#if defined(NAN) && defined(INFINITIY)
+template <>
+struct num_metrics<float> {
+    constexpr static const float bit_mask = NAN;
+    constexpr static const bool is_signed = true;
+    constexpr static const float max = INFINITY;
+    constexpr static const float min = -INFINITY;
+    constexpr static const float zero = 0.0;
+};
+template <>
+struct num_metrics<double> {
+    constexpr static const double bit_mask = NAN;
+    constexpr static const bool is_signed = true;
+    constexpr static const double max = INFINITY;
+    constexpr static const double min = -INFINITY;
+    constexpr static const double zero = 0.0;
+};
+#endif
+template <size_t Width>
+struct mask {
+    using int_type = uintx<get_word_size(Width)>;
+
+   private:
+    constexpr static const int_type int_mask = ~int_type(0);
+
+   public:
+    constexpr static const int_type left = int_mask << ((sizeof(int_type) * 8 - Width) & int_mask);
+    constexpr static const int_type right = int_mask >> (sizeof(int_type) * 8 - Width);
+    constexpr static const int_type not_left = ~left;
+    constexpr static const int_type not_right = ~right;
+};
+
+constexpr inline static void set_bits(void* bits, size_t offset_bits, size_t size_bits, bool value) {
+    const size_t offset_bytes = offset_bits / 8;
+    const size_t offset = offset_bits % 8;
+    const size_t total_size_bytes = (offset_bits + size_bits + 7) / 8;
+    const size_t overhang = (offset_bits + size_bits) % 8;
+    uint8_t* pbegin = ((uint8_t*)bits) + offset_bytes;
+    uint8_t* pend = ((uint8_t*)bits) + total_size_bytes;
+    uint8_t* plast = pend - (pbegin != pend);
+
+    const uint8_t maskL = 0 != offset ? (uint8_t)((uint8_t(0xFF >> offset))) : uint8_t(0xff);
+    const uint8_t maskR = 0 != overhang ? (uint8_t) ~((uint8_t(0xFF >> overhang))) : uint8_t(0xFF);
+    if (value) {
+        if (pbegin == plast) {
+            const uint8_t mask = maskL & maskR;
+            *pbegin |= mask;
+            return;
+        }
+        *pbegin |= maskL;
+        *plast |= maskR;
+        if (pbegin + 1 < plast) {
+            const size_t len = (plast) - (pbegin + 1);
+            if (0 != len && len <= total_size_bytes)
+                memset(pbegin + 1, 0xFF, len);
+        }
+    } else {
+        if (pbegin == plast) {
+            const uint8_t mask = maskL & maskR;
+            *pbegin &= ~mask;
+            return;
+        }
+        *pbegin &= ~maskL;
+        *plast &= ~maskR;
+
+        if (pbegin + 1 < plast) {
+            const size_t len = (plast) - (pbegin + 1);
+            if (0 != len && len <= total_size_bytes)
+                memset(pbegin + 1, 0, len);
+        }
+    }
+}
+
+template <size_t OffsetBits, size_t SizeBits, bool Value>
+constexpr inline static void set_bits(void* bits) {
+    if (0 == SizeBits)
+        return;
+    const size_t offset_bytes = OffsetBits / 8;
+    const size_t offset = OffsetBits % 8;
+    const size_t total_size_bytes = (OffsetBits + SizeBits + 7) / 8;
+    const size_t overhang = (OffsetBits + SizeBits) % 8;
+    uint8_t* pbegin = ((uint8_t*)bits) + offset_bytes;
+    uint8_t* pend = ((uint8_t*)bits) + total_size_bytes;
+    uint8_t* plast = pend - (pbegin != pend);
+
+    const uint8_t maskL = 0 != offset ? (uint8_t)((uint8_t(0xFF >> offset))) : uint8_t(0xff);
+    const uint8_t maskR = 0 != overhang ? (uint8_t) ~((uint8_t(0xFF >> overhang))) : uint8_t(0xFF);
+    if (Value) {
+        if (pbegin == plast) {
+            const uint8_t mask = maskL & maskR;
+            *pbegin |= mask;
+            return;
+        }
+        *pbegin |= maskL;
+        *plast |= maskR;
+        if (pbegin + 1 < plast) {
+            const size_t len = (plast) - (pbegin + 1);
+            if (0 != len && len <= total_size_bytes)
+                memset(pbegin + 1, 0xFF, len);
+        }
+    } else {
+        if (pbegin == plast) {
+            const uint8_t mask = maskL & maskR;
+            *pbegin &= ~mask;
+            return;
+        }
+        *pbegin &= ~maskL;
+        *plast &= ~maskR;
+
+        if (pbegin + 1 < plast) {
+            const size_t len = (plast) - (pbegin + 1);
+            if (0 != len && len <= total_size_bytes)
+                memset(pbegin + 1, 0, len);
+        }
+    }
+}
+constexpr inline static void set_bits(size_t offset_bits, size_t size_bits, void* dst, const void* src) {
+    const size_t offset_bytes = offset_bits / 8;
+    const size_t offset = offset_bits % 8;
+    const size_t total_size_bytes = (offset_bits + size_bits + 7) / 8;
+    const size_t overhang = (offset_bits + size_bits) % 8;
+    uint8_t* pbegin = ((uint8_t*)dst) + offset_bytes;
+    uint8_t* psbegin = ((uint8_t*)src) + offset_bytes;
+    uint8_t* pend = ((uint8_t*)dst) + total_size_bytes;
+    uint8_t* plast = pend - (pbegin != pend);
+
+    const uint8_t maskL = 0 != offset ? (uint8_t)((uint8_t(0xFF >> offset))) : uint8_t(0xff);
+    const uint8_t maskR = 0 != overhang ? (uint8_t) ~((uint8_t(0xFF >> overhang))) : uint8_t(0xFF);
+    if (pbegin == plast) {
+        uint8_t v = *psbegin;
+        const uint8_t mask = maskL & maskR;
+        v &= mask;
+        *pbegin &= ~mask;
+        *pbegin |= v;
+        return;
+    }
+    *pbegin &= ~maskL;
+    *pbegin |= ((*psbegin) & maskL);
+    *plast &= ~maskR;
+    *plast |= ((*(psbegin + total_size_bytes - 1)) & maskR);
+    if (pbegin + 1 < plast) {
+        const size_t len = plast - (pbegin + 1);
+        if (0 != len && len <= total_size_bytes)
+            memcpy(pbegin + 1, psbegin + 1, len);
+    }
+}
+template <size_t OffsetBits, size_t SizeBits>
+constexpr inline static void set_bits(void* dst, const void* src) {
+    const size_t offset_bytes = OffsetBits / 8;
+    const size_t offset = OffsetBits % 8;
+    const size_t total_size_bytes = (OffsetBits + SizeBits + 7) / 8;
+    const size_t overhang = (OffsetBits + SizeBits) % 8;
+    uint8_t* pbegin = ((uint8_t*)dst) + offset_bytes;
+    uint8_t* psbegin = ((uint8_t*)src) + offset_bytes;
+    uint8_t* pend = ((uint8_t*)dst) + total_size_bytes;
+    uint8_t* plast = pend - (pbegin != pend);
+    uint8_t* pslast = psbegin + total_size_bytes - 1;
+    const uint8_t maskL = 0 != offset ? (uint8_t)((uint8_t(0xFF >> offset))) : uint8_t(0xff);
+    const uint8_t maskR = 0 != overhang ? (uint8_t) ~((uint8_t(0xFF >> overhang))) : uint8_t(0xFF);
+    if (pbegin == plast) {
+        uint8_t v = *psbegin;
+        const uint8_t mask = maskL & maskR;
+        v &= mask;
+        *pbegin = (*pbegin & uint8_t(~mask)) | v;
+        return;
+    }
+    *pbegin = (*pbegin & ~maskL) | ((*psbegin) & maskL);
+
+    *plast = (*plast & ~maskR) | ((*pslast) & maskR);
+    if (pbegin + 1 < plast) {
+        const size_t len = plast - (pbegin + 1);
+        if (0 != len && len <= total_size_bytes)
+            memcpy(pbegin + 1, psbegin + 1, len);
+    }
+}
+
+template <size_t OffsetBits, size_t SizeBits, size_t Shift>
+constexpr inline static void shift_left(void* bits) {
+    if (nullptr == bits || 0 == SizeBits || 0 == Shift) {
+        return;
+    }
+    // special case if we shift all the bits out
+    if (Shift >= SizeBits) {
+        set_bits<OffsetBits, SizeBits, false>(bits);
+        return;
+    }
+    uint8_t* pbegin = ((uint8_t*)bits) + (OffsetBits / 8);
+    const size_t offset = OffsetBits % 8;
+    const size_t shift_bytes = Shift / 8;
+    const size_t shift_bits = Shift % 8;
+    const size_t overhang = (SizeBits + OffsetBits) % 8;
+    // preserves left prior to offset
+    const uint8_t left_mask = ((uint8_t)uint8_t(0xFF << (8 - offset)));
+    // preserves right after overhang
+    const uint8_t right_mask = 0 != overhang ? uint8_t(0xFF >> overhang) : 0;
+    uint8_t* pend = pbegin + (size_t)((OffsetBits + SizeBits + 7) / 8);
+    uint8_t* plast = pend - 1;
+    uint8_t* psrc = pbegin + shift_bytes;
+    uint8_t* pdst = pbegin;
+    if (pbegin + 1 == pend) {
+        // special case for a shift all within one byte
+        uint8_t save_mask = left_mask | right_mask;
+        uint8_t tmp = *pbegin;
+        *pbegin = uint8_t(uint8_t(tmp << shift_bits) & ~save_mask) |
+                  uint8_t(tmp & save_mask);
+        return;
+    }
+    // preserve the ends so we can
+    // fix them up later
+    uint8_t left = *pbegin;
+    uint8_t right = *(pend - 1);
+
+    while (pdst != pend) {
+        uint8_t src = psrc < pend ? *psrc : 0;
+        uint8_t src2 = (psrc + 1) < pend ? *(psrc + 1) : 0;
+        *pdst = (src << shift_bits) | (src2 >> (8 - shift_bits));
+        ++psrc;
+        ++pdst;
+    }
+
+    *pbegin = (left & left_mask) | uint8_t(*pbegin & ~left_mask);
+    --pend;
+    *plast = uint8_t(right & right_mask) | uint8_t(*plast & uint8_t(~right_mask));
+};
+
+constexpr static void shift_left(void* bits, size_t offset_bits, size_t size_bits, size_t shift) {
+    if (nullptr == bits || 0 == size_bits || 0 == shift) {
+        return;
+    }
+    // special case if we shift all the bits out
+    if (shift >= size_bits) {
+        set_bits(bits, offset_bits, size_bits, false);
+        return;
+    }
+    uint8_t* pbegin = ((uint8_t*)bits) + (offset_bits / 8);
+    const size_t offset = offset_bits % 8;
+    const size_t shift_bytes = shift / 8;
+    const size_t shift_bits = shift % 8;
+    const size_t overhang = (size_bits + offset_bits) % 8;
+    // preserves left prior to offset
+    const uint8_t left_mask = ((uint8_t)uint8_t(0xFF << (8 - offset)));
+    // preserves right after overhang
+    const uint8_t right_mask = 0 != overhang ? uint8_t(0xFF >> overhang) : 0;
+    uint8_t* pend = pbegin + (size_t)((offset_bits + size_bits + 7) / 8);
+    uint8_t* plast = pend - 1;
+    uint8_t* psrc = pbegin + shift_bytes;
+    uint8_t* pdst = pbegin;
+    if (pbegin + 1 == pend) {
+        // special case for a shift all within one byte
+        uint8_t save_mask = left_mask | right_mask;
+        uint8_t tmp = *pbegin;
+        *pbegin = uint8_t(uint8_t(tmp << shift_bits) & ~save_mask) |
+                  uint8_t(tmp & save_mask);
+        return;
+    }
+    // preserve the ends so we can
+    // fix them up later
+    uint8_t left = *pbegin;
+    uint8_t right = *(pend - 1);
+
+    while (pdst != pend) {
+        uint8_t src = psrc < pend ? *psrc : 0;
+        uint8_t src2 = (psrc + 1) < pend ? *(psrc + 1) : 0;
+        *pdst = (src << shift_bits) | (src2 >> (8 - shift_bits));
+        ++psrc;
+        ++pdst;
+    }
+
+    *pbegin = (left & left_mask) | uint8_t(*pbegin & ~left_mask);
+    --pend;
+    *plast = uint8_t(right & right_mask) | uint8_t(*plast & uint8_t(~right_mask));
+};
+
+template <size_t OffsetBits, size_t SizeBits, size_t Shift>
+constexpr inline static void shift_right(void* bits) {
+    if (nullptr == bits || 0 == SizeBits || 0 == Shift) {
+        return;
+    }
+    // special case if we shift all the bits out
+    if (Shift >= SizeBits) {
+        set_bits<OffsetBits, SizeBits, false>(bits);
+        return;
+    }
+    uint8_t* pbegin = ((uint8_t*)bits) + (OffsetBits / 8);
+    const size_t offset = OffsetBits % 8;
+    const size_t shift_bytes = Shift / 8;
+    const size_t shift_bits = Shift % 8;
+    const size_t overhang = (SizeBits + OffsetBits) % 8;
+    // preserves left prior to offset
+    const uint8_t left_mask = ((uint8_t)uint8_t(0xFF << (8 - offset)));
+    // preserves right after overhang
+    const uint8_t right_mask = 0 != overhang ? uint8_t(0xFF >> overhang) : 0;
+    uint8_t* pend = pbegin + (size_t)((OffsetBits + SizeBits + 7) / 8) - (OffsetBits / 8);
+    uint8_t* plast = pend - 1;
+    uint8_t* psrc = (pend - 1) - shift_bytes;
+    uint8_t* pdst = pend - 1;
+    if (pbegin + 1 == pend) {
+        // special case for a shift all within one byte
+        uint8_t save_mask = left_mask | right_mask;
+        uint8_t tmp = *pbegin;
+        *pbegin = uint8_t(uint8_t(tmp >> shift_bits) & ~save_mask) |
+                  uint8_t(tmp & save_mask);
+        return;
+    }
+    // preserve the ends so we can
+    // fix them up later
+    uint8_t left = *pbegin;
+    uint8_t right = *psrc;
+
+    while (pdst >= pbegin) {
+        uint8_t src = psrc >= pbegin ? *psrc : 0;
+        uint8_t src2 = (psrc - 1) >= pbegin ? *(psrc - 1) : 0;
+        *pdst = (src >> shift_bits) | (src2 << (8 - shift_bits));
+        --psrc;
+        --pdst;
+    }
+
+    *pbegin = uint8_t(left & left_mask) | uint8_t(*pbegin & ~left_mask);
+    *plast = uint8_t(right & right_mask) | uint8_t(*plast & uint8_t(~right_mask));
+};
+constexpr static void shift_right(void* bits, size_t offset_bits, size_t size_bits, size_t shift) {
+    if (nullptr == bits || 0 == size_bits || 0 == shift) {
+        return;
+    }
+    // special case if we shift all the bits out
+    if (shift >= size_bits) {
+        set_bits(bits, offset_bits, size_bits, false);
+        return;
+    }
+    uint8_t* pbegin = ((uint8_t*)bits) + (offset_bits / 8);
+    const size_t offset = offset_bits % 8;
+    const size_t shift_bytes = shift / 8;
+    const size_t shift_bits = shift % 8;
+    const size_t overhang = (size_bits + offset_bits) % 8;
+    // preserves left prior to offset
+    const uint8_t left_mask = ((uint8_t)uint8_t(0xFF << (8 - offset)));
+    // preserves right after overhang
+    const uint8_t right_mask = 0 != overhang ? uint8_t(0xFF >> overhang) : 0;
+    uint8_t* pend = pbegin + (size_t)((offset_bits + size_bits + 7) / 8) - (offset_bits / 8);
+    uint8_t* plast = pend - 1;
+    uint8_t* psrc = (pend - 1) - shift_bytes;
+    uint8_t* pdst = pend - 1;
+    if (pbegin + 1 == pend) {
+        // special case for a shift all within one byte
+        uint8_t save_mask = left_mask | right_mask;
+        uint8_t tmp = *pbegin;
+        *pbegin = uint8_t(uint8_t(tmp >> shift_bits) & ~save_mask) |
+                  uint8_t(tmp & save_mask);
+        return;
+    }
+    // preserve the ends so we can
+    // fix them up later
+    uint8_t left = *pbegin;
+    uint8_t right = *psrc;
+
+    while (pdst >= pbegin) {
+        uint8_t src = psrc >= pbegin ? *psrc : 0;
+        uint8_t src2 = (psrc - 1) >= pbegin ? *(psrc - 1) : 0;
+        *pdst = (src >> shift_bits) | (src2 << (8 - shift_bits));
+        --psrc;
+        --pdst;
+    }
+
+    *pbegin = uint8_t(left & left_mask) | uint8_t(*pbegin & ~left_mask);
+    *plast = uint8_t(right & right_mask) | uint8_t(*plast & uint8_t(~right_mask));
+};
+}  // namespace bits
+#endif

--- a/lib/htcw_bits/htcw_endian.h
+++ b/lib/htcw_bits/htcw_endian.h
@@ -1,0 +1,4 @@
+#ifndef HTCW_ENDIAN_H
+#define HTCW_ENDIAN_H
+#include "htcw_endian.hpp"
+#endif

--- a/lib/htcw_bits/htcw_endian.hpp
+++ b/lib/htcw_bits/htcw_endian.hpp
@@ -1,0 +1,194 @@
+#ifndef HTCW_ENDIAN_HPP
+#define HTCW_ENDIAN_HPP
+#include <stddef.h>
+#include <stdint.h>
+#ifndef HTCW_MAX_WORD
+#define HTCW_MAX_WORD 64
+#endif
+#if !defined(HTCW_LITTLE_ENDIAN) && !defined(HTCW_BIG_ENDIAN)
+#ifdef ARDUINO_ARCH_STM32
+#define HTCW_LITTLE_ENDIAN
+#endif
+#if defined(ARDUINO_ARDUINO_NANO33BLE) || defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
+#define HTCW_LITTLE_ENDIAN
+#endif
+#if defined(ARDUINO_ARCH_SAMD) && defined(SEEED_GROVE_UI_WIRELESS)
+#define HTCW_LITTLE_ENDIAN
+#endif
+#if defined(ARDUINO_ARCH_AVR)
+#define HTCW_LITTLE_ENDIAN
+#endif
+#if defined(ARDUINO_ARCH_ESP8266)
+#define HTCW_LITTLE_ENDIAN
+#endif
+#if defined(ARDUINO_ARCH_ESP32)
+#define HTCW_LITTLE_ENDIAN
+#endif
+#endif
+#if !defined(HTCW_LITTLE_ENDIAN) && !defined(HTCW_BIG_ENDIAN)
+#ifdef ESP_PLATFORM
+#define HTCW_LITTLE_ENDIAN
+#endif
+#ifdef _WIN32_WINNT
+#define HTCW_LITTLE_ENDIAN
+#endif
+#endif
+#if !defined(HTCW_LITTLE_ENDIAN) && !defined(HTCW_BIG_ENDIAN) && defined(__arm__)
+#define HTCW_LITTLE_ENDIAN
+#endif
+#if !defined(HTCW_LITTLE_ENDIAN) && !defined(HTCW_BIG_ENDIAN) && defined(_M_X64)
+#define HTCW_LITTLE_ENDIAN
+#endif
+namespace bits {
+enum struct endian_mode {
+    none = 0,
+    big_endian = 1,
+    little_endian = 2
+};
+// true if the platform is little endian
+constexpr static endian_mode endianness() {
+#ifdef HTCW_BIG_ENDIAN
+    return endian_mode::big_endian;
+#else //if defined(HTCW_LITTLE_ENDIAN)
+    return endian_mode::little_endian;
+#endif
+}
+// swaps byte order
+constexpr static inline uint16_t swap(uint16_t value) {
+    return ((value & 0xFF00) >> 8) | ((value & 0x00FF) << 8);
+}
+// swaps byte order
+constexpr static inline uint32_t swap(uint32_t value) {
+#if defined(__llvm__) || (defined(__GNUC__) && !defined(__ICC))
+    return __builtin_bswap32(value);
+#else
+    return ((value >> 24) & 0xff) |       // move byte 3 to byte 0
+           ((value << 8) & 0xff0000) |    // move byte 1 to byte 2
+           ((value >> 8) & 0xff00) |      // move byte 2 to byte 1
+           ((value << 24) & 0xff000000);  // byte 0 to byte 3
+#endif
+}
+#if HTCW_MAX_WORD >= 64
+// swaps byte order
+constexpr static inline uint64_t swap(uint64_t value) {
+#if defined(__llvm__) || (defined(__GNUC__) && !defined(__ICC))
+    return __builtin_bswap64(value);
+#else
+    uint64_t x = (uint64_t)value;
+    x = (x & 0x00000000FFFFFFFF) << 32 | (x & 0xFFFFFFFF00000000) >> 32;
+    x = (x & 0x0000FFFF0000FFFF) << 16 | (x & 0xFFFF0000FFFF0000) >> 16;
+    x = (x & 0x00FF00FF00FF00FF) << 8 | (x & 0xFF00FF00FF00FF00) >> 8;
+    return x;
+#endif
+#endif
+}
+// swaps byte order (no-op to resolve ambiguous overload)
+constexpr static inline uint8_t swap(uint8_t value) {
+    return value;
+}
+
+// swaps byte order
+constexpr static inline int16_t swap(int16_t value) {
+    return (int16_t)swap(uint16_t(value));
+}
+// swaps byte order
+constexpr static inline int32_t swap(int32_t value) {
+    return (int32_t)swap(uint32_t(value));
+}
+#if HTCW_MAX_WORD >= 64
+// swaps byte order
+constexpr static inline int64_t swap(int64_t value) {
+    return (int64_t)swap(uint64_t(value));
+}
+#endif
+
+// swaps byte order (no-op to resolve ambiguous overload)
+constexpr static inline int8_t swap(int8_t value) {
+    return value;
+}
+
+template <size_t SizeBytes>
+constexpr static inline void swap_inline(void* data) {
+    switch (SizeBytes) {
+        case 0:
+        case 1:
+            return;
+        case 2:
+            *((uint16_t*)data) = swap(*(uint16_t*)data);
+            return;
+        case 4:
+            *((uint32_t*)data) = swap(*(uint32_t*)data);
+            return;
+#if HTCW_MAX_WORD >= 64
+        case 8:
+            *((uint64_t*)data) = swap(*(uint64_t*)data);
+            return;
+#endif
+    }
+    for (size_t low = 0, high = SizeBytes - 1; low < high; low++, high--) {
+        size_t tmp = ((uint8_t*)data)[low];
+        ((uint8_t*)data)[low] = ((uint8_t*)data)[high];
+        ((uint8_t*)data)[high] = tmp;
+    }
+}
+constexpr static inline uint16_t from_le(uint16_t value) {
+    return endianness() == endian_mode::big_endian ? swap(value) : value;
+}
+constexpr static inline uint32_t from_le(uint32_t value) {
+    return endianness() == endian_mode::big_endian ? swap(value) : value;
+}
+#if HTCW_MAX_WORD >= 64
+constexpr static inline uint64_t from_le(uint64_t value) {
+    return endianness() == endian_mode::big_endian ? swap(value) : value;
+}
+#endif
+constexpr static inline uint8_t from_le(uint8_t value) {
+    return value;
+}
+
+constexpr static inline uint16_t from_be(uint16_t value) {
+    return endianness() == endian_mode::little_endian ? swap(value) : value;
+}
+constexpr static inline uint32_t from_be(uint32_t value) {
+    return endianness() == endian_mode::little_endian ? swap(value) : value;
+}
+#if HTCW_MAX_WORD >= 64
+constexpr static inline uint64_t from_be(uint64_t value) {
+    return endianness() == endian_mode::little_endian ? swap(value) : value;
+}
+#endif
+constexpr static inline uint8_t from_be(uint8_t value) {
+    return value;
+}
+
+constexpr static inline int16_t from_le(int16_t value) {
+    return endianness() == endian_mode::big_endian ? swap(value) : value;
+}
+constexpr static inline int32_t from_le(int32_t value) {
+    return endianness() == endian_mode::big_endian ? swap(value) : value;
+}
+#if HTCW_MAX_WORD >= 64
+constexpr static inline int64_t from_le(int64_t value) {
+    return endianness() == endian_mode::big_endian ? swap(value) : value;
+}
+#endif
+constexpr static inline int8_t from_le(int8_t value) {
+    return value;
+}
+
+constexpr static inline int16_t from_be(int16_t value) {
+    return endianness() == endian_mode::little_endian ? swap(value) : value;
+}
+constexpr static inline int32_t from_be(int32_t value) {
+    return endianness() == endian_mode::little_endian ? swap(value) : value;
+}
+#if HTCW_MAX_WORD >= 64
+constexpr static inline int64_t from_be(int64_t value) {
+    return endianness() == endian_mode::little_endian ? swap(value) : value;
+}
+#endif
+constexpr static inline int8_t from_be(int8_t value) {
+    return value;
+}
+}  // namespace bits
+#endif  // HTCW_ENDIAN_HPP

--- a/lib/htcw_bits/library.json
+++ b/lib/htcw_bits/library.json
@@ -1,0 +1,22 @@
+{
+    "name": "htcw_bits",
+    "version": "1.0.17",
+    "description": "Provides advanced bit manipulation",
+    "keywords": ["bits","binary","data"],
+    "authors": {
+        "name":"honey the codewitch",
+        "homepage": "https://www.codeproject.com/Members/code-witch"
+    },
+    "license": "MIT",
+    "frameworks": "*",
+    "platforms": "*",
+    "build": {
+        "unflags": "-std=gnu++11",
+        "flags": "-std=gnu++14"
+    },
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/codewitch-honey-crisis/htcw_bits.git"
+    }
+}

--- a/lib/htcw_io/LICENSE
+++ b/lib/htcw_io/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 honey the codewitch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/htcw_io/README.md
+++ b/lib/htcw_io/README.md
@@ -1,0 +1,12 @@
+# io
+
+A set of io classes in C++
+
+```
+[env:node32s]
+platform = espressif32
+board = node32s
+framework = arduino
+lib_deps = 
+	codewitch-honey-crisis/htcw_io@^1.1.4
+```

--- a/lib/htcw_io/library.json
+++ b/lib/htcw_io/library.json
@@ -1,0 +1,24 @@
+{
+    "name": "htcw_io",
+    "version": "1.4.1",
+    "description": "Provides io classes",
+    "keywords": [
+        "stream",
+        "io"
+    ],
+    "authors": {
+        "name": "honey the codewitch",
+        "homepage": "https://www.codeproject.com/Members/code-witch"
+    },
+    "license": "MIT",
+    "frameworks": "*",
+    "platforms": "*",
+    "build": {
+        "unflags": "-std=gnu++11",
+        "flags": "-std=gnu++14"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codewitch-honey-crisis/htcw_io.git"
+    }
+}

--- a/lib/htcw_io/src/htcw_io.h
+++ b/lib/htcw_io/src/htcw_io.h
@@ -1,0 +1,5 @@
+#ifndef HTCW_IO_H
+#define HTCW_IO_H
+#include "io_stream.h"
+#include "io_lex_source.h"
+#endif

--- a/lib/htcw_io/src/io_lex_source.h
+++ b/lib/htcw_io/src/io_lex_source.h
@@ -1,0 +1,4 @@
+#ifndef IO_LEX_SOURCE_H
+#define IO_LEX_SOURCE_H
+#include "io_lex_source.hpp"
+#endif

--- a/lib/htcw_io/src/io_lex_source.hpp
+++ b/lib/htcw_io/src/io_lex_source.hpp
@@ -1,0 +1,354 @@
+#ifndef HTCW_LEX_SOURCE_HPP
+#define HTCW_LEX_SOURCE_HPP
+#include "io_stream.hpp"
+namespace io {
+    template<size_t Capacity> class lex_source {
+        static_assert(Capacity>4,"The capacity must be at least 5.");
+        int m_state;
+        int32_t m_current;
+        unsigned long long m_position;
+        char m_capture[Capacity];
+        size_t m_capture_size;
+        bool (*m_capture_flush)(const char*,size_t,void*);
+        void* m_capture_flush_state;
+        stream* m_stream;
+    public:
+        static const int8_t io_error = -3;
+        static const int8_t out_of_memory_error=-4;
+    private:
+        lex_source(lex_source& rhs) = delete;
+        lex_source& operator=(lex_source& rhs) = delete;
+        
+        const int8_t initial = -5;
+        bool advance_impl() {
+            int16_t ch;
+            int16_t i = read();
+            if(0>i) {
+                m_state = i;
+                m_current = 0;
+                return false;
+            }
+            m_current = i;
+            m_state = 0;
+            
+            ++m_position;
+            if(m_current<128) {    
+                return -1<m_state;
+            }
+            
+            if (0xf0 == (0xf8 & m_current)) {
+                // 4 byte utf8 codepoint
+                m_current = (0x07 & m_current) << 18;
+                ch = read();
+                if(end_of_input==ch||closed==ch||io_error==ch) {
+                    m_state = io_error;
+                    return false;
+                }
+                m_current |= (0x3f & ch) << 12;
+                ch = read();
+                if(end_of_input==ch||closed==ch||io_error==ch) {
+                    m_state = io_error;
+                    return false;
+                }
+                m_current |= (0x3f & ch) << 6;
+                ch = read();
+                if(end_of_input==ch||closed==ch||io_error==ch) {
+                    m_state = io_error;
+                    return false;
+                }
+                m_current |= 0x3f & ch;
+                ++m_position;
+                return true;
+            }
+            if (0xe0 == (0xf0 & m_current)) {
+                // 3 byte utf8 codepoint
+                m_current = (0x0f & m_current) << 12;
+                ch = read();
+                if(end_of_input==ch||closed==ch||io_error==ch) {
+                    m_state = io_error;
+                    return false;
+                }
+                m_current |= (0x3f & ch) << 6;
+                ch = read();
+                if(end_of_input==ch||closed==ch||io_error==ch) {
+                    m_state = io_error;
+                    return false;
+                }
+                m_current |= 0x3f & ch;
+                ++m_position;
+                return true;
+            }
+            // 2 byte utf8 codepoint
+            m_current = (0x1f & m_current) << 6;
+            ch = read();
+            if(end_of_input==ch||closed==ch||io_error==ch) {
+                m_state = io_error;
+                return false;
+            }
+            m_current |= 0x3f & ch;
+            ++m_position;
+            return true;
+        }
+        static const int8_t end_of_input=-1;
+        static const int8_t closed=-2;
+        inline int read() {
+            if(nullptr==m_stream) {
+                return closed;
+            }
+            int result = m_stream->getch();
+            if(-1==result)
+                return end_of_input;
+            return result;
+        }
+        
+        bool skip_to_any(const char* characters7bit,unsigned long long& position,int16_t& match,int8_t& error) {
+            error = 0;
+            const char *sz;
+            if(current()>-1&&current()<128) {
+                match=(int16_t)current();
+                sz = strchr(characters7bit,match);
+                if(nullptr!=sz) {
+                    match=*sz;
+                    return true;
+                }
+            }
+            while(-1<(match=read())) {
+                ++position;
+                if(match>127)
+                    continue;
+                sz = strchr(characters7bit,(char)match);
+                if(nullptr!=sz) {
+                    match=*sz;
+                    return true;
+                }
+            
+            }
+            error = match;
+            return false;
+        }
+        bool append_capture(char ch) {
+             char*sz = m_capture+(m_capture_size++);
+            *(sz++)=ch;
+            *sz=0;
+            return true;
+        }
+        void clear_error() {
+            m_state = 0;
+        }
+        
+    public:
+        inline lex_source(stream* input) : m_capture_flush(nullptr) {
+            m_stream = input;
+            reset();
+        }
+        lex_source(lex_source&& rhs) :
+            m_state(rhs.m_state),
+            m_current(rhs.m_current),
+            m_position(rhs.m_position),
+            m_capture_size(rhs.m_capture_size),
+            m_capture_flush(rhs.m_capture_flush),
+            m_capture_flush_state(rhs.m_capture_flush_state),
+            m_stream(rhs.m_stream) {
+            memcpy(m_capture,rhs.m_capture,rhs.m_capture_size+1);
+            rhs.m_stream = nullptr;
+        }
+        lex_source& operator=(lex_source&& rhs) {
+            m_state=rhs.m_state;
+            m_current=rhs.m_current;
+            m_position=rhs.m_position;
+            memcpy(m_capture,rhs.m_capture,rhs.m_capture_size+1);
+            m_capture_size=rhs.m_capture_size;
+            m_capture_flush = rhs.m_capture_flush;
+            m_capture_flush_state = rhs.m_capture_flush_state;
+            m_stream=rhs.m_stream;
+            rhs.m_stream = nullptr;
+            return *this;
+        }
+        inline static bool is_whitespace(uint32_t codepoint) {
+            return ((codepoint>=9 && codepoint<=13) ||
+                codepoint==32 ||
+                codepoint==133 ||
+                codepoint==160 ||
+                codepoint==5760 ||
+                (codepoint>=8192 && codepoint<=8202) ||
+                codepoint==8232 ||
+                codepoint==8233 ||
+                codepoint==8239 ||
+                codepoint==8287 ||
+                codepoint==1288);
+        }
+        inline char* capture_buffer() {
+            return m_capture;
+        }
+        inline const char* const_capture_buffer() const {
+            return m_capture;
+        }
+        inline size_t capture_capacity()  const {return Capacity - 1;}
+        inline size_t capture_size() const {return m_capture_size;}
+        bool capture_fill(char* utf8) {
+            char*sz = capture_buffer();
+            while(0!=*sz) ++sz;
+            size_t free_len = capture_capacity()-capture_size();
+            size_t len = strlen(utf8);
+            if(free_len<=len) return false;
+            memcpy(sz,utf8,len+1);
+            m_capture_size+=len;
+            return true;
+        }
+        void clear_capture() {
+            m_capture_size=0;
+            *m_capture=0;
+            // clear out of memory errors
+            if(out_of_memory_error==error())
+                clear_error();
+        }
+        bool flush_capture() {
+            if(m_capture_flush!=nullptr) {
+                if(!m_capture_flush(m_capture,m_capture_size,m_capture_flush_state)) {
+                    m_current = io_error;
+                    return false;
+                }
+                clear_capture();
+                return true;
+            }
+            return false;
+        }
+        void set_flush_capture(bool(*callback)(const char*,size_t,void*),void* state) {
+            flush_capture();
+            m_capture_flush= callback;
+            m_capture_flush_state = state;
+        }
+        void reset() {
+            m_state = initial;
+            m_position = 0;
+            m_current = 0; 
+            m_capture_size=0;
+            *m_capture=0;
+        }
+        bool skip(bool(*fn)(uint32_t)) {
+            if(!ensure_started()) return false;
+            bool result = false;
+            while(more() && fn(m_current)) {
+                advance();
+                result = true;
+            }
+            return result;
+        }
+        bool read(bool(*fn)(uint32_t)) {
+            if(!ensure_started()) return false;
+            bool result = false;
+            while(more() && fn(m_current)) {
+                if(!capture(m_current)) {
+                    return false;
+                }
+                advance();
+                result = true;
+            }
+            return result;
+        }
+        
+        bool read_until_full(bool(*fn)(uint32_t)) {
+            if(!ensure_started()) return false;
+            bool result = false;
+            while(more() && fn(m_current) && capture_capacity()-capture_size()>=4) {
+                if(!capture(m_current)) {
+                    return false;
+                }
+                advance();
+                result = true;
+            }
+            return result;
+        }
+        char skip_to_any(const char* characters7bit) {
+            int16_t match;
+            unsigned long long int pos=m_position;
+            int8_t error=0;
+            if(!skip_to_any(characters7bit,pos,match,error)) {
+                if(0>error)
+                    m_state=error;
+                m_position=pos;
+                return false;
+            }
+            m_current = match;
+            //printf("Advanced %d characters\r\n",(int)(pos-m_position));
+            m_position=pos;
+            return match;
+        }
+
+        inline bool advance() {
+            return advance_impl();
+        }
+        bool advance(bool capture) {
+            if (end_of_input == m_state || io_error==m_state) {
+                m_current = 0;
+                return false;
+            }
+
+            if(capture) {
+                if(capture_size()>capture_capacity()-4) {
+                    if(!flush_capture()) {
+                        m_state=out_of_memory_error;
+                        m_current=0;
+                    }
+                    return false;
+                }
+                return advance_impl() && this->capture(m_current);
+            }
+            return advance_impl();
+        }
+        inline int32_t current() const {
+            return m_current;
+        }
+        bool ensure_started() {
+            if(m_state==initial) {
+                return advance_impl();
+            }
+            return true;
+        }
+        inline unsigned long long position() const { return m_position; }
+        inline bool more() const {
+            return -1<m_state||initial==m_state;
+        }
+        inline bool eof() const {return end_of_input==m_state;};
+        inline bool has_error() const {return -1> m_state;};
+        inline int8_t error() const {if(has_error()) return m_state; return 0;}
+        bool capture(int32_t codepoint) {
+            size_t n = capture_capacity()-capture_size();
+            if(n<4) {
+                if(!flush_capture()) {
+                    m_state = out_of_memory_error; 
+                    return false;
+                }
+            }
+            if (0 == ((int32_t)0xffffff80 & codepoint)) {
+                // 1-byte/7-bit ascii
+                // (0b0xxxxxxx)
+                append_capture(codepoint);
+                return true;
+            }
+            if (0 == ((int32_t)0xfffff800 & codepoint)) {
+                // 2-byte/11-bit utf8 code point
+                // (0b110xxxxx 0b10xxxxxx)
+                append_capture(0xc0 | (char)(codepoint >> 6));                
+                append_capture(0x80 | (char)(codepoint & 0x3f));
+                return true;
+            }
+            if (0 == ((int32_t)0xffff0000 & codepoint)) {
+                // 3-byte/16-bit utf8 code point
+                append_capture(0xe0 | (char)(codepoint >> 12));
+                append_capture(0x80 | (char)((codepoint >> 6) & 0x3f));
+                append_capture(0x80 | (char)(codepoint & 0x3f));
+                return true;
+            } 
+            // 4-byte/21-bit utf8 code point
+            // (0b11110xxx 0b10xxxxxx 0b10xxxxxx 0b10xxxxxx)
+            append_capture(0xf0 | (char)(codepoint >> 18));
+            append_capture(0x80 | (char)((codepoint >> 12) & 0x3f));
+            append_capture(0x80 | (char)((codepoint >> 6) & 0x3f));
+            append_capture(0x80 | (char)(codepoint & 0x3f));
+            return true;
+        }
+        
+    };
+}
+#endif

--- a/lib/htcw_io/src/io_stream.h
+++ b/lib/htcw_io/src/io_stream.h
@@ -1,0 +1,4 @@
+#ifndef IO_STREAM_H
+#define IO_STREAM_H
+#include "io_stream.hpp"
+#endif

--- a/lib/htcw_io/src/io_stream.hpp
+++ b/lib/htcw_io/src/io_stream.hpp
@@ -1,0 +1,259 @@
+#ifndef HTCW_STREAM_HPP
+#define HTCW_STREAM_HPP
+#include <htcw_endian.hpp>
+#ifdef ARDUINO
+#include <Arduino.h>
+#ifdef SAMD_SERIES 
+#ifndef IO_SEEED_FS
+    #define IO_NO_FS
+#endif
+#endif
+#ifdef ARDUINO_ARCH_STM32
+    #define IO_NO_FS
+
+#endif
+#if defined(ARDUINO_ARDUINO_NANO33BLE) || defined(ARDUINO_ARCH_MBED_RP2040)|| defined(ARDUINO_ARCH_RP2040)
+    #define IO_NO_FS
+#endif
+#ifndef IO_NO_FS
+    #ifdef IO_ARDUINO_SD_FS
+        #include <SD.h>
+    #else
+        #if !defined(SAMD_SERIES)
+            #include <FS.h>
+        #endif
+    #endif
+#endif
+#if defined(ESP_PLATFORM) || defined(ARDUINO_ARCH_ESP8266)
+#include <pgmspace.h>
+#elif defined(ARDUINO_ARDUINO_NANO33BLE) || defined(ARDUINO_ARCH_MBED_RP2040)|| defined(ARDUINO_ARCH_RP2040)
+#include <api/deprecated-avr-comp/avr/pgmspace.h>
+#else
+#include <avr/pgmspace.h>
+#endif
+#else
+    #include <stdio.h>
+    #include <string.h>
+    #include <inttypes.h>
+#endif
+#if defined(SAMD_SERIES) && defined(IO_SEEED_FS)
+    #include <Seeed_FS.h>
+    #include "SD/Seeed_SD.h"
+#endif
+namespace io {
+    struct stream_caps {
+        uint8_t read : 1;
+        uint8_t write : 1;
+        uint8_t seek :1;
+    };
+    enum struct seek_origin {
+        start = 0,
+        current = 1,
+        end = 2
+    };
+    class stream {
+    public:
+        virtual int getch()=0;
+        virtual size_t read(uint8_t* destination,size_t size)=0;
+        virtual int putch(int value)=0;
+        virtual size_t write(const uint8_t* source,size_t size)=0;
+        virtual unsigned long long seek(long long position,seek_origin origin=seek_origin::start)=0;
+        virtual stream_caps caps() const=0;
+        template<typename T>
+        size_t read(T* out_value) {
+            return read((uint8_t*)out_value,sizeof(T));
+        }
+        template<typename T>
+        T read(const T& default_value=T()) {
+            T result;
+            if(sizeof(T)!=read(&result))
+                return default_value;
+            return result;
+        }
+        template<typename T>
+        size_t write(const T& value) {
+            return write((uint8_t*)&value,sizeof(T));
+        }
+    };
+    enum struct file_mode {
+        read = 1,
+        write = 2,
+        append = 6
+    };
+    class buffer_stream final : public stream {
+        uint8_t* m_begin;
+        uint8_t* m_current;
+        size_t m_size;
+        buffer_stream(const buffer_stream& rhs)=delete;
+        buffer_stream& operator=(const buffer_stream& rhs)=delete;
+    public:
+        buffer_stream();
+        buffer_stream(uint8_t* buffer,size_t size);
+        buffer_stream(buffer_stream&& rhs);
+        buffer_stream& operator=(buffer_stream&& rhs);
+        uint8_t* handle();
+        void set(uint8_t* buffer,size_t size);
+        virtual int getch();
+        virtual int putch(int value);
+        virtual stream_caps caps() const;
+        virtual size_t read(uint8_t* destination,size_t size);
+        virtual size_t write(const uint8_t* source,size_t size);
+        virtual unsigned long long seek(long long position,seek_origin origin=seek_origin::start);
+    };
+    class const_buffer_stream final : public stream {
+        const uint8_t* m_begin;
+        const uint8_t* m_current;
+        size_t m_size;
+        const_buffer_stream(const const_buffer_stream& rhs)=delete;
+        const_buffer_stream& operator=(const const_buffer_stream& rhs)=delete;
+    public:
+        const_buffer_stream();
+        const_buffer_stream(const uint8_t* buffer,size_t size);
+        const_buffer_stream(const_buffer_stream&& rhs);
+        const_buffer_stream& operator=(const_buffer_stream&& rhs);
+        const uint8_t* handle() const;
+        void set(const uint8_t* buffer,size_t size);
+        virtual int getch();
+        virtual int putch(int value);
+        virtual stream_caps caps() const;
+        virtual size_t read(uint8_t* destination,size_t size);
+        virtual size_t write(const uint8_t* source,size_t size);
+        virtual unsigned long long seek(long long position,seek_origin origin=seek_origin::start);
+    };
+#ifdef ARDUINO
+
+    class arduino_stream final : public stream {
+        Stream* m_stream;
+        arduino_stream(const arduino_stream& rhs) = delete;
+        arduino_stream& operator=(const arduino_stream& rhs)=delete;
+    public:
+        arduino_stream();
+        arduino_stream(Stream* stream);
+        arduino_stream(arduino_stream&& rhs);
+        arduino_stream& operator=(arduino_stream&& rhs);
+        Stream* handle();
+        void set(Stream* stream);
+        virtual size_t read(uint8_t* destination,size_t size);
+        virtual int getch();
+        virtual size_t write(const uint8_t* source,size_t size);
+        virtual int putch(int value);
+        virtual unsigned long long seek(long long position, seek_origin origin=seek_origin::start);
+        virtual stream_caps caps() const;
+    };
+#endif
+#ifndef IO_NO_FS
+    class file_stream final : public stream {
+#ifdef ARDUINO
+        File* m_file;
+#else
+        FILE* m_fd;
+#endif
+        stream_caps m_caps;
+        file_stream(const file_stream& rhs) = delete;
+        file_stream& operator=(const file_stream& rhs)=delete;
+    public:
+        file_stream();
+#ifdef ARDUINO
+        file_stream(File& file);
+        file_stream(file_stream&& rhs);
+        file_stream& operator=(file_stream&& rhs);
+        ~file_stream();
+        File* handle() const;
+        void set(File& file);
+        virtual size_t read(uint8_t* destination,size_t size);
+        virtual int getch();
+        virtual size_t write(const uint8_t* source,size_t size);
+        virtual int putch(int value);
+        virtual unsigned long long seek(long long position, seek_origin origin=seek_origin::start);
+        void close();
+#else
+        file_stream(const char* name,file_mode mode=file_mode::read);
+        file_stream(file_stream&& rhs);
+        file_stream& operator=(file_stream&& rhs);
+        ~file_stream();
+        FILE* handle() const;
+        void set(const char* name,file_mode mode = file_mode::read);
+        virtual size_t read(uint8_t* destination,size_t size);
+        virtual int getch();
+        virtual size_t write(const uint8_t* source,size_t size);
+        virtual int putch(int value);
+        virtual unsigned long long seek(long long position, seek_origin origin=seek_origin::start);
+        void close();
+#endif
+        virtual stream_caps caps() const;
+    };
+
+#ifdef ARDUINO
+    class c_file_stream final : public stream {
+        FILE* m_fd;
+        io::stream_caps m_caps;
+        c_file_stream(const c_file_stream& rhs) = delete;
+        c_file_stream& operator=(const c_file_stream& rhs)=delete;
+    public:
+        c_file_stream();
+        c_file_stream(const char* name,file_mode mode=file_mode::read);
+        c_file_stream(c_file_stream&& rhs);
+        c_file_stream& operator=(c_file_stream&& rhs);
+        ~c_file_stream();
+        FILE* handle() const;
+        void set(const char* name,file_mode mode = file_mode::read);
+        virtual size_t read(uint8_t* destination,size_t size);
+        virtual int getch();
+        virtual size_t write(const uint8_t* source,size_t size);
+        virtual int putch(int value);
+        virtual unsigned long long seek(long long position, seek_origin origin=seek_origin::start);
+        void close();
+        virtual io::stream_caps caps() const;
+    };
+#else
+    using c_file_stream = file_stream;
+#endif
+
+#endif
+    class stream_reader_base {
+    protected:
+        stream* m_stream;
+        stream_reader_base(io::stream* stream) : m_stream(stream) {
+        }
+    public:
+        inline bool initialized() const {
+            return m_stream!=nullptr;
+        }
+        inline stream* base_stream() const {
+            return m_stream;
+        }
+    };
+    class stream_reader_le : public stream_reader_base {
+     public:
+        stream_reader_le(io::stream* stream);
+        bool read(uint8_t* out_value) const;
+        bool read(uint16_t* out_value) const;
+        bool read(uint32_t* out_value) const;
+#if HTCW_MAX_WORD >= 64
+        bool read(uint64_t* out_value) const;
+#endif
+        bool read(int8_t* out_value) const;
+        bool read(int16_t* out_value) const;
+        bool read(int32_t* out_value) const;
+#if HTCW_MAX_WORD >= 64
+        bool read(int64_t* out_value) const;
+#endif
+    };
+    class stream_reader_be : public stream_reader_base {
+    public:
+        stream_reader_be(io::stream* stream);
+        bool read(uint8_t* out_value) const;
+        bool read(uint16_t* out_value) const;
+        bool read(uint32_t* out_value) const;
+#if HTCW_MAX_WORD >= 64
+        bool read(uint64_t* out_value) const;
+#endif
+        bool read(int8_t* out_value) const;
+        bool read(int16_t* out_value) const;
+        bool read(int32_t* out_value) const;
+#if HTCW_MAX_WORD >= 64
+        bool read(int64_t* out_value) const;
+#endif
+    };
+}
+#endif

--- a/lib/htcw_io/src/source/io_stream.cpp
+++ b/lib/htcw_io/src/source/io_stream.cpp
@@ -1,0 +1,729 @@
+#include <htcw_endian.hpp>
+#include <io_stream.hpp>
+namespace io {
+    buffer_stream::buffer_stream() : m_begin(nullptr),m_current(nullptr),m_size(0) {}
+    buffer_stream::buffer_stream(uint8_t* buffer, size_t size) :m_begin(buffer),m_current(buffer),m_size(size) {
+        if(nullptr==buffer) m_size=0;
+    }
+    buffer_stream::buffer_stream(buffer_stream&& rhs) : m_begin(rhs.m_begin), m_current(rhs.m_current), m_size(rhs.m_size) {
+        rhs.m_begin=rhs.m_current=nullptr;
+        rhs.m_size=0;
+    }
+    buffer_stream& buffer_stream::operator=(buffer_stream&& rhs) {
+        m_begin=rhs.m_begin;
+        m_current=rhs.m_current;
+        m_size=rhs.m_size;
+        rhs.m_begin=rhs.m_current=nullptr;
+        rhs.m_size=0;
+        return *this;
+    }
+    uint8_t* buffer_stream::handle() {
+        return m_begin;
+    }
+    void buffer_stream::set(uint8_t* buffer,size_t size) {
+        m_begin = m_current = buffer;
+        m_size = size;
+        if(nullptr==buffer) m_size=0;
+    }
+    int buffer_stream::getch() {
+        if(nullptr==m_current || (size_t)(m_current-m_begin)>=m_size)
+            return -1;
+        return *(m_current++);
+    }
+    int buffer_stream::putch(int value) {
+        if(nullptr==m_current || (size_t)(m_current-m_begin)>=m_size)
+            return -1;
+        return *(m_current++)=(uint8_t)value;
+    }
+    stream_caps buffer_stream::caps() const {
+            stream_caps s;
+            s.read = s.write = s.seek = (nullptr!=m_current);
+            return s;
+        }
+    size_t buffer_stream::read(uint8_t* destination,size_t size) {
+        if(nullptr==m_current || nullptr==destination)
+            return 0;
+        size_t offs=m_current-m_begin;
+        if(offs>=m_size)
+            return 0;
+        if(size+offs>m_size) 
+            size = (m_size-offs);
+        memcpy(destination,m_current,size);
+        m_current+=size;
+        return size;
+    }
+    
+    size_t buffer_stream::write(const uint8_t* source,size_t size) {
+        if(nullptr==m_current || nullptr==source)
+            return 0;
+        size_t offs=m_current-m_begin;
+        if(offs>=m_size)
+            return 0;
+        if(size+offs>=m_size) 
+            size = (m_size-offs);
+        if(0!=size) {
+            memcpy(m_current,source,size);
+            m_current+=size;
+        }
+        return size;
+    }
+    
+    unsigned long long buffer_stream::seek(long long position,seek_origin origin)  {
+        if(nullptr==m_current)
+            return 0;
+        size_t offs=m_current-m_begin;
+        size_t p;
+        switch(origin) {
+            case seek_origin::start:
+                if(position<0)
+                    p = 0;
+                else if(0<=position && ((unsigned long long)position)>m_size) {
+                    p=m_size;
+                } else
+                    p=(size_t)position;
+                break;
+            case seek_origin::current:
+                if(offs+position<0)
+                    p = offs;
+                else if(offs+position>m_size) {
+                    p=m_size;
+                } else
+                    p=(size_t)(offs+position);
+                break;
+            case seek_origin::end:
+                return seek(m_size+position,seek_origin::start);
+            default:
+                return offs;
+        }
+        m_current=m_begin+p;
+        return m_current-m_begin;   
+    }
+
+    const_buffer_stream::const_buffer_stream() : m_begin(nullptr),m_current(nullptr),m_size(0) {}
+    const_buffer_stream::const_buffer_stream(const uint8_t* buffer,size_t size) :m_begin(buffer),m_current(buffer),m_size(size) {
+        if(nullptr==buffer) m_size=0;
+    }
+    const_buffer_stream::const_buffer_stream(const_buffer_stream&& rhs) : m_begin(rhs.m_begin), m_current(rhs.m_current), m_size(rhs.m_size) {
+        rhs.m_begin=rhs.m_current=nullptr;
+        rhs.m_size=0;
+    }
+    const_buffer_stream& const_buffer_stream::operator=(const_buffer_stream&& rhs) {
+        m_begin=rhs.m_begin;
+        m_current=rhs.m_current;
+        m_size=rhs.m_size;
+        rhs.m_begin=rhs.m_current=nullptr;
+        rhs.m_size=0;
+        return *this;
+    }
+    const uint8_t* const_buffer_stream::handle() const {
+        return m_begin;
+    }
+    void const_buffer_stream::set(const uint8_t* buffer,size_t size) {
+        m_begin = m_current = buffer;
+        m_size = size;
+        if(nullptr==buffer) m_size=0;
+    }
+    int const_buffer_stream::getch() {
+        if(nullptr==m_current || (size_t)(m_current-m_begin)>=m_size)
+            return -1;
+#if defined(ARDUINO) && !defined(ESP32)
+        return pgm_read_byte(m_current++);
+#else
+        return *(m_current++);
+#endif
+    }
+    int const_buffer_stream::putch(int value) {
+        return -1;
+    }
+    stream_caps const_buffer_stream::caps() const {
+        stream_caps s;
+        s.read = s.seek= (nullptr!=m_current);
+        s.write = 0;
+    
+        return s;
+    }
+    size_t const_buffer_stream::read(uint8_t* destination,size_t size) {
+        if(nullptr==m_current || nullptr==destination || size==0)
+            return 0;
+        size_t offs=m_current-m_begin;
+        if(offs>=m_size)
+            return 0;
+        if(size+offs>m_size) 
+            size = (m_size-offs);
+#if defined(ARDUINO) && !defined(ESP32)
+        offs=size;
+        while(offs--) {
+            *destination++=pgm_read_byte(m_current++);
+        }
+#else
+        memcpy(destination,m_current,size);
+        m_current+=size;
+#endif
+        return size;
+    }
+    
+    size_t const_buffer_stream::write(const uint8_t* source,size_t size) {
+        return 0;
+    }
+    
+    unsigned long long const_buffer_stream::seek(long long position,seek_origin origin) {
+        if(nullptr==m_current)
+            return 0;
+        size_t offs=m_current-m_begin;
+        size_t p;
+        switch(origin) {
+            case seek_origin::start:
+                if(position<0)
+                    p = 0;
+                else if(0<=position && ((unsigned long long)position)>m_size) {
+                    p=m_size;
+                } else
+                    p=(size_t)position;
+                break;
+            case seek_origin::current:
+                if(offs+position<0)
+                    p = offs;
+                else if(offs+position>m_size) {
+                    p=m_size;
+                } else
+                    p=(size_t)(offs+position);
+                break;
+            case seek_origin::end:
+                return seek(m_size+position,seek_origin::start);
+            default:
+                return offs;
+        }
+        m_current=m_begin+p;
+        return m_current-m_begin;   
+    }
+    
+#ifdef ARDUINO
+    arduino_stream::arduino_stream(Stream* stream) : m_stream(stream) {
+    }
+    arduino_stream::arduino_stream() : m_stream(nullptr) {
+    }
+    arduino_stream::arduino_stream(arduino_stream&& rhs) : m_stream(rhs.m_stream) {
+        rhs.m_stream=nullptr;
+    }
+    arduino_stream& arduino_stream::operator=(arduino_stream&& rhs) {
+        m_stream=rhs.m_stream;
+        rhs.m_stream=nullptr;
+        return *this;
+    }
+    Stream* arduino_stream::handle() {
+        return m_stream;
+    }
+    void arduino_stream::set(Stream* stream) {
+        m_stream = stream;
+    }
+    size_t arduino_stream::read(uint8_t* destination,size_t size) {
+        if(nullptr==m_stream) return 0;
+        for(int i = 0; i < 1000 && !m_stream->available(); ++i) {
+            delay(1);
+        }
+        size = m_stream->readBytes(destination,size);
+        return size;
+    }
+    int arduino_stream::getch() {
+        if(nullptr==m_stream) return -1;
+        for(int i = 0; i < 1000 && !m_stream->available(); ++i) {
+            delay(1);
+        }
+        return m_stream->read();
+    }
+    size_t arduino_stream::write(const uint8_t* source,size_t size) {
+        if(nullptr==m_stream) return 0;
+        return m_stream->write(source,size);
+    }
+    int arduino_stream::putch(int value) {
+        if(nullptr==m_stream) return 0;
+        return m_stream->write((uint8_t)value);
+    } 
+    unsigned long long arduino_stream::seek(long long position, seek_origin origin) {
+        return 0;
+    }
+    stream_caps arduino_stream::caps() const {
+        stream_caps c;
+        c.read = c.write = (m_stream!=nullptr);
+        c.seek = 0;
+        return c;
+    }
+
+#endif
+
+#ifndef IO_NO_FS
+#ifdef ARDUINO
+    file_stream::file_stream() : m_file(nullptr) {
+        m_caps.read=0;
+        m_caps.write=0;
+        m_caps.seek=0;
+    }
+    file_stream::file_stream(File& file) : m_file(&file){
+        if(!file) {
+            m_caps.read=0;
+            m_caps.write=0;
+            m_caps.seek=0;
+        } else {
+            m_caps.read=1;
+            m_caps.write=1;
+            m_caps.seek=1;
+        }
+    }
+    file_stream::file_stream(file_stream&& rhs) : m_file(rhs.m_file),m_caps(rhs.m_caps) {
+        rhs.m_caps={0,0,0};
+    }
+    file_stream& file_stream::operator=(file_stream&& rhs) {
+        m_file=rhs.m_file;
+        m_caps=rhs.m_caps;
+        rhs.m_caps={0,0,0};
+        return *this;
+    }
+    file_stream::~file_stream() {
+    }
+    File* file_stream::handle() const {
+        return m_file;
+    }
+    void file_stream::set(File& file) {
+        if(!file) {
+            m_caps.read = m_caps.write = m_caps.seek = 0;
+        } else {
+            m_caps.read = m_caps.write = m_caps.seek = 1;
+        }
+        m_file = &file;
+    }
+    size_t file_stream::read(uint8_t* destination,size_t size) {
+        if(!m_file) return 0;
+        if(0!=m_file->readBytes((char*)destination,size)) {
+            return size;
+        }
+        return 0;
+    }
+    int file_stream::getch() {
+        if(!m_file) return -1;
+        return m_file->read();
+    }
+    size_t file_stream::write(const uint8_t* source,size_t size) {
+        if(!m_file) return 0;
+        size_t s= m_file->write(source,size);
+        //m_file.flush();
+        return s;
+    }
+    int file_stream::putch(int value) {
+        if(!m_file) return 0;
+        size_t s = m_file->write((uint8_t)value);
+        //m_file.flush();
+        return s;
+    } 
+    unsigned long long file_stream::seek(long long position, seek_origin origin) {    
+        switch(origin) {
+            case seek_origin::start:
+                m_file->seek((uint32_t)position);
+                break;
+            case seek_origin::current:
+                if(0!=position) {
+                    m_file->seek(uint32_t(position+m_file->position()));
+                }
+                break;
+            case seek_origin::end:
+                m_file->seek(uint32_t(m_file->size()+position));
+                break;
+        }
+        return m_file->position();
+    }
+    void file_stream::close() {
+        if(!m_file) {
+            return;;
+        }
+        m_file->close();
+    }
+#else
+    #include <stdio.h>
+    file_stream::file_stream() : m_fd(nullptr) {
+        m_caps.read=0;
+        m_caps.write=0;
+        m_caps.seek=0;
+    }
+    file_stream::file_stream(const char* name,file_mode mode) : m_fd(nullptr), m_caps({0,0,0}) {
+        set(name,mode);
+    }
+    file_stream::file_stream(file_stream&& rhs) : m_fd(rhs.m_fd),m_caps(rhs.m_caps) {
+        rhs.m_fd=nullptr;
+        rhs.m_caps={0,0,0};
+    }
+    file_stream& file_stream::operator=(file_stream&& rhs) {
+        m_fd=rhs.m_fd;
+        m_caps=rhs.m_caps;
+        rhs.m_fd=nullptr;
+        rhs.m_caps={0,0,0};
+        return *this;
+    }
+    file_stream::~file_stream() {
+        close();
+    }
+    FILE* file_stream::handle() const {
+        return m_fd;
+    }
+    void file_stream::set(const char* name,file_mode mode) {
+        close();
+        if((int)file_mode::append==((int)mode & (int)file_mode::append)) {
+            if((int)file_mode::read==((int)mode & (int)file_mode::read)) {
+                m_fd = fopen(name,"ab+");
+                if(nullptr!=m_fd) {
+                    m_caps.read=1;
+                    m_caps.write=1;
+                    m_caps.seek=1;
+                }
+                return;
+            }
+            m_fd = fopen(name,"ab");
+            if(nullptr!=m_fd) {
+                m_caps.read=0;
+                m_caps.write=1;
+                m_caps.seek=1;
+            }
+            return;
+        }
+        if((int)file_mode::write==((int)mode & (int)file_mode::write)) {
+            if((int)file_mode::read==((int)mode & (int)file_mode::read)) {
+                m_fd = fopen(name,"wb+");
+                if(nullptr!=m_fd) {
+                    m_caps.read=1;
+                    m_caps.write=1;
+                    m_caps.seek=1;
+                }
+                return;
+            }
+            m_fd = fopen(name,"wb");
+            if(nullptr!=m_fd) {
+                m_caps.read=0;
+                m_caps.write=1;
+                m_caps.seek=1;
+            }
+            return;
+        }
+        if((int)file_mode::read==((int)mode & (int)file_mode::read)) {
+            m_fd = fopen(name,"rb");
+            if(nullptr!=m_fd) {
+                m_caps.read=1;
+                m_caps.write=0;
+                m_caps.seek=1;
+            }
+        }
+    }
+    size_t file_stream::read(uint8_t* destination,size_t size) {
+        if(0==m_caps.read) return 0;
+        return fread(destination,1,size,m_fd);
+    }
+    int file_stream::getch() {
+        if(0==m_caps.read) return -1;
+        return fgetc(m_fd);
+    }
+    size_t file_stream::write(const uint8_t* source,size_t size) {
+        if(0==m_caps.write) return 0;
+        return fwrite(source,1,size,m_fd);
+    }
+    int file_stream::putch(int value) {
+        if(0==m_caps.write) return -1;
+        return fputc(value,m_fd);
+    } 
+    unsigned long long file_stream::seek(long long position, seek_origin origin) {
+        if(0==m_caps.seek) return 0; // should always be true unless uninitialized
+        // on error we still need to report the current position
+        // so we continue regardless
+        if(position!=0||origin!=seek_origin::current)
+            fseek(m_fd,(long int)position,(int)origin);
+        return ftell(m_fd);
+    }
+    void file_stream::close() {
+        if(nullptr!=m_fd) {
+            m_caps = {0,0,0};
+            fclose(m_fd);
+            m_fd=nullptr;
+        }
+    }
+#endif
+    stream_caps file_stream::caps() const {
+        return m_caps;
+    }   
+#ifdef ARDUINO
+
+    c_file_stream::c_file_stream(const char* name,file_mode mode) : m_fd(nullptr), m_caps({0,0,0}) {
+        set(name,mode);
+    }
+    c_file_stream::c_file_stream() : m_fd(nullptr), m_caps({0,0,0}) {
+        
+    }
+    c_file_stream::c_file_stream(c_file_stream&& rhs) : m_fd(rhs.m_fd),m_caps(rhs.m_caps) {
+        rhs.m_fd=nullptr;
+        rhs.m_caps={0,0,0};
+    }
+    c_file_stream& c_file_stream::operator=(c_file_stream&& rhs) {
+        m_fd=rhs.m_fd;
+        m_caps=rhs.m_caps;
+        rhs.m_fd=nullptr;
+        rhs.m_caps={0,0,0};
+        return *this;
+    }
+    c_file_stream::~c_file_stream() {
+        close();
+    }
+    FILE* c_file_stream::handle() const {
+        return m_fd;
+    }
+    void c_file_stream::set(const char* name,file_mode mode) {
+        close();
+        if((int)file_mode::append==((int)mode & (int)file_mode::append)) {
+            if((int)file_mode::read==((int)mode & (int)file_mode::read)) {
+                m_fd = fopen(name,"ab+");
+                if(nullptr!=m_fd) {
+                    m_caps.read=1;
+                    m_caps.write=1;
+                    m_caps.seek=1;
+                }
+                return;
+            }
+            m_fd = fopen(name,"ab");
+            if(nullptr!=m_fd) {
+                m_caps.read=0;
+                m_caps.write=1;
+                m_caps.seek=1;
+            }
+            return;
+        }
+        if((int)file_mode::write==((int)mode & (int)file_mode::write)) {
+            if((int)file_mode::read==((int)mode & (int)file_mode::read)) {
+                m_fd = fopen(name,"wb+");
+                if(nullptr!=m_fd) {
+                    m_caps.read=1;
+                    m_caps.write=1;
+                    m_caps.seek=1;
+                }
+                return;
+            }
+            m_fd = fopen(name,"wb");
+            if(nullptr!=m_fd) {
+                m_caps.read=0;
+                m_caps.write=1;
+                m_caps.seek=1;
+            }
+            return;
+        }
+        if((int)file_mode::read==((int)mode & (int)file_mode::read)) {
+            m_fd = fopen(name,"rb");
+            if(nullptr!=m_fd) {
+                m_caps.read=1;
+                m_caps.write=0;
+                m_caps.seek=1;
+            }
+        }
+    }
+    size_t c_file_stream::read(uint8_t* destination,size_t size) {
+        if(0==m_caps.read) return 0;
+        return fread(destination,1,size,m_fd);
+    }
+    int c_file_stream::getch() {
+        if(0==m_caps.read) return -1;
+        return fgetc(m_fd);
+    }
+    size_t c_file_stream::write(const uint8_t* source,size_t size) {
+        if(0==m_caps.write) return 0;
+        return fwrite(source,1,size,m_fd);
+    }
+    int c_file_stream::putch(int value) {
+        if(0==m_caps.write) return -1;
+        return fputc(value,m_fd);
+    } 
+    unsigned long long c_file_stream::seek(long long position, seek_origin origin) {
+        if(0==m_caps.seek) return 0; // should always be true unless uninitialized
+        // on error we still need to report the current position
+        // so we continue regardless
+        if(position!=0||origin!=seek_origin::current)
+            fseek(m_fd,(long int)position,(int)origin);
+        return ftell(m_fd);
+    }
+    void c_file_stream::close() {
+        if(nullptr!=m_fd) {
+            m_caps = {0,0,0};
+            fclose(m_fd);
+            m_fd=nullptr;
+        }
+    }
+    stream_caps c_file_stream::caps() const {
+        return m_caps;
+    }   
+#endif
+#endif
+    stream_reader_le::stream_reader_le(io::stream* stream) : stream_reader_base(stream) {}
+    bool stream_reader_le::read(uint8_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_le(*out_value);
+        return true;
+    }
+    bool stream_reader_le::read(uint16_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_le(*out_value);
+        return true;
+    }
+    bool stream_reader_le::read(uint32_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_le(*out_value);
+        return true;
+    }
+#if HTCW_MAX_WORD >= 64
+    bool stream_reader_le::read(uint64_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_le(*out_value);
+        return true;
+    }
+#endif
+    bool stream_reader_le::read(int8_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_le(*out_value);
+        return true;
+    }
+    bool stream_reader_le::read(int16_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_le(*out_value);
+        return true;
+    }
+    bool stream_reader_le::read(int32_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_le(*out_value);
+        return true;
+    }
+#if HTCW_MAX_WORD >= 64
+    bool stream_reader_le::read(int64_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_le(*out_value);
+        return true;
+    }
+#endif
+
+    stream_reader_be::stream_reader_be(io::stream* stream) : stream_reader_base(stream) {
+
+    }
+    bool stream_reader_be::read(uint8_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_be(*out_value);
+        return true;
+    }
+    bool stream_reader_be::read(uint16_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_be(*out_value);
+        return true;
+    }
+    bool stream_reader_be::read(uint32_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_be(*out_value);
+        return true;
+    }
+#if HTCW_MAX_WORD >= 64
+    bool stream_reader_be::read(uint64_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_be(*out_value);
+        return true;
+    }
+#endif
+    bool stream_reader_be::read(int8_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_be(*out_value);
+        return true;
+    }
+    bool stream_reader_be::read(int16_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_be(*out_value);
+        return true;
+    }
+    bool stream_reader_be::read(int32_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_be(*out_value);
+        return true;
+    }
+#if HTCW_MAX_WORD >= 64
+    bool stream_reader_be::read(int64_t* out_value) const {
+        if(nullptr==m_stream || nullptr==out_value) {
+            return false;
+        }
+        if(sizeof(*out_value)!=m_stream->read((uint8_t*)out_value,sizeof(*out_value))) {
+            return false;
+        }
+        *out_value = bits::from_be(*out_value);
+        return true;
+    }
+#endif
+}

--- a/lib/htcw_json/LICENSE
+++ b/lib/htcw_json/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 honey the codewitch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/htcw_json/README.md
+++ b/lib/htcw_json/README.md
@@ -1,0 +1,284 @@
+# JSON
+
+A minimalist JSON parser with streaming support
+
+```
+[env:node32s]
+platform = espressif32
+board = node32s
+framework = arduino
+lib_deps = 
+	codewitch-honey-crisis/htcw_json
+```
+
+See https://www.codeproject.com/Tips/5382125/IP-Geolocation-with-an-ESP32-and-Arduino for a simple real world example
+
+```cpp
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <memory.h>
+#include <string.h>
+#include <json.hpp>
+using namespace io;
+using namespace json;
+void indent(int spaces, FILE* file) {
+    while(spaces--) fprintf(file,"    ");
+}
+// accept any reader regardless of capture size
+void dump(json_reader_base& reader, FILE* file) {
+    // don't de-escape and dequote field names or string values:
+    //reader.raw_strings(true);
+    
+    bool first_part=true; // first value part in series
+    int tabs = 0; // number of "tabs" to indent by
+    bool skip_read = false; // don't call read() the next iteration
+    while(skip_read || reader.read()) {
+        skip_read = false;
+        switch(reader.node_type()) {
+            case json_node_type::array:
+                indent(tabs++,file);
+                fputs("[",file);
+                break;
+            case json_node_type::end_array:
+                indent(--tabs,file);
+                fputs("]",file);
+                break;
+            case json_node_type::object:
+                indent(tabs++,file);
+                fputs("{",file);
+                break;
+            case json_node_type::end_object:
+                indent(--tabs,file);
+                fputs("}",file);
+                break;
+            case json_node_type::field:
+                indent(tabs,file);
+                fprintf(file, "%s: ",reader.value());
+                // we want to spit the value here, so 
+                // we basically hijack the reader and 
+                // read the value subtree here.
+                while(reader.read() && reader.is_value()) {
+                    fprintf(file,"%s",reader.value());
+                }
+                fputs("",file);
+                skip_read = true;
+                break;
+            case json_node_type::value:
+                indent(tabs,file);
+                fprintf(file,"%s\r\n",reader.value());
+                //fwrite(reader.value(),1,strlen(reader.value()),file);
+                fputs("",file);
+                break;
+            case json_node_type::value_part:
+                // the first value part needs to be indented
+                if(first_part) {
+                    indent(tabs,file);
+                    first_part = false; // reset the flag
+                }
+                fprintf(file,"%s",reader.value());
+                break;
+            case json_node_type::end_value_part:
+                fprintf(file,"%s,\r\n",reader.value());               
+                // set the first flag
+                first_part = true;
+                break;      
+        }
+    }
+}
+char name[2048];
+char overview[8192];
+void read_episodes(json_reader_base& reader, FILE* file) {
+    int episodes_array_depth = 0;
+    if(reader.read() && reader.node_type()==json_node_type::array) {
+        episodes_array_depth = reader.depth();
+        while(true) {
+            if(reader.depth()==episodes_array_depth && reader.node_type()==json_node_type::end_array) {
+                break;
+            }
+            if(reader.read()&&reader.node_type()==json_node_type::object) {
+                
+                int episode_object_depth = reader.depth();
+                int season_number = -1;
+                int episode_number = -1;
+                while(reader.read() && reader.depth()>=episode_object_depth) {
+                    if(reader.depth()==episode_object_depth && reader.node_type()==json_node_type::field) {
+                        if(0==strcmp("episode_number",reader.value()) && reader.read() && reader.node_type()==json_node_type::value) {
+                            episode_number = reader.value_int();
+                        }
+                        if(0==strcmp("season_number",reader.value()) && reader.read() && reader.node_type()==json_node_type::value) {
+                            season_number = reader.value_int();
+                        }
+                        if(0==strcmp("name",reader.value())) {
+                            name[0]=0;
+                            while(reader.read() && reader.is_value()) {
+                                strcat(name,reader.value());
+                            }
+                        }
+                        if(0==strcmp("overview",reader.value())) {
+                            overview[0]=0;
+                            while(reader.read() && reader.is_value()) {
+                                strcat(overview,reader.value());
+                            }
+                        }
+                    }
+                }
+                if(season_number>-1 && episode_number>-1 && name[0]) {
+                    fprintf(file,"S%02dE%02d %s\r\n",season_number,episode_number,name);
+                    if(overview[0]) {
+                        fprintf(file,"\t%s\r\n",overview);
+                    }
+                    fputs("",file);
+                }
+            }
+        }
+    }
+}
+void read_series(json_reader_base& reader,FILE* file) {
+    while(reader.read()) {
+        switch(reader.node_type()) {
+            case json_node_type::field:
+                if(0==strcmp("episodes",reader.value())) {
+                    read_episodes(reader,file);
+                }
+                break;
+            default:
+                break;      
+        }
+    }
+}
+int main() {
+    file_stream stm("C:\\Users\\gazto\\Documents\\json_test\\data.json",io::file_mode::read);
+    json_reader reader(stm);
+    read_series(reader,stdout);
+    return 0;
+}
+```
+
+This will parse JSON of the following format
+
+```js
+{
+  "backdrop_path": "/lgTB0XOd4UFixecZgwWrsR69AxY.jpg",
+  "created_by": [
+      {
+        "id": 1233032,
+        "credit_id": "525749f819c29531db09b231",
+        "name": "Matt Nix",
+        "profile_path": "/qvfbD7kc7nU3RklhFZDx9owIyrY.jpg"
+      }
+    ],
+  "episode_run_time": [
+      45
+    ],
+  "first_air_date": "2007-06-28",
+  "genres": [
+      {
+        "id": 10759,
+        "name": "Action & Adventure"
+      },
+      {
+        "id": 18,
+        "name": "Drama"
+      }
+    ],
+  "homepage": "http://usanetwork.com/burnnotice",
+  "id": 2919,
+  "in_production": false,
+  "languages": [
+      "en"
+    ],
+  "last_air_date": "2013-09-12",
+  "last_episode_to_air": {
+      "air_date": "2013-09-12",
+      "episode_number": 13,
+      "id": 224759,
+      "name": "Reckoning",
+      "overview": "Series Finale. Michael must regain the trust of those closest to him in order to finish what he started.",
+      "production_code": null,
+      "season_number": 7,
+      "show_id": 2919,
+      "still_path": "/lGdhFXEi29e2HeXMzgA9bvvIIJU.jpg",
+      "vote_average": 0,
+      "vote_count": 0
+    },
+  "name": "Burn Notice",
+  "next_episode_to_air": null,
+  "networks": [
+      {
+        "name": "USA Network",
+        "id": 30,
+        "logo_path": "/g1e0H0Ka97IG5SyInMXdJkHGKiH.png",
+        "origin_country": "US"
+      }
+    ],
+  "number_of_episodes": 111,
+  "number_of_seasons": 7,
+  "origin_country": [
+      "US"
+    ],
+  "original_language": "en",
+  "original_name": "Burn Notice",
+  "overview": "A formerly blacklisted spy uses his unique skills and training to help people in desperate situations.",
+  "popularity": 12.174,
+  "poster_path": "/A9EmzNtwfEnXYdMTgGKcL4kiZm2.jpg",
+  "production_companies": [
+      {
+        "id": 6981,
+        "logo_path": null,
+        "name": "Fuse Entertainment",
+        "origin_country": ""
+      },
+      {
+        "id": 6529,
+        "logo_path": null,
+        "name": "Fox Television Studios",
+        "origin_country": ""
+      }
+    ],
+  "seasons": [
+      {
+        "_id": "525749cc19c29531db0988cc",
+        "air_date": "2011-04-17",
+        "episodes": [
+            {
+              "air_date": "2011-04-17",
+              "episode_number": 1,
+              "id": 224659,
+              "name": "The Fall of Sam Axe",
+              "overview": "The Fall of Sam Axe is a 2011 American television film based on the USA Network television series Burn Notice. It was the first official Burn Notice spin-off, and was directed by Jeffrey Donovan. The show was broadcast in the United States on April 17, 2011, on the U.S. television network USA Network. The film, while not an episode of the show, introduced plot elements for the show's fifth season.",
+              "production_code": null,
+              "season_number": 0,
+              "show_id": 2919,
+              "still_path": "/dchZWB1GoBuk1l4HFtmbVdIfE6w.jpg",
+              "vote_average": 0,
+              "vote_count": 0,
+              "crew": [
+                  {
+                    "id": 52886,
+                    "credit_id": "525749ee19c29531db09a624",
+                    "name": "Jeffrey Donovan",
+                    "department": "Directing",
+                    "job": "Director",
+                    "profile_path": "/5i47zZDpnAjLBtQdlqhg5AIYCuT.jpg"
+                  },
+                  {
+                    "id": 1233032,
+                    "credit_id": "525749d019c29531db098a46",
+                    "name": "Matt Nix",
+                    "department": "Writing",
+                    "job": "Writer",
+                    "profile_path": null
+                  }
+                ],
+              "guest_stars": []
+            }
+          ],
+        "name": "Specials",
+        "overview": "",
+        "poster_path": "/AoMKrA2j56SrQMBc3hp5jVmLv3B.jpg",
+        "season_number": 0
+      },
+...
+```
+

--- a/lib/htcw_json/library.json
+++ b/lib/htcw_json/library.json
@@ -1,0 +1,37 @@
+{
+    "name": "htcw_json",
+    "version": "0.2.5",
+    "description": "Provides a minimalist streaming JSON pull parser",
+    "keywords": [
+        "JSON",
+        "stream",
+        "bulk",
+        "data"
+    ],
+    "authors": {
+        "name": "honey the codewitch",
+        "homepage": "https://www.codeproject.com/Members/code-witch"
+    },
+    "license": "MIT",
+    "frameworks": "*",
+    "platforms": "*",
+    "build": {
+        "unflags": "-std=gnu++11",
+        "flags": "-std=gnu++14"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codewitch-honey-crisis/htcw_json.git"
+    },
+    "examples": [
+        {
+            "name": "Demo",
+            "base": "examples/demo",
+            "files": [
+                "platformio.ini",
+                "data/data.json",
+                "src/main.cpp"
+            ]
+        }
+    ]
+}

--- a/lib/htcw_json/src/htcw_json.h
+++ b/lib/htcw_json/src/htcw_json.h
@@ -1,0 +1,4 @@
+#ifndef HTCW_JSON_H
+#define HTCW_JSON_H
+#include "json.hpp"
+#endif

--- a/lib/htcw_json/src/json.hpp
+++ b/lib/htcw_json/src/json.hpp
@@ -1,0 +1,1068 @@
+#ifndef HTCW_JSON_HPP
+#define HTCW_JSON_HPP
+#include <stddef.h>
+#include <stdint.h>
+#include <math.h>
+#include <io_stream.hpp>
+#include <io_lex_source.hpp>
+namespace json {
+using stream = io::stream;
+/// @brief Indicates the type of node currently under the cursor
+enum struct json_node_type {
+    error = -3,
+    end_document = -2,
+    initial = -1,
+    value = 0,
+    field = 1,
+    array = 2,
+    end_array = 3,
+    object = 4,
+    end_object = 5,
+    value_part = 6,
+    end_value_part = 7
+};
+
+/// @brief Indicates the typed value under the cursor, if any
+enum struct json_value_type {
+    none = 0,
+    null = 1,
+    boolean = 2,
+    integer = 3,
+    real = 4
+};
+
+/// @brief Indicates the current error value
+enum struct json_error {
+    none = 0,
+    unterminated_object,
+    unterminated_array,
+    unterminated_string,
+    unterminated_element,
+    illegal_literal,
+    illegal_character,
+    field_too_long,
+    field_missing_value
+};
+namespace {
+    // implement std::move to limit dependencies on the STL, which may not be there
+    template< class T > struct remove_reference      { typedef T type; };
+    template< class T > struct remove_reference<T&>  { typedef T type; };
+    template< class T > struct remove_reference<T&&> { typedef T type; };
+    template <typename T>
+    typename remove_reference<T>::type&& member_move(T&& arg) {
+        return static_cast<typename remove_reference<T>::type&&>(arg);
+    }
+}
+/// @brief A common interface for any JSON reader
+class json_reader_base {
+public:
+    /// @brief The node type under the cursor
+    /// @return A json_node_type indicating the node
+    virtual json_node_type node_type() const = 0;
+    /// @brief The typed value under the cursor, if any
+    /// @return A json_value_type indicating the type
+    virtual json_value_type value_type() const = 0;
+    /// @brief Indicates the error if any
+    /// @return A json_error indicating the error
+    virtual json_error error() const = 0;
+    /// @brief Retrieves the current typed value as an integer
+    /// @return The integer value
+    virtual long long value_int() const=0;
+    /// @brief Retrieves the current typed value as floating point
+    /// @return The real number value
+    virtual double value_real() const=0;
+    /// @brief Retreives the current typed value as a boolean
+    /// @return The bool value
+    virtual bool value_bool() const=0;
+    /// @brief Returns the current string value under the cursor
+    /// @return The string value
+    virtual const char* value() const=0;
+    /// @brief Indicates whether or not the node type is a value, value_part, or end_value_part
+    /// @return True if it's a value, otherwise false
+    virtual bool is_value() const=0;
+    /// @brief Indicates whether or not strings are escaped and dequoted
+    /// @return True if not escaped and dequoted, otherwise false
+    virtual bool raw_strings() const=0;
+    /// @brief Sets whether or not the strings are escaped and dequoted
+    /// @param value True if the strings are not escaped and dequoted, otherwise false
+    virtual void raw_strings(bool value)=0;
+    /// @brief Indicates the current nested object depth
+    /// @return The nesting depth
+    virtual unsigned int depth() const=0;
+    /// @brief Reads the next element
+    /// @return True if successful, otherwise error or no more data
+    virtual bool read()=0;
+};
+template<size_t CaptureSize=1024>
+class json_reader_ex : public json_reader_base {
+public:
+    constexpr static const size_t capture_size = CaptureSize;
+private:
+    using ls_type = io::lex_source<CaptureSize>;
+    ls_type m_source;
+    int m_state;
+    unsigned int m_depth;
+    int m_error;
+    int m_lex_state;
+    bool m_lex_neg;
+    int m_lex_sub;
+    int32_t m_lex_accum;
+    double m_real;
+    long long m_int;
+    json_value_type m_value_type;
+    bool m_raw_strings;
+    void do_move(json_reader_ex& rhs) {
+        m_source = member_move(rhs.m_source);
+        m_state = rhs.m_state;
+        rhs.m_state = (int)json_node_type::initial;
+        m_depth = rhs.m_depth;
+        rhs.m_depth = 0;
+        m_error = rhs.m_error;
+        rhs.m_error = 0;
+        m_lex_state = rhs.m_lex_state;
+        m_lex_neg = rhs.m_lex_state;
+        m_lex_sub = rhs.m_lex_sub;
+        m_lex_accum = rhs.m_lex_accum;
+        m_value_type = rhs.m_value_type;
+        m_raw_strings = rhs.m_raw_strings;
+    }
+    json_reader_ex(const json_reader_ex& rhs)=delete;
+    json_reader_ex& operator=(const json_reader_ex& rhs)=delete;
+    void skip_whitespace() {
+        while(m_source.current()==' ' || m_source.current()=='\r' || m_source.current()=='\v' ||
+                m_source.current()=='\t' || m_source.current()=='\n') {
+            if(!m_source.advance()) {
+                break;
+            }
+        }
+    }
+    static uint8_t from_hex_char(int32_t hex) {
+        if (':' > hex && '/' < hex)
+            return (uint8_t)(hex - '0');
+        if ('G' > hex && '@' < hex)
+            return (uint8_t)(hex - '7'); // 'A'-10
+        return (uint8_t)(hex - 'W'); // 'a'-10
+    }
+    static bool is_hex_char(int32_t hex) {
+        return (':' > hex && '/' < hex) ||
+            ('G' > hex && '@' < hex) ||
+            ('g' > hex && '`' < hex);
+    }
+    bool lex_number() {
+        switch(m_lex_state) {
+            case 0:
+                m_lex_neg = false;
+                m_lex_sub = 0;
+                m_lex_accum = 0;
+                m_real = 0.0;
+                m_int = 0;
+                m_value_type = json_value_type::integer;
+                if(m_source.current()=='0') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 2;
+                    return true;
+                }
+                if(m_source.current()=='-') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_neg = true;
+                    m_lex_state = 1;
+                    return true;
+                }
+                if(m_source.current()>='1' && m_source.current()<='9') {
+                    m_int=m_source.current()-'0';
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 8;
+                    m_real = m_int;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 1:
+                if(m_source.current()=='0') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 2;
+                    return true;
+                }
+                if(m_source.current()>='1' && m_source.current()<='9') {
+                    m_int=m_source.current()-'0';
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 8;
+                    m_real = m_int;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 2:
+                if(m_source.current()>='0' && m_source.current()<='9') {
+                    m_int=m_source.current()-'0';
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 4;
+                    m_real = m_int;
+                    return true;
+                }
+                if(m_source.current()=='.') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 3;
+                    m_lex_sub = 1; // frac part
+                    return true;
+                }
+                if(m_source.current()=='E' || m_source.current()=='e') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 5;
+                    m_lex_sub = 2;
+                    return true;
+                }
+                if(m_lex_neg) {
+                    m_real*=-1;
+                    m_int*=-1;
+                }
+                // is already int
+                // no more data
+                return false;
+            case 3:
+                if(m_source.current()>='0' && m_source.current()<='9') {
+                    double f = m_source.current()-'0';
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 4;
+                    int i = m_lex_accum+1;
+                    while(i--) {
+                        f*=.1;
+                    }
+                    ++m_lex_accum;
+                    m_real+=f;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 4:
+                if(m_source.current()>='0' && m_source.current()<='9') {
+                    if(m_lex_sub==1) {
+                        double f = m_source.current()-'0';
+                        int i = m_lex_accum+1;
+                        while(i--) {
+                            f*=.1;
+                        }
+                        ++m_lex_accum;
+                        m_real+=f;
+                    } else {
+                        m_int*=10;
+                        m_int += (m_source.current()-'0');
+                        m_real = m_int;
+                    }
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 4;
+                    return true;
+                }
+                if(m_source.current()=='E' || m_source.current()=='e') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 5;
+                    m_lex_sub = 2;
+                    m_lex_accum = 0;
+                    return true;
+                }
+                if(m_lex_neg) {
+                    m_real*=-1;
+                    m_int*=-1;
+                }
+                if(m_lex_sub==0) {
+                    m_value_type = json_value_type::integer;
+                } else {
+                    m_value_type = json_value_type::real;
+                }
+                return false;
+            case 5:
+                if(m_source.current()>='0' && m_source.current()<='9') {
+                    m_lex_accum*=10;
+                    m_lex_accum += (m_source.current()-'0');
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 7;
+                    
+                    return true;
+                }
+                if(m_source.current()=='-') {
+                    m_lex_state = 6;
+                    m_lex_sub = 3;
+                    return true;
+                }
+                if(m_source.current()=='+') {
+                    m_lex_state = 6;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 6:
+                if(m_source.current()>='0' && m_source.current()<='9') {
+                    m_lex_accum*=10;
+                    m_lex_accum += (m_source.current()-'0');
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 7;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 7:
+                if(m_source.current()>='0' && m_source.current()<='9') {
+                    m_lex_accum*=10;
+                    m_lex_accum += (m_source.current()-'0');
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 7;
+                    return true;
+                }
+                m_real*=pow(10,m_lex_accum);
+                m_int*=pow(10,m_lex_accum);
+                if(m_lex_neg) {
+                    m_real*=-1;
+                    m_int*=-1;
+                }
+                m_value_type = json_value_type::real;
+                return false;
+            case 8:
+                if(m_source.current()>='0' && m_source.current()<='9') {
+                    m_int*=10;
+                    m_int += (m_source.current()-'0');
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 8;
+                    m_real = m_int;
+                    return true;
+                }
+                if(m_source.current()=='.') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_sub=1;
+                    m_lex_state = 3;
+                    return true;
+                }
+                if(m_source.current()=='E' || m_source.current()=='e') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 5;
+                    return true;
+                }
+                if(m_lex_neg) {
+                    m_real*=-1;
+                    m_int*=-1;
+                }
+                m_value_type = json_value_type::real;
+                return false;
+            default:
+                m_error = (int)json_error::illegal_literal;
+                return false;
+        }
+        
+    }
+    bool lex_boolean() {
+        switch(m_lex_state-9) {
+            case 0:
+                if(m_source.current()=='f') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_int = 0;
+                    m_lex_state = 1+9;
+                    return true;
+                }
+                if(m_source.current()=='t') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_int = 1;
+                    m_lex_state = 6+9;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 1:
+                if(m_source.current()=='a') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 2+9;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 2:
+                if(m_source.current()=='l') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 3+9;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 3:
+                if(m_source.current()=='s') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 4+9;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 4:
+                if(m_source.current()=='e') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 5+9;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 5:
+                m_value_type = json_value_type::boolean;
+                return false;
+            case 6:
+                if(m_source.current()=='r') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 7+9;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 7:
+                if(m_source.current()=='u') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 4+9;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            default:
+                m_error = (int)json_error::illegal_literal;
+                return false;
+        }
+    }
+    bool lex_null() {
+        switch(m_lex_state-16) {
+            case 0:
+                if(m_source.current()=='n') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 1+16;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 1:
+                if(m_source.current()=='u') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 2+16;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 2:
+                if(m_source.current()=='l') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 3+16;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 3:
+                if(m_source.current()=='l') {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    m_lex_state = 4+16;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 4:
+                m_value_type = json_value_type::null;
+                return false;
+            default:
+                m_error = (int)json_error::illegal_literal;
+                return false;
+        }
+    }
+    bool lex_string() {
+        switch(m_lex_state-21) {
+            case 0:
+                if(m_source.current()=='\"') {
+                    if(m_raw_strings) {
+                        m_source.capture(m_source.current());
+                    }
+                    m_source.advance();
+                    m_lex_state = 1+21;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 1:
+                if(!m_source.eof() && (m_source.current()!='\"' && m_source.current()!='\n' && m_source.current()!='\\')) {
+                    m_source.capture(m_source.current());
+                    m_source.advance();
+                    // m_lex_state = 1+21;
+                    return true;
+                }
+                if(m_source.current()=='\"') {
+                    if(m_raw_strings) {
+                        m_source.capture(m_source.current());
+                    }
+                    m_source.advance();
+                    m_lex_state = 2+21;
+                    return true;
+                }
+                if(m_source.current()=='\\') {
+                    if(m_raw_strings) {
+                        m_source.capture(m_source.current());
+                    }
+                    m_source.advance();
+                    m_lex_state = 3+21;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 2:
+                m_value_type = json_value_type::none;
+                return false;
+            case 3:
+            
+                switch(m_source.current()) {
+                    case '\"':
+                    case '/':
+                    case '\\':
+                        m_source.capture(m_source.current());
+                        m_source.advance();
+                        break;
+                    case 'b':
+                        if(m_raw_strings) {
+                            m_source.capture(m_source.current());
+                        } else {
+                            m_source.capture('\b');
+                        }
+                        m_source.advance();
+                        break;
+                    case 'f':
+                        if(m_raw_strings) {
+                            m_source.capture(m_source.current());
+                        } else {
+                            m_source.capture('\f');
+                        }
+                        m_source.advance();
+                        break;
+                    case 'n':
+                        if(m_raw_strings) {
+                            m_source.capture(m_source.current());
+                        } else {
+                            m_source.capture('\n');
+                        }
+                        m_source.advance();
+                        break;
+                    case 'r':
+                        if(m_raw_strings) {
+                            m_source.capture(m_source.current());
+                        } else {
+                            m_source.capture('\r');
+                        }
+                        m_source.advance();
+                        break;
+                    case 't':
+                        if(m_raw_strings) {
+                            m_source.capture(m_source.current());
+                        } else {
+                            m_source.capture('\t');
+                        }
+                        m_source.advance();
+                        break;
+                    case 'u':
+                        if(m_raw_strings) {
+                            m_source.capture(m_source.current());
+                        }
+                        m_lex_accum = 0;
+                        m_source.advance();
+                        m_lex_state = 4+21;
+                        return true;
+                    default:
+                        m_error = (int)json_error::illegal_literal;
+                        return false;
+                    
+                }
+            
+                m_lex_state = 1+21;
+                return true;
+            case 4:
+            case 5:
+            case 6:
+                if(is_hex_char(m_source.current())) {
+                    if(m_raw_strings) {
+                        m_source.capture(m_source.current());
+                    } 
+                    m_lex_accum*=0x10;
+                    m_lex_accum |= from_hex_char(m_source.current());
+                    m_source.advance();
+                    ++m_lex_state;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            case 7:
+                if(is_hex_char(m_source.current())) {
+                    if(m_raw_strings) {
+                            m_source.capture(m_source.current());
+                    } 
+                    m_lex_accum*=0x10;
+                    m_lex_accum |= from_hex_char(m_source.current());
+                    if(!m_raw_strings) {
+                        m_source.capture(m_lex_accum);
+                    }
+                    m_source.advance();
+                    m_lex_state=1;
+                    return true;
+                }
+                m_error = (int)json_error::illegal_literal;
+                return false;
+            default:
+                m_error = (int)json_error::illegal_literal;
+                return false;
+        }
+    }
+    bool skip_if_comma() {
+        if(m_source.more() && ','==m_source.current()) {
+            m_source.advance();
+            skip_whitespace();
+            if(m_source.eof()) {
+                m_error = (int)json_error::unterminated_element;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool read_any_open() {
+        skip_whitespace();
+        switch(m_source.current()) {
+            case '[':
+                if(!m_source.advance()) {
+                    m_error = (int)json_error::unterminated_array;
+                    return false;
+                }
+                skip_whitespace();
+                if(!m_source.more()) {
+                    m_error =  (int)json_error::unterminated_array;
+                    return false;
+                }
+                m_state = (int)json_node_type::array;
+                return true;
+            case '{':
+                if(!m_source.advance()) {
+                    m_error = (int)json_error::unterminated_object;
+                    return false;
+                }
+                skip_whitespace();
+                if(!m_source.more()) {
+                    m_error =  (int)json_error::unterminated_object;
+                    return false;
+                }
+                m_state = (int)json_node_type::object;
+                ++m_depth;
+                return true;
+            case '-':
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9': {
+                m_source.clear_capture();
+                m_lex_state = 0;
+                bool more = false;
+                while(m_source.capture_size()<m_source.capture_capacity()-3 && (more=lex_number()));
+                if(more) {
+                    m_state = (int)json_node_type::value_part;
+                    return true;
+                }
+                else {
+                    if(m_error==0) {
+                        m_state = (int)json_node_type::value;
+                        return true;
+                    }
+                }
+                return false;
+            }
+            case 't':
+            case 'f': {
+                m_source.clear_capture();
+                m_lex_state = 9;
+                bool more = false;
+                while(m_source.capture_size()<m_source.capture_capacity()-3 && (more=lex_boolean()));
+                if(more) {
+                    m_state = (int)json_node_type::value_part;
+                    return true;
+                }
+                else {
+                    if(m_error==0) {
+                        m_state = (int)json_node_type::value;
+                        return true;
+                    }
+                }
+                return false;
+            }
+            case 'n': {
+                m_source.clear_capture();
+                m_lex_state = 16;
+                bool more = false;
+                while(m_source.capture_size()<m_source.capture_capacity()-3 && (more=lex_null()));
+                if(more) {
+                    m_state = (int)json_node_type::value_part;
+                    return true;
+                }
+                else {
+                    if(m_error==0) {
+                        m_state = (int)json_node_type::value;
+                        return true;
+                    }
+                }
+                return false;
+            }
+            case '\"': {
+                m_source.clear_capture();
+                m_lex_state = 21;
+                bool more = false;
+                while(m_source.capture_size()<m_source.capture_capacity()-3 && (more=lex_string()));
+                skip_whitespace();
+                bool field = m_source.current()==':';
+                if(more) {
+                    if(field) {
+                        m_error = (int)json_error::field_too_long;
+                        return false;
+                    }
+                    m_state = (int)json_node_type::value_part;
+                    return true;
+                }
+                else {
+                    if(m_error==0) {
+                        if(field) {
+                            m_source.advance();
+                            m_state = (int)json_node_type::field;
+                        } else {
+                            m_state = (int)json_node_type::value;
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+        return false;
+    }
+    bool read_field_or_end_object() {
+        skip_whitespace();
+        switch(m_source.current()) {
+            case '}':
+                --m_depth;
+                m_source.advance();
+                skip_whitespace();
+                m_state = (int)json_node_type::end_object;
+                return true;
+            case '\"':
+                m_source.clear_capture();
+                m_lex_state = 21;
+                bool more = false;
+                while(m_source.capture_size()<m_source.capture_capacity()-3 && (more=lex_string()));
+                if(more) {
+                    m_error=(int)json_error::field_too_long;
+                    return false;
+                }
+                else {
+                    if(m_error!=0) { 
+                        return false;
+                    }
+                    skip_whitespace();
+                    if(m_source.current()!=':') {
+                        m_error=(int)json_error::field_missing_value;
+                        return false;
+                    }
+                    m_source.advance();
+                    m_state = (int)json_node_type::field;
+                    return true;
+                
+                }
+                return false;
+        }
+        return false;
+    }
+    bool read_any() {
+        if(!m_source.more()) {
+            return false;
+        }
+        skip_whitespace();
+        switch(m_source.current()) {
+            case ']':
+                m_source.advance();
+                m_state = (int)json_node_type::end_array;
+                return true;
+            case '}':
+                m_source.advance();
+                if(m_depth==0) {
+                    m_error = (int)json_error::illegal_character;
+                    return false;
+                }
+                --m_depth;
+                m_state = (int)json_node_type::end_object;
+                return true;
+        }
+        if(!skip_if_comma()) {
+            return false;
+        }
+        return read_any_open();
+    }
+    bool read_value_or_end_array() {
+            skip_whitespace();
+            switch(m_source.current()) {
+                case ']':
+                    m_source.advance();
+                    skip_whitespace();
+                    m_state = (int)json_node_type::end_array;
+                    return true;
+                default:
+                    if(!read_any_open())
+                        return false;
+                    return true;
+            }
+        }
+public:    
+    json_reader_ex(stream& input) : m_source(&input),m_state((int)json_node_type::initial),m_depth(0), m_error(0),m_raw_strings(false) {
+
+    }
+    json_reader_ex() : m_source(nullptr),m_state((int)json_node_type::error),m_depth(0),m_error(-1),m_raw_strings(false) {
+
+    }
+    json_reader_ex(json_reader_ex&& rhs) {
+        do_move(rhs);
+    }
+    json_reader_ex& operator=(json_reader_ex&& rhs) {
+        do_move(rhs);
+        return *this;
+    }
+    /// @brief The node type under the cursor
+    /// @return A json_node_type indicating the node
+    virtual json_node_type node_type() const override {
+        if(m_error!=0) {
+            return json_node_type::error;
+        }
+        return (json_node_type)m_state;
+    }
+    /// @brief The typed value under the cursor, if any
+    /// @return A json_value_type indicating the type
+    virtual json_value_type value_type() const override {
+        if(m_state == (int)json_node_type::value ||
+            /*m_state == (int)json_node_type::value_part ||*/ // don't have the whole value yet
+            m_state == (int)json_node_type::end_value_part) {
+            return (json_value_type)m_value_type;
+        }
+        return json_value_type::none;
+    }
+    /// @brief Indicates the error if any
+    /// @return A json_error indicating the error
+    virtual json_error error() const override {
+        return (json_error)m_error;
+    }
+    /// @brief Retrieves the current typed value as an integer
+    /// @return The integer value
+    virtual long long value_int() const override {
+        json_value_type vt = value_type();
+        if(vt==json_value_type::integer || vt==json_value_type::real) {
+            return m_int;
+        }
+        if(vt==json_value_type::boolean) {
+            return m_int!=0;
+        }
+        return 0;
+    }
+    /// @brief Retrieves the current typed value as floating point
+    /// @return The real number value
+    virtual double value_real() const override {
+        json_value_type vt = value_type();
+        if(vt==json_value_type::integer || vt==json_value_type::real) {
+            return m_real;
+        }
+        if(vt==json_value_type::boolean) {
+            return m_int!=0;
+        }
+        return 0.0;
+    }
+    /// @brief Retreives the current typed value as a boolean
+    /// @return The bool value
+    virtual bool value_bool() const override {
+        json_value_type vt = value_type();
+        if(vt==json_value_type::boolean || vt==json_value_type::integer || vt==json_value_type::real) {
+            return m_int!=0;
+        }
+        return false;
+    }
+    /// @brief Returns the current string value under the cursor
+    /// @return The string value
+    virtual const char* value() const override {
+        return m_source.const_capture_buffer();
+    }
+    /// @brief Indicates whether or not the node type is a value, value_part, or end_value_part
+    /// @return True if it's a value, otherwise false
+    virtual bool is_value() const override {
+        return m_state == (int)json_node_type::value ||
+            m_state == (int)json_node_type::value_part ||
+            m_state == (int)json_node_type::end_value_part;
+    }
+    /// @brief Indicates whether or not strings are escaped and dequoted
+    /// @return True if not escaped and dequoted, otherwise false
+    virtual bool raw_strings() const override {
+        return m_raw_strings;
+    }
+    /// @brief Sets whether or not the strings are escaped and dequoted
+    /// @param value True if the strings are not escaped and dequoted, otherwise false
+    virtual void raw_strings(bool value) override {
+        m_raw_strings = value;
+    }
+    /// @brief Indicates the current nested object depth
+    /// @return The nesting depth
+    virtual unsigned int depth() const override {
+        return m_depth;
+    }
+    /// @brief Sets the stream and resets the reader
+    /// @param stream The new stream
+    virtual void set(io::stream& stream) {
+        if(stream.caps().read==0) {
+            return;
+        }
+        m_source = &stream;
+        m_state = (int)json_node_type::initial;
+        m_depth = 0;
+        m_error = 0;
+    }
+    /// @brief Reads the next element
+    /// @return True if successful, otherwise error or no more data
+    virtual bool read() override {
+        if(m_error!=0) {
+            return false;
+        }
+        if(!m_source.ensure_started() || !m_source.more()) {
+            m_state = (int)json_node_type::end_document;
+            return false;
+        }
+        switch((json_node_type)m_state) {
+            case json_node_type::error:
+            case json_node_type::end_document:
+                return false;
+            case json_node_type::initial:
+                m_depth = 0;
+                skip_whitespace();
+                if(!read_any_open()) {
+                    return false;
+                }
+                break;
+            case json_node_type::value_part:
+                // 0, 9, 16, 21
+                if(m_lex_state>=21) {
+                    m_source.clear_capture();
+                    bool more = false;
+                    while(m_source.capture_size()<m_source.capture_capacity()-3 && (more=lex_string()));
+                    if(more) {
+                        m_state = (int)json_node_type::value_part;
+                        return true;
+                    }
+                    else {
+                        if(m_error==0) {
+                            m_state = (int)json_node_type::end_value_part;
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+                else if(m_lex_state>=16) {
+                    m_source.clear_capture();
+                    bool more = false;
+                    while(m_source.capture_size()<m_source.capture_capacity()-3 && (more=lex_null()));
+                    if(more) {
+                        m_state = (int)json_node_type::value_part;
+                        return true;
+                    }
+                    else {
+                        if(m_error==0) {
+                            m_state = (int)json_node_type::end_value_part;
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+                else if(m_lex_state>=9) {
+                    m_source.clear_capture();
+                    bool more = false;
+                    while(m_source.capture_size()<m_source.capture_capacity()-3 && (more=lex_boolean()));
+                    if(more) {
+                        m_state = (int)json_node_type::value_part;
+                        return true;
+                    }
+                    else {
+                        if(m_error==0) {
+                            m_state = (int)json_node_type::end_value_part;
+                            return true;
+                        }
+                    }
+                    return false;
+                } else {
+                    m_source.clear_capture();
+                    bool more = false;
+                    while(m_source.capture_size()<m_source.capture_capacity()-3 && (more=lex_number()));
+                    if(more) {
+                        m_state = (int)json_node_type::value_part;
+                        return true;
+                    }
+                    else {
+                        if(m_error==0) {
+                            m_state = (int)json_node_type::end_value_part;
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+            case json_node_type::value:
+            case json_node_type::end_value_part:
+            case json_node_type::end_array:
+            case json_node_type::end_object:
+                if(!read_any()) {
+                    return false;
+                }
+                break;
+            case json_node_type::array:
+                if(!read_value_or_end_array()) {
+                    return false;
+                }
+                break;
+            case json_node_type::object:
+                if(!read_field_or_end_object()) {
+                    return false;
+                }
+                break;
+            case json_node_type::field:
+                if(!read_any_open()) {
+                    return false;
+                }
+                break;
+        }   
+        return true;    
+    }
+};
+using json_reader = json_reader_ex<1024>;
+}
+#endif // HTCW_JSON_HPP

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,10 @@ lib_deps =
 	bblanchon/ArduinoJson@7.4.3
 	densaugeo/base64@1.4.0
 	knolleary/PubSubClient@2.8
-	codewitch-honey-crisis/htcw_json@0.2.5
+	; htcw_json + htcw_io + htcw_bits are vendored in lib/ — the registry
+	; deleted the pinned 0.2.5 release (2026-09-06 CI outage; only 0.2.7
+	; remained) and the streaming-parser semantics are validated against
+	; exactly 0.2.5. Do not re-add a registry dependency for them.
 	adafruit/Adafruit NeoPixel@1.15.4
 	adafruit/Adafruit PN532@1.3.4
 	chris--a/Keypad@3.1.1

--- a/src/DiagnosticsManager.cpp
+++ b/src/DiagnosticsManager.cpp
@@ -512,13 +512,21 @@ void DiagnosticsManager::checkReaderRegisters() {
     if (readerSnap_.bus_wedged) {
         addResult(DiagnosticTest::NFC_REGISTER_HEALTH, DiagnosticStatus::FAIL, 0, 0,
                   "PN5180 SPI bus is wedged (fail-fast latched)",
-                  "A transaction hung. Power-cycle the board; if it recurs check 5V supply/decoupling and SPI wiring.");
+                  "A transaction hung. Power-cycle the board; if it recurs check 5V supply/decoupling and SPI wiring. /logs shows which BUSY handshake stalled.");
         return;
     }
     char summary[96];
     snprintf(summary, sizeof(summary), "RF=0x%08lX IRQ=0x%08lX SYS=0x%08lX",
              (unsigned long)readerSnap_.rf_status, (unsigned long)readerSnap_.irq_status,
              (unsigned long)readerSnap_.system_status);
+    // All-ones on MISO means nothing drove the bus during the read — a dead,
+    // unpowered, or miswired module — and must not report as healthy (#293).
+    if (readerSnap_.rf_status == 0xFFFFFFFF || readerSnap_.system_status == 0xFFFFFFFF) {
+        addResult(DiagnosticTest::NFC_REGISTER_HEALTH, DiagnosticStatus::FAIL, 0, 0, summary,
+                  "Registers read all-ones — the reader is not responding on SPI. "
+                  "Check module power and MISO wiring; if wiring is good the module is likely faulty.");
+        return;
+    }
     addResult(DiagnosticTest::NFC_REGISTER_HEALTH, DiagnosticStatus::PASS, 0, 0, summary, "");
 }
 

--- a/src/HardwareNFCConnection.cpp
+++ b/src/HardwareNFCConnection.cpp
@@ -150,27 +150,35 @@ bool HardwareNFCConnection::begin() {
 
     // BUSY signal indicates RF subsystem boot state; timeout detects dead/unreliable chips
     unsigned long start = millis();
+    bool busyLow = true;
     while (digitalRead(pinBusy_) == HIGH) {
         if (millis() - start > 2000) {
             logBuf.logPrintf("HardwareNFCConnection: TIMEOUT waiting for BUSY LOW after reset!\n");
+            busyLow = false;
             break;
         }
         delay(1);
     }
-    logBuf.logPrintf("HardwareNFCConnection: BUSY went LOW after %lums\n", millis() - start);
+    if (busyLow) {
+        logBuf.logPrintf("HardwareNFCConnection: BUSY went LOW after %lums\n", millis() - start);
+    }
 
     // IDLE_IRQ_STAT (bit 2) confirms RF initialization complete; without it, transceive fails
     start = millis();
     uint32_t irqStatus = 0;
+    bool idleIrq = true;
     while (0 == (irqStatus & (1 << 2))) {
         nfc_->readRegister(IRQ_STATUS, &irqStatus);
         if (millis() - start > 2000) {
             logBuf.logPrintf("HardwareNFCConnection: TIMEOUT waiting for IDLE IRQ! IRQ=0x%08lX\n", irqStatus);
+            idleIrq = false;
             break;
         }
         delay(1);
     }
-    logBuf.logPrintf("HardwareNFCConnection: IDLE IRQ after %lums, IRQ=0x%08lX\n", millis() - start, irqStatus);
+    if (idleIrq) {
+        logBuf.logPrintf("HardwareNFCConnection: IDLE IRQ after %lums, IRQ=0x%08lX\n", millis() - start, irqStatus);
+    }
     nfc_->clearIRQStatus(0xffffffff);  // clear IDLE_IRQ and all pending flags before transceive
     logBuf.logPrintf("HardwareNFCConnection: Reset complete\n");
 
@@ -198,7 +206,7 @@ bool HardwareNFCConnection::begin() {
     hal_.is_present = nullptr;  // unused for ISO15693 tags
     hal_.user_ctx = this;
 
-    Serial.println("HardwareNFCConnection: Initialized successfully");
+    logBuf.logPrintf("HardwareNFCConnection: Initialized successfully\n");
     return true;
 }
 

--- a/src/HardwareNFCConnection.cpp
+++ b/src/HardwareNFCConnection.cpp
@@ -1,5 +1,6 @@
 #include "HardwareNFCConnection.h"
 #include "ConfigurationManager.h"
+#include "LogBuffer.h"
 #include <Arduino.h>
 #include <cstring>
 #include <esp_task_wdt.h>
@@ -17,6 +18,22 @@ static inline void feedTaskWatchdog() {
 
 // PN5180 ISO15693 NFC reader with ISO14443A fallback. Handles tag detection,
 // multi-block read/write caching (prevents watchdog timeout), and RF state management.
+
+// BUSY-handshake timeout sink (#293): the wedge lines are the only record of
+// WHICH handshake stalled the bus, so mirror them into the web log ring — but
+// rate-limited, because a dead reader re-wedges on every recovery cycle and
+// would scroll everything else out of the 4KB ring. Serial keeps every line;
+// the ring gets the first and every 20th, with a running count.
+static void pn5180TimeoutToLogBuffer(const char* phase) {
+    static uint32_t count = 0;
+    count++;
+    if (count % 20 == 1) {
+        LogBuffer::getInstance().logPrintf("PN5180: TIMEOUT %s (occurrence %lu)\n",
+                                           phase, (unsigned long)count);
+    } else {
+        Serial.printf("PN5180: TIMEOUT %s\n", phase);
+    }
+}
 
 //#define ENABLE_NFC_DEBUG_LOGS
 
@@ -107,36 +124,40 @@ bool HardwareNFCConnection::begin() {
     iso14443a_ = new PN5180ISO14443(pinNss_, pinBusy_, pinRst_,
                                     pinSck_, pinMiso_, pinMosi_);
 
-    Serial.println("HardwareNFCConnection: Starting PN5180...");
-    Serial.printf("HardwareNFCConnection: Pins — NSS=%d BUSY=%d RST=%d SCK=%d MISO=%d MOSI=%d\n",
+    // Boot lines go through LogBuffer (Serial + web /logs ring) so a reader
+    // that dies in the field can be diagnosed without a USB cable (#293).
+    auto& logBuf = LogBuffer::getInstance();
+    logBuf.logPrintf("HardwareNFCConnection: Starting PN5180...\n");
+    logBuf.logPrintf("HardwareNFCConnection: Pins — NSS=%d BUSY=%d RST=%d SCK=%d MISO=%d MOSI=%d\n",
                   pinNss_, pinBusy_, pinRst_,
                   pinSck_, pinMiso_, pinMosi_);
     // Bench diagnostics: confirms whether a PN5180_SPI_HZ build-flag override
     // reached this image. "Requested" because Arduino-ESP32 derives a hardware
     // divider from this — e.g. 7 MHz actually runs at ~6.67 MHz on the wire.
-    Serial.printf("HardwareNFCConnection: PN5180 requested SPI clock %lu Hz\n",
+    logBuf.logPrintf("HardwareNFCConnection: PN5180 requested SPI clock %lu Hz\n",
                   (unsigned long)PN5180_SPI_HZ);
+    PN5180::setTimeoutLogSink(pn5180TimeoutToLogBuffer);
     nfc_->begin();
     iso14443a_->begin();
-    Serial.println("HardwareNFCConnection: SPI begin done, resetting...");
-    Serial.printf("HardwareNFCConnection: BUSY pin=%d before reset\n", digitalRead(pinBusy_));
+    logBuf.logPrintf("HardwareNFCConnection: SPI begin done, resetting...\n");
+    logBuf.logPrintf("HardwareNFCConnection: BUSY pin=%d before reset\n", digitalRead(pinBusy_));
 
     // Manual reset with timeout: PN5180::reset() library call has no timeout, blocking on hung chips
     digitalWrite(pinRst_, LOW);
     delay(10);
     digitalWrite(pinRst_, HIGH);
-    Serial.println("HardwareNFCConnection: RST pin released, waiting for boot...");
+    logBuf.logPrintf("HardwareNFCConnection: RST pin released, waiting for boot...\n");
 
     // BUSY signal indicates RF subsystem boot state; timeout detects dead/unreliable chips
     unsigned long start = millis();
     while (digitalRead(pinBusy_) == HIGH) {
         if (millis() - start > 2000) {
-            Serial.println("HardwareNFCConnection: TIMEOUT waiting for BUSY LOW after reset!");
+            logBuf.logPrintf("HardwareNFCConnection: TIMEOUT waiting for BUSY LOW after reset!\n");
             break;
         }
         delay(1);
     }
-    Serial.printf("HardwareNFCConnection: BUSY went LOW after %lums\n", millis() - start);
+    logBuf.logPrintf("HardwareNFCConnection: BUSY went LOW after %lums\n", millis() - start);
 
     // IDLE_IRQ_STAT (bit 2) confirms RF initialization complete; without it, transceive fails
     start = millis();
@@ -144,14 +165,14 @@ bool HardwareNFCConnection::begin() {
     while (0 == (irqStatus & (1 << 2))) {
         nfc_->readRegister(IRQ_STATUS, &irqStatus);
         if (millis() - start > 2000) {
-            Serial.printf("HardwareNFCConnection: TIMEOUT waiting for IDLE IRQ! IRQ=0x%08lX\n", irqStatus);
+            logBuf.logPrintf("HardwareNFCConnection: TIMEOUT waiting for IDLE IRQ! IRQ=0x%08lX\n", irqStatus);
             break;
         }
         delay(1);
     }
-    Serial.printf("HardwareNFCConnection: IDLE IRQ after %lums, IRQ=0x%08lX\n", millis() - start, irqStatus);
+    logBuf.logPrintf("HardwareNFCConnection: IDLE IRQ after %lums, IRQ=0x%08lX\n", millis() - start, irqStatus);
     nfc_->clearIRQStatus(0xffffffff);  // clear IDLE_IRQ and all pending flags before transceive
-    Serial.println("HardwareNFCConnection: Reset complete");
+    logBuf.logPrintf("HardwareNFCConnection: Reset complete\n");
 
     // Firmware version stored at EEPROM address; used for debugging and feature detection
     uint8_t firmwareVersion[2];
@@ -159,15 +180,15 @@ bool HardwareNFCConnection::begin() {
         fw_[0] = firmwareVersion[0];
         fw_[1] = firmwareVersion[1];
         pn5180Ready_ = true;
-        Serial.printf("HardwareNFCConnection: PN5180 firmware: %d.%d\n",
+        logBuf.logPrintf("HardwareNFCConnection: PN5180 firmware: %d.%d\n",
                       firmwareVersion[1], firmwareVersion[0]);
     } else {
-        Serial.println("HardwareNFCConnection: Failed to read PN5180 firmware version");
+        logBuf.logPrintf("HardwareNFCConnection: Failed to read PN5180 firmware version\n");
     }
 
     // Load RF config enables ISO15693 field; failure here is terminal
     if (!nfc_->setupRF()) {
-        Serial.println("HardwareNFCConnection: Failed to setup RF");
+        logBuf.logPrintf("HardwareNFCConnection: Failed to setup RF\n");
         return false;
     }
 


### PR DESCRIPTION
Implements #293 so a reader that fails in the field can be diagnosed from the browser, without a USB cable.

## Changes

- **Boot sequence → /logs**: the PN5180 startup block in `HardwareNFCConnection::begin()` (pin map, requested SPI clock, reset handshake, firmware version, RF setup) logs through `LogBuffer` (Serial + 4KB web ring). The pin line answers 'did the right board variant flash' in one line.
- **BUSY-timeout sink**: the five wedge-latch timeout sites in the vendored PN5180 library call a host-installable sink (`PN5180::setTimeoutLogSink`) instead of `Serial.println` directly. With no sink installed the library behaves exactly as before (Serial only) — it stays application-agnostic, no LogBuffer include. `HardwareNFCConnection` installs a sink that mirrors the lines into the ring rate-limited (first and every 20th occurrence, with a running count) so a dead reader re-wedging on every recovery cycle cannot scroll the ring; Serial keeps every line.
- **Self-test**: `checkReaderRegisters` now FAILs when RF_STATUS or SYSTEM_STATUS reads all-ones — nothing driving MISO (dead, unpowered, or miswired module) previously reported `[PASS]`. The wedge row's recommendation now points at /logs for the stalled handshake.

## Verification

- All 6 envs + native suite green
- Datasheet check: reserved upper bits of RF_STATUS/SYSTEM_STATUS are defined zero, so all-ones can never be a healthy read
- No lock-order inversion: the timeout path takes shared-SPI then the log mutex; no LogBuffer user acquires SPI while holding it

Unblocks #292 (community no-read report — reporter can flash a dev build via /update and paste /logs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PN5180 timeout messages can now be routed to the application’s logging system, including web logs.
  * Boot diagnostics and timeout information are available through the shared log buffer, with repeated timeout messages rate-limited.

* **Bug Fixes**
  * Invalid all-ones register readings are now correctly reported as failures, with guidance to check power and MISO wiring.
  * Wedged-bus diagnostics now identify the stalled BUSY handshake and reference the `/logs` page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->