### PR TITLE
MQTT weight_source field — label nominal vs measured tag weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **The MQTT `tag/state` payload labels its weight** — a new `weight_source` field says whether `remaining_g` is a real level (`"measured"`) or the spool's fixed nominal size (`"nominal"`, which never changes on the tag: OpenTag3D v2 without a measured weight, TigerTag, Bambu). Middleware and automations must not use a nominal value as a deduction baseline; older consumers can ignore the field. (#297)
 - **OpenTag3D v2.000 support — read, write, and weight deduction** — the spec's breaking revision (opentag3d.info) repacks the tag into a single 224-byte map, adds SKU, barcode, chamber temperature, and minimum nozzle diameter, doubles the serial number to 32 characters, and drops NTAG213 (NTAG215 is the new minimum). The scanner reads both v1 and v2 tags; the writer page writes v2 with the new fields; the reader page shows the tag's spec version. Existing v1 tags keep working, and deduction write-back preserves each tag's own version. (#297)
 
 ### Fixed

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -501,6 +501,20 @@ void ApplicationManager::handleSpoolDetected(const AppMessage& msg) {
         f.density = s.density;
         f.diameter_mm = s.diameter;
 
+        // Label the weight for consumers (middleware#119): nominal sizes must
+        // not be used as deduction baselines. Formats without an on-tag weight
+        // claim leave the field out entirely.
+        switch (spoolState.kind) {
+            case TagKind::OpenPrintTag:
+            case TagKind::OpenTag3D:
+            case TagKind::TigerTag:
+            case TagKind::BambuTag:
+                f.weight_source = s.weight_is_nominal ? "nominal" : "measured";
+                break;
+            default:
+                break;
+        }
+
 #ifndef NATIVE_TEST
         BambuTagData bambuData;
         if (spoolState.kind == TagKind::BambuTag && NFCManager::getInstance().getLastBambuTagData(bambuData)) {

--- a/src/HomeAssistantManager.cpp
+++ b/src/HomeAssistantManager.cpp
@@ -728,6 +728,7 @@ void HomeAssistantManager::publishCurrentTagState() {
             snprintf(f.color, sizeof(f.color), "#%02X%02X%02X", tt.color_r, tt.color_g, tt.color_b);
             f.initial_weight_g = tt.weight_g;
             f.remaining_g = tt.weight_g;
+            f.weight_source = "nominal";  // TigerTag carries no consumed weight
         }
     } else if (spool.kind == TagKind::OpenTag3D) {
         opentag3d_t ot3d;
@@ -742,6 +743,8 @@ void HomeAssistantManager::publishCurrentTagState() {
                            ? ot3d.measured_filament_weight_g : ot3d.target_weight_g;
             f.initial_weight_g = weight;
             f.remaining_g = weight;
+            f.weight_source = (opentag3d_major(ot3d.tag_version) >= 2 &&
+                               ot3d.measured_filament_weight_g == 0) ? "nominal" : "measured";
         }
     } else if (spool.tag_data_valid) {
         // OpenPrintTag
@@ -768,6 +771,7 @@ void HomeAssistantManager::publishCurrentTagState() {
         opt_get_consumed_weight(&spool.tag_data, &consumed);
         f.remaining_g = f.initial_weight_g - consumed;
         if (f.remaining_g < 0) f.remaining_g = 0;
+        f.weight_source = "measured";  // OPT tracks consumed weight on-tag
         opt_get_gp_spoolman_id(&spool.tag_data, &f.spoolman_id);
     }
 

--- a/src/TagStateJson.h
+++ b/src/TagStateJson.h
@@ -28,6 +28,11 @@ struct TagStateFields {
     float density;
     float diameter_mm;
     uint32_t filament_length_m;
+    const char* weight_source;    // "measured" = remaining_g is a real level;
+                                  // "nominal" = it is the spool's sticker size and
+                                  // never changes on-tag (middleware must not
+                                  // baseline deductions from it — middleware#119);
+                                  // NULL = tag makes no weight claim, field omitted
 };
 
 // Build full tag state JSON. Optional temp/density/diameter fields included only when non-zero.
@@ -54,6 +59,7 @@ inline size_t buildTagStateJson(char* out, size_t outSize, const TagStateFields&
     if (f.density > 0.0f)           doc["density"] = f.density;
     if (f.diameter_mm > 0.0f)       doc["diameter_mm"] = f.diameter_mm;
     if (f.filament_length_m > 0)    doc["filament_length_m"] = f.filament_length_m;
+    if (f.weight_source)            doc["weight_source"] = f.weight_source;
 
     return serializeJson(doc, out, outSize);
 }


### PR DESCRIPTION
Scanner half of SpoolSense/spoolsense_middleware#119: every `tag/state` payload for a weight-bearing format now carries `weight_source`:

- `"measured"` — `remaining_g` is a real level (OpenPrintTag; OpenTag3D with a measured weight, v1 or v2).
- `"nominal"` — `remaining_g` is the spool's fixed nominal size and never changes on the tag (OpenTag3D v2 without measured weight, TigerTag, Bambu). Consumers must not use it as a deduction baseline.
- Field absent — the format makes no on-tag weight claim (uid-only, OpenSpool, blank), or older firmware.

Emitted at both publish sites: the live scan publish (from the detection payload's existing `weight_is_nominal` flag) and the MQTT-reconnect republish (derived per format from the cached tag data). Omission-when-null keeps every existing consumer byte-compatible.

Validation plan for the pair once released: SpoolSense/spoolsense_middleware#120.

All six board environments build; native suite green.