### PR TITLE
ST7796 display driver (320x480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **ST7796 (320×480) joins the selectable TFT drivers** — same geometry as the ILI9488, so the dashboard centers on it with the identical layout and the wide-landscape screens apply. Orientation and inversion defaults follow typical ST7796 modules (unmirrored, non-inverted) rather than the ILI9488's mirror-corrected setup; field confirmation pending — a tester whose module differs adjusts from those defaults. (#301)
 - **The MQTT `tag/state` payload labels its weight** — a new `weight_source` field says whether `remaining_g` is a real level (`"measured"`) or the spool's fixed nominal size (`"nominal"`, which never changes on the tag: OpenTag3D v2 without a measured weight, TigerTag, Bambu). Middleware and automations must not use a nominal value as a deduction baseline; older consumers can ignore the field. (#297)
 - **OpenTag3D v2.000 support — read, write, and weight deduction** — the spec's breaking revision (opentag3d.info) repacks the tag into a single 224-byte map, adds SKU, barcode, chamber temperature, and minimum nozzle diameter, doubles the serial number to 32 characters, and drops NTAG213 (NTAG215 is the new minimum). The scanner reads both v1 and v2 tags; the writer page writes v2 with the new fields; the reader page shows the tag's spec version. Existing v1 tags keep working, and deduction write-back preserves each tag's own version. (#297)
 

--- a/src/ConfigHTML.h
+++ b/src/ConfigHTML.h
@@ -290,6 +290,7 @@ const char CONFIG_HTML[] PROGMEM = R"rawliteral(
                   <option value="gc9a01">GC9A01 (round)</option>
                   <option value="ili9341">ILI9341 (240&times;320)</option>
                   <option value="ili9488">ILI9488 (320&times;480)</option>
+                  <option value="st7796">ST7796 (320&times;480)</option>
                 </select>
               </div>
             </div>

--- a/src/ConfigurationManager.h
+++ b/src/ConfigurationManager.h
@@ -36,7 +36,7 @@ struct ConfigUpdate {
     uint8_t led_enabled;
     uint8_t keypad_enabled;
     uint8_t tft_enabled;
-    char tft_driver[8];   // "st7789" or "gc9a01"
+    char tft_driver[8];   // "st7789", "gc9a01", "ili9341", "ili9488", or "st7796"
     // Klipper / Moonraker
     char moonraker_url[128];
     // PrusaLink integration

--- a/src/TFTConfig.h
+++ b/src/TFTConfig.h
@@ -116,10 +116,12 @@ public:
             }
             // ILI9488 3.5" modules ship X-mirrored vs the ST7789 default and are
             // mounted landscape; rotation 5 = 90° + horizontal mirror-correct.
-            // ST7796 uses the ST7789 default (rotation 0, invert off): typical
-            // modules ship unmirrored and non-inverted; field confirmation pending
-            // (#301) — a tester adjusts from here if their module differs.
-            cfg.offset_rotation = (driver == TFTDriver::ILI9488) ? 5 : 0;
+            // ST7796 is the same 320x480 glass mounted landscape but typically
+            // unmirrored and non-inverted: rotation 1 = plain 90°, yielding the
+            // 480x320 surface the wide renderers expect. Field confirmation
+            // pending (#301) — a tester adjusts from here if their module differs.
+            cfg.offset_rotation = (driver == TFTDriver::ILI9488) ? 5
+                                : (driver == TFTDriver::ST7796) ? 1 : 0;
             cfg.dummy_read_pixel = 8;
             cfg.dummy_read_bits  = 1;
             cfg.readable     = false;
@@ -235,10 +237,12 @@ public:
             }
             // ILI9488 3.5" modules ship X-mirrored vs the ST7789 default and are
             // mounted landscape; rotation 5 = 90° + horizontal mirror-correct.
-            // ST7796 uses the ST7789 default (rotation 0, invert off): typical
-            // modules ship unmirrored and non-inverted; field confirmation pending
-            // (#301) — a tester adjusts from here if their module differs.
-            cfg.offset_rotation = (driver == TFTDriver::ILI9488) ? 5 : 0;
+            // ST7796 is the same 320x480 glass mounted landscape but typically
+            // unmirrored and non-inverted: rotation 1 = plain 90°, yielding the
+            // 480x320 surface the wide renderers expect. Field confirmation
+            // pending (#301) — a tester adjusts from here if their module differs.
+            cfg.offset_rotation = (driver == TFTDriver::ILI9488) ? 5
+                                : (driver == TFTDriver::ST7796) ? 1 : 0;
             cfg.dummy_read_pixel = 8;
             cfg.dummy_read_bits  = 1;
             cfg.readable     = false;

--- a/src/TFTConfig.h
+++ b/src/TFTConfig.h
@@ -19,8 +19,14 @@ enum class TFTDriver : uint8_t {
     ST7789 = 0,
     GC9A01 = 1,
     ILI9341 = 2,   // 240x320 — dashboard centered with 40px letterbox
-    ILI9488 = 3    // 320x480 — dashboard centered
+    ILI9488 = 3,   // 320x480 — dashboard centered
+    ST7796 = 4     // 320x480 — dashboard centered, like ILI9488
 };
+
+// 480x320 panels share the centered-sprite / wide-landscape geometry.
+inline bool tftIs480Wide(TFTDriver d) {
+    return d == TFTDriver::ILI9488 || d == TFTDriver::ST7796;
+}
 
 #if defined(BOARD_ESP32_S3)
 
@@ -29,6 +35,7 @@ class LGFX : public lgfx::LGFX_Device {
     lgfx::Panel_GC9A01  _panel_gc9a01;
     lgfx::Panel_ILI9341 _panel_ili9341;
     lgfx::Panel_ILI9488 _panel_ili9488;
+    lgfx::Panel_ST7796  _panel_st7796;
     lgfx::Bus_SPI       _bus_instance;
     lgfx::Light_PWM     _light_instance;
 
@@ -70,6 +77,8 @@ public:
             panel = &_panel_ili9341;
         } else if (driver == TFTDriver::ILI9488) {
             panel = &_panel_ili9488;
+        } else if (driver == TFTDriver::ST7796) {
+            panel = &_panel_st7796;
         } else {
             panel = &_panel_st7789;
         }
@@ -90,7 +99,7 @@ public:
                 cfg.panel_height  = 240;
                 cfg.offset_x      = 0;
                 cfg.offset_y      = 40;
-            } else if (driver == TFTDriver::ILI9488) {
+            } else if (driver == TFTDriver::ILI9488 || driver == TFTDriver::ST7796) {
                 cfg.memory_width  = 320;
                 cfg.memory_height = 480;
                 cfg.panel_width   = 320;   // full native panel (landscape via rotation)
@@ -107,11 +116,15 @@ public:
             }
             // ILI9488 3.5" modules ship X-mirrored vs the ST7789 default and are
             // mounted landscape; rotation 5 = 90° + horizontal mirror-correct.
+            // ST7796 uses the ST7789 default (rotation 0, invert off): typical
+            // modules ship unmirrored and non-inverted; field confirmation pending
+            // (#301) — a tester adjusts from here if their module differs.
             cfg.offset_rotation = (driver == TFTDriver::ILI9488) ? 5 : 0;
             cfg.dummy_read_pixel = 8;
             cfg.dummy_read_bits  = 1;
             cfg.readable     = false;
-            cfg.invert       = (driver == TFTDriver::ILI9341 || driver == TFTDriver::ILI9488)
+            cfg.invert       = (driver == TFTDriver::ILI9341 || driver == TFTDriver::ILI9488 ||
+                                driver == TFTDriver::ST7796)
                                    ? false : true;
             cfg.rgb_order    = false;
             cfg.dlen_16bit   = false;
@@ -141,6 +154,7 @@ class LGFX : public lgfx::LGFX_Device {
     lgfx::Panel_GC9A01  _panel_gc9a01;
     lgfx::Panel_ILI9341 _panel_ili9341;
     lgfx::Panel_ILI9488 _panel_ili9488;
+    lgfx::Panel_ST7796  _panel_st7796;
     lgfx::Bus_SPI       _bus_instance;
     lgfx::Light_PWM     _light_instance;
 
@@ -182,6 +196,8 @@ public:
             panel = &_panel_ili9341;
         } else if (driver == TFTDriver::ILI9488) {
             panel = &_panel_ili9488;
+        } else if (driver == TFTDriver::ST7796) {
+            panel = &_panel_st7796;
         } else {
             panel = &_panel_st7789;
         }
@@ -202,7 +218,7 @@ public:
                 cfg.panel_height  = 240;
                 cfg.offset_x      = 0;
                 cfg.offset_y      = 40;
-            } else if (driver == TFTDriver::ILI9488) {
+            } else if (driver == TFTDriver::ILI9488 || driver == TFTDriver::ST7796) {
                 cfg.memory_width  = 320;
                 cfg.memory_height = 480;
                 cfg.panel_width   = 320;   // full native panel (landscape via rotation)
@@ -219,11 +235,15 @@ public:
             }
             // ILI9488 3.5" modules ship X-mirrored vs the ST7789 default and are
             // mounted landscape; rotation 5 = 90° + horizontal mirror-correct.
+            // ST7796 uses the ST7789 default (rotation 0, invert off): typical
+            // modules ship unmirrored and non-inverted; field confirmation pending
+            // (#301) — a tester adjusts from here if their module differs.
             cfg.offset_rotation = (driver == TFTDriver::ILI9488) ? 5 : 0;
             cfg.dummy_read_pixel = 8;
             cfg.dummy_read_bits  = 1;
             cfg.readable     = false;
-            cfg.invert       = (driver == TFTDriver::ILI9341 || driver == TFTDriver::ILI9488)
+            cfg.invert       = (driver == TFTDriver::ILI9341 || driver == TFTDriver::ILI9488 ||
+                                driver == TFTDriver::ST7796)
                                    ? false : true;
             cfg.rgb_order    = false;
             cfg.dlen_16bit   = false;

--- a/src/TFTManager.cpp
+++ b/src/TFTManager.cpp
@@ -9,7 +9,7 @@
 #include <WiFi.h>
 #include <Arduino.h>
 
-// TFT display controller (ST7789/GC9A01 240x240, ILI9341/ILI9488). All screens
+// TFT display controller (ST7789/GC9A01 240x240, ILI9341/ILI9488/ST7796). All screens
 // render through sprites for flicker-free updates: PSRAM boards hold a
 // persistent 16-bit full framebuffer, no-PSRAM boards draw each frame through
 // a transient 16-bit strip band (see render240Frame / renderLandscapeFrame).
@@ -74,7 +74,7 @@ void TFTManager::begin() {
 #endif
     delay(100);  // panel initialization delay
     _tft.setRotation(0);
-    // Panel geometry: wide panels (ILI9488 480x320) center the 240x240 sprite;
+    // Panel geometry: wide panels (ILI9488/ST7796 480x320) center the 240x240 sprite;
     // fillScreen below now clears the whole panel so no RAM-noise border shows.
     _wide = (_tft.width() > 240 || _tft.height() > 240);
     _blitOx = _wide ? (_tft.width()  - 240) / 2 : 0;
@@ -298,26 +298,26 @@ void TFTManager::processQueue() {
             bool rendered = true;
             switch (msg.state) {
                 case TFTState::Boot:
-                    if (_driver == TFTDriver::ILI9488)
+                    if (tftIs480Wide(_driver))
                         rendered = renderTextLandscape("SpoolSense", msg.statusText, COLOR_ACCENT);
                     else
                         rendered = renderBoot(msg.statusText);
                     break;
                 case TFTState::WifiConnecting:
-                    if (_driver == TFTDriver::ILI9488)
+                    if (tftIs480Wide(_driver))
                         rendered = renderTextLandscape(msg.statusText, msg.statusText2[0] ? msg.statusText2 : nullptr, COLOR_TEXT);
                     else
                         rendered = renderStatus(msg.statusText, msg.statusText2[0] ? msg.statusText2 : nullptr);
                     break;
                 case TFTState::Ready:
-                    if (_driver == TFTDriver::ILI9488) {
+                    if (tftIs480Wide(_driver)) {
                         rendered = renderReadyLandscape();
                     } else {
                         rendered = renderReady();
                     }
                     break;
                 case TFTState::SpoolScanned:
-                    if (_driver == TFTDriver::ILI9488) {
+                    if (tftIs480Wide(_driver)) {
                         rendered = renderSpoolScannedLandscape(msg.spool);
                     } else {
                         rendered = renderSpoolScanned(msg.spool);
@@ -336,13 +336,13 @@ void TFTManager::processQueue() {
                     }
                     break;
                 case TFTState::Writing:
-                    if (_driver == TFTDriver::ILI9488)
+                    if (tftIs480Wide(_driver))
                         rendered = renderTextLandscape("Writing...", msg.statusText, COLOR_TEXT);
                     else
                         rendered = renderStatus("Writing...", msg.statusText);
                     break;
                 case TFTState::WriteResult:
-                    if (_driver == TFTDriver::ILI9488)
+                    if (tftIs480Wide(_driver))
                         rendered = renderTextLandscape(msg.writeSuccess ? "Success" : "Write Failed",
                                                        msg.statusText,
                                                        msg.writeSuccess ? COLOR_BAR_FG : COLOR_BAR_LOW);
@@ -350,13 +350,13 @@ void TFTManager::processQueue() {
                         rendered = renderWriteResult(msg.writeSuccess, msg.statusText);
                     break;
                 case TFTState::KeypadEntry:
-                    if (_driver == TFTDriver::ILI9488)
+                    if (tftIs480Wide(_driver))
                         rendered = renderTextLandscape("Tool", msg.statusText, COLOR_ACCENT);
                     else
                         rendered = renderKeypadEntry(msg.statusText);
                     break;
                 case TFTState::Error:
-                    if (_driver == TFTDriver::ILI9488)
+                    if (tftIs480Wide(_driver))
                         rendered = renderTextLandscape("Error", msg.statusText, COLOR_BAR_LOW);
                     else
                         rendered = renderStatus("Error", msg.statusText);

--- a/src/TFTManager.h
+++ b/src/TFTManager.h
@@ -8,7 +8,7 @@
 // C5/C6 have one general-purpose SPI bus, reserved for NFC. Keeping a tiny
 // compile-time stub lets shared application code remain board-agnostic while
 // the build omits LovyanGFX and all TFT implementation objects.
-enum class TFTDriver : uint8_t { ST7789, GC9A01, ILI9341, ILI9488 };
+enum class TFTDriver : uint8_t { ST7789, GC9A01, ILI9341, ILI9488, ST7796 };
 
 class TFTManager : public DisplayI {
 public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,6 +275,8 @@ void setup() {
         tftDriver = TFTDriver::ILI9341;
     } else if (strcmp(config.getTftDriver(), "ili9488") == 0) {
         tftDriver = TFTDriver::ILI9488;
+    } else if (strcmp(config.getTftDriver(), "st7796") == 0) {
+        tftDriver = TFTDriver::ST7796;
     }
     tftManagerPtr = new TFTManager(tftDriver);
     tftManagerPtr->begin();


### PR DESCRIPTION
Adds ST7796 as a fifth selectable TFT driver (#301, community request). It shares the ILI9488 480x320 geometry: the 8 wide-panel gates in TFTManager now go through one `tftIs480Wide()` predicate instead of per-driver comparisons, LovyanGFX's native `Panel_ST7796` is wired into both panel classes, and the config page gains the dropdown option.

Panel defaults follow typical ST7796 modules — unmirrored (`offset_rotation` 0, unlike ILI9488's 5) and non-inverted (grouped with ILI9341/ILI9488 in the invert expression, whose ternary yields invert-off for that group). Both await field confirmation on real glass; the reporting user is the tester (#301 has the checklist).

All six board environments build; native suite green. No behavior change for existing panels — ST7789 bench regression is on the checklist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting ST7796 (320×480) TFT displays from the device configuration page.
  - ST7796 displays now support wide-landscape rendering with appropriate orientation and inversion defaults.
  - Expanded documented TFT driver options to include ILI9341, ILI9488, and ST7796.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->